### PR TITLE
ci: add security gate workflow (secret/SAST/dependency scan)

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -1,0 +1,127 @@
+# ------------------------------------------------------------
+# Security Gate (cm-butterfly 변형) — Echo Go 백엔드(api/) + Vue 2 프론트엔드(front/).
+#
+# 표준 원본: conf/workflow-templates/security-gate.yml (Go 단일 저장소용, 예: cm-ant)
+# 본 변형의 차이:
+#   - Go 스캐너(gosec·govulncheck)는 Go 모듈이 있는 api/ 에서 실행(working-directory).
+#   - 프론트엔드(JS/TS/Vue)는 Semgrep job 추가(security-gate-semgrep-job.yml 통합).
+#   - 이미지 CVE는 cm-butterfly-api·cm-butterfly-front 2종을 빌드 파이프라인(onecloud-ci)의
+#     2개 dispatch에 각각 security-image-scan-step.yml 로 추가(소스 CI에서 빌드하지 않음).
+#
+# 도입 단계(Phase A): 시크릿만 차단, 나머지(gosec·govulncheck·Semgrep·Trivy)는 경고.
+# 기준선 정리 후 신규분 차단으로 승격(GUIDE-보안게이트-기준선및롤아웃).
+# first-party 액션은 commit SHA pin. 정책: POLICY-SECURITY.md
+# 대상 경로: .github/workflows/security-gate.yml
+# ------------------------------------------------------------
+
+name: Security Gate
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+  security-events: write
+
+env:
+  GITLEAKS_VERSION: "8.21.2"
+  TRIVY_VERSION: "0.71.2"
+
+jobs:
+  # 시크릿 — 차단(Phase A). 저장소 전체(api+front) 파일시스템 스캔.
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - name: Install gitleaks
+        run: |
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o gitleaks.tgz
+          tar -xzf gitleaks.tgz gitleaks
+      - name: Run gitleaks (filesystem, redacted) — blocking
+        run: |
+          ./gitleaks dir . --report-format sarif --report-path gitleaks.sarif --redact --exit-code 1
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks
+
+  # Go(api) SAST + 취약점 — 경고(Phase A). Go 모듈이 api/ 에 있으므로 거기서 실행.
+  go-security:
+    name: Go SAST + vuln (api/, gosec·govulncheck)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: api/go.mod
+      - name: gosec (SAST, 경고)
+        continue-on-error: true
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.21.4
+          gosec -no-fail -fmt sarif -out gosec.sarif ./...
+      - name: Upload gosec SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: api/gosec.sarif
+          category: gosec
+      - name: govulncheck (경고)
+        continue-on-error: true
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./... | tee govulncheck.txt || true
+
+  # 프론트엔드(JS/TS/Vue) SAST — 경고. Semgrep CE(코드 미전송, 메트릭 off).
+  semgrep:
+    name: SAST (Semgrep, front JS/TS/Vue)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install Semgrep (CE)
+        run: pipx install semgrep
+      - name: Run Semgrep (경고)
+        continue-on-error: true
+        run: semgrep scan front --config auto --sarif --output semgrep.sarif --metrics=off || true
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+  # 의존성/Dockerfile — 경고. Go(api/go.mod) + npm(front/package-lock.json) + Dockerfile 2종.
+  trivy:
+    name: Dependencies + Dockerfile (Trivy fs)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install Trivy
+        run: |
+          curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o trivy.tgz
+          tar -xzf trivy.tgz trivy
+          sudo mv trivy /usr/local/bin/
+      - name: Trivy filesystem (의존성·Dockerfile·시크릿, 경고)
+        continue-on-error: true
+        run: |
+          trivy fs --scanners vuln,misconfig,secret --format sarif --output trivy-fs.sarif --exit-code 0 .
+      - name: Upload Trivy fs SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+# 이미지 CVE(권위): cm-butterfly-api·cm-butterfly-front 2종을 빌드하는 onecloud-ci dispatch
+# (dispatch-butterfly-api-docker-updated.yaml·dispatch-butterfly-front-docker.yaml)에
+# 각각 security-image-scan-step.yml 을 추가한다. (소스 CI는 이미지를 빌드하지 않음)

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -64,14 +64,15 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version-file: api/go.mod
+          # go.mod은 1.21.6이나 gosec 최신본·x/tools 분석 호환을 위해 툴링 Go는 1.23 고정(상위호환).
+          go-version: "1.23"
       - name: gosec (SAST, 경고)
         continue-on-error: true
         run: |
           go install github.com/securego/gosec/v2/cmd/gosec@v2.21.4
-          gosec -no-fail -fmt sarif -out gosec.sarif ./...
+          gosec -no-fail -fmt sarif -out gosec.sarif ./... || true
       - name: Upload gosec SARIF
-        if: always()
+        if: always() && hashFiles('api/gosec.sarif') != ''
         uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: api/gosec.sarif
@@ -94,7 +95,7 @@ jobs:
         continue-on-error: true
         run: semgrep scan front --config auto --sarif --output semgrep.sarif --metrics=off || true
       - name: Upload SARIF
-        if: always()
+        if: always() && hashFiles('semgrep.sarif') != ''
         uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: semgrep.sarif
@@ -116,7 +117,7 @@ jobs:
         run: |
           trivy fs --scanners vuln,misconfig,secret --format sarif --output trivy-fs.sarif --exit-code 0 .
       - name: Upload Trivy fs SARIF
-        if: always()
+        if: always() && hashFiles('trivy-fs.sarif') != ''
         uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: trivy-fs.sarif


### PR DESCRIPTION
## 개요
PR 시점 보안 점검 워크플로우(`.github/workflows/security-gate.yml`)를 추가합니다. cm-butterfly는 Echo Go 백엔드(`api/`)와 Vue 프론트엔드(`front/`) 구조에 맞춘 변형입니다.

## 무엇을 하나
- **시크릿 스캔(gitleaks)** — 차단(전체 저장소).
- **Go 정적분석·취약점(gosec·govulncheck)** — 경고. Go 모듈이 있는 `api/`에서 실행.
- **프론트엔드 정적분석(Semgrep)** — 경고. `front/` JS/TS/Vue.
- **의존성/Dockerfile(Trivy fs)** — 경고. Go+npm 의존성·Dockerfile 2종.
- 결과는 GitHub Security 탭(code scanning)에 업로드.

## 도입 단계 (Phase A)
시크릿만 차단·나머지는 경고로 시작하고, 기준선 정리 후 신규분 차단으로 승격합니다. 컨테이너 이미지 CVE(cm-butterfly-api·front 2종)는 이미지 빌드 파이프라인에서 별도 점검합니다.

## 안전성
- 새 파일 1개 추가라 기존 소스와 충돌 없고, 경고 모드라 머지/빌드를 막지 않습니다.
- 스캐너는 바이너리로 직접 설치, 외부 액션은 commit SHA로 고정.

---
- [BAR-1344](https://mzdevs.atlassian.net/browse/BAR-1344) CI/CD 보안 게이트 통합 (확산)
- 검증 결과서: https://mzdevs.atlassian.net/wiki/x/UYBORQE