### PR TITLE
add make file in project root directory to build and run the cm-butterfly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ CONTRIBUTING.md
 README.md
 .git
 .idea
+bin/*

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ conf/setup.env
 !conf/setup.sample.env
 
 data/*
+
+bin/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+SHELL := /bin/bash
+
+.PHONY: build
+build:
+	@go build -o ./bin/butterfly main.go
+	@echo "CM-Butterfly build complete."
+
+.PHONY: config
+config:
+	@source ./conf/setup.env
+	@echo "CM-Butterfly is configured."
+
+.PHONY: build-run
+build-run: build config
+	@./bin/butterfly 
+
+.PHONY: run
+run: config
+	@go run main.go


### PR DESCRIPTION
As per [planning for applying ci/cd migrator subsystem](https://github.com/cloud-barista/cloud-migrator/issues/8), create makefile for cm-butterfly.

# 작업 내용
cm-butterfly build 를 위한 Makefile 작성