### PR TITLE
Add github action for ci 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@ CONTRIBUTING.md
 README.md
 .git
 .idea
+
+cm-butterfly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ on:
 jobs:
   check-skip:
     name: Check to skip CI
-    needs: prepare-commit-msg
     runs-on: ubuntu-22.04
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') && !contains(steps.commitMsg.outputs.HEAD_COMMIT_MSG, '[skip ci]') }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,18 +9,27 @@ on:
       - main
 
 jobs:
-  check-skip:
-    name: Check to skip CI
+  prepare-head-commit-message:
+    name: Retrive head commit message
     runs-on: ubuntu-22.04
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') && !contains(steps.commitMsg.outputs.HEAD_COMMIT_MSG, '[skip ci]') }}
+    outputs:
+      HEAD_COMMIT_MSG: ${{ steps.commitMsg.outputs.HEAD_COMMIT_MSG }}
     steps:
       - uses: actions/checkout@v4
-      - name: find commit msg to ckeck skip ci
+      - name: find commit msg for PR
         id: commitMsg
         run: echo "HEAD_COMMIT_MSG=$(git log --no-merges -1 --oneline)" >> "$GITHUB_OUTPUT"
+
+  check-skip:
+    name: Check to skip CI
+    needs: prepare-head-commit-message
+    runs-on: ubuntu-22.04
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') && !contains(needs.prepare-commit-msg.outputs.HEAD_COMMIT_MSG, '[skip ci]') }}
+    steps:
+      - uses: actions/checkout@v4
       - run: |
           echo "${{ github.event.head_commit.message }}"
-          echo "${{ steps.commitMsg.outputs.HEAD_COMMIT_MSG }}"
+          echo "${{ needs.prepare-commit-msg.outputs.HEAD_COMMIT_MSG }}"
 
 
   build-source:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,58 @@
+name: CM-Butterfly CI
+
+on:
+  push:
+    branches: 
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-skip:
+    name: Check to skip CI
+    needs: prepare-commit-msg
+    runs-on: ubuntu-22.04
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') && !contains(steps.commitMsg.outputs.HEAD_COMMIT_MSG, '[skip ci]') }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: find commit msg to ckeck skip ci
+        id: commitMsg
+        run: echo "HEAD_COMMIT_MSG=$(git log --no-merges -1 --oneline)" >> "$GITHUB_OUTPUT"
+      - run: |
+          echo "${{ github.event.head_commit.message }}"
+          echo "${{ steps.commitMsg.outputs.HEAD_COMMIT_MSG }}"
+
+
+  build-source:
+    name: Build CM-Butterfly source code
+    needs: check-skip
+    strategy:
+      matrix:
+        go-version: ["1.19"]
+        os: [ubuntu-22.04]
+    runs-on: ${{matrix.os}}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+          go-version: ${{matrix.go-version}}
+
+    - name: Build binary executable file
+      run: go build -v -o cm-butterfly main.go
+
+ 
+  build-container-image:
+    name: Build a cm-butterfly container image
+    needs: check-skip
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Build
+        env:
+          IMAGE_NAME: ${{ github.event.repository.name }}
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,32 +9,8 @@ on:
       - main
 
 jobs:
-  prepare-head-commit-message:
-    name: Retrive head commit message
-    runs-on: ubuntu-22.04
-    outputs:
-      HEAD_COMMIT_MSG: ${{ steps.commitMsg.outputs.HEAD_COMMIT_MSG }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: find commit msg for PR
-        id: commitMsg
-        run: echo "HEAD_COMMIT_MSG=$(git log --no-merges -1 --oneline)" >> "$GITHUB_OUTPUT"
-
-  check-skip:
-    name: Check to skip CI
-    needs: prepare-head-commit-message
-    runs-on: ubuntu-22.04
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') && !contains(needs.prepare-commit-msg.outputs.HEAD_COMMIT_MSG, '[skip ci]') }}
-    steps:
-      - uses: actions/checkout@v4
-      - run: |
-          echo "${{ github.event.head_commit.message }}"
-          echo "${{ needs.prepare-commit-msg.outputs.HEAD_COMMIT_MSG }}"
-
-
   build-source:
     name: Build CM-Butterfly source code
-    needs: check-skip
     strategy:
       matrix:
         go-version: ["1.19"]
@@ -54,7 +30,6 @@ jobs:
  
   build-container-image:
     name: Build a cm-butterfly container image
-    needs: check-skip
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-
 jobs:
   build-source:
     name: Build CM-Butterfly source code
@@ -27,7 +26,6 @@ jobs:
     - name: Build binary executable file
       run: go build -v -o cm-butterfly main.go
 
- 
   build-container-image:
     name: Build a cm-butterfly container image
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ conf/setup.env
 !conf/setup.sample.env
 
 data/*
+
+cm-butterfly


### PR DESCRIPTION
Add github action for ci.

This pr is to check github action trigger when other branch is merged in to main branch or push directly to main branch.

Github Action 은 head commit message 에 포함되는 다음과 같은 단어들로 ci 를 skip 합니다.([참고](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/))

on: push / pull
keyword in commit message (대괄호 포함) :
- [skip ci]
- [ci skip]
- [no ci]
- [skip actions]
- [actions skip]
