### PR TITLE
ci: Fix broken source-build job by replacing Buffalo with go build (Echo)

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -39,15 +39,12 @@ jobs:
         with:
           go-version: ${{matrix.go-version}}
 
-      - name: Install Buffalo CLI
-        run: go install github.com/gobuffalo/cli/cmd/buffalo@v0.18.14
-
       - name: Install Go dependencies
         run: go mod download
         working-directory: ./api
-    
-      - name: Build Buffalo application
-        run: buffalo build --static
+
+      - name: Build API server (Echo)
+        run: go build -ldflags="-s -w" -o butterfly-api ./cmd/app
         working-directory: ./api
 
   # The job key is "build-container-image"


### PR DESCRIPTION
## Summary
- API 서버가 Buffalo → Echo v4 로 마이그레이션(#59)된 이후에도 GitHub Actions CI 의 `Build source code for butterfly api` Job이 여전히 `buffalo CLI` 설치와 `buffalo build --static` 을 실행하고 있어, Buffalo 프로젝트 마커가 사라진 develop 브랜치 빌드 시 `Error: you need to be inside your buffalo project path` 로 항상 실패하는 문제 수정
- upstream PR(cloud-barista/cm-butterfly#94) 의 `Build source code for butterfly api (1.23, ubuntu-22.04)` Job 실패 원인이 본 워크플로우 정의에 있음

## 변경 내용
- `.github/workflows/continuous-integration.yaml`
  - `Install Buffalo CLI` 단계 제거
  - `buffalo build --static` → `go build -ldflags="-s -w" -o butterfly-api ./cmd/app` 로 교체
  - `api/Dockerfile` 의 빌드 명령과 동일 기준 적용 (엔트리포인트: `api/cmd/app/main.go`)

## 검증
- 로컬(`api/` 디렉토리)에서 `go build -ldflags="-s -w" -o butterfly-api ./cmd/app` 실행 시 정상적으로 `butterfly-api` 바이너리(14MB) 생성 확인
- GitHub Actions 의 `Build source code for butterfly api` Job이 본 PR 에서 통과해야 함

## Test plan
- [ ] 본 PR 의 CI `Build source code for butterfly api (1.23, ubuntu-22.04)` Job 통과 확인
- [ ] `Build a container image for butterfly api` Job 통과 확인 (Dockerfile 기반, 영향 없음 예상)
- [ ] front-end 관련 Job 통과 확인 (영향 없음 예상)

## 관련 PR
- cloud-barista/cm-butterfly#94 (upstream 머지 대상 PR)
- 본 fix 머지 후 develop → upstream 동기화 시 #94 의 CI 도 정상화됨