### PR TITLE
feat(workload): add a load-test progress bar

### DIFF
--- a/front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue
+++ b/front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { PButton, PTooltip } from '@cloudforet-test/mirinae';
-import { computed, Ref } from 'vue';
+import { computed, Ref, ref, watch, onBeforeUnmount } from 'vue';
 import { ILoadTestExecutionStep } from '@/entities/mci/model';
 import LoadTestEvaluationMetric from '@/widgets/workload/vm/vmEvaluatePerf/ui/LoadTestEvaluationMetric.vue';
 import LoadTestResourceMetric from '@/widgets/workload/vm/vmEvaluatePerf/ui/LoadTestResourceMetric.vue';
@@ -19,6 +19,8 @@ interface IProps {
   loadTestFailureMessage?: string;
   // 세분화 단계 진행(cm-ant FR-007-08 steps[]). 구버전 cm-ant면 빈 배열.
   loadTestSteps?: ILoadTestExecutionStep[];
+  // 진행률 바용 예상 총 소요(초) — cm-ant totalExpectedExecutionSecond.
+  loadTestExpectedSeconds?: number;
 }
 
 const props = defineProps<IProps>();
@@ -37,6 +39,40 @@ const hasLoadTest = computed(() => !!props.loadTestStatus);
 const isLoadTestFailed = computed(() => props.loadTestStatus === 'Failed');
 // 결과(차트·집계)는 성공(Completed)일 때만 노출. 실패/진행 중엔 결과 조회를 하지 않는다.
 const isLoadTestCompleted = computed(() => props.loadTestStatus === 'Completed');
+
+// 진행률 바 — startAt·예상 소요(초)로 경과 비율 계산. 진행 중엔 1초 틱으로 부드럽게 갱신.
+const nowMs = ref(Date.now());
+let tickTimer: ReturnType<typeof setInterval> | null = null;
+const stopTick = () => {
+  if (tickTimer) {
+    clearInterval(tickTimer);
+    tickTimer = null;
+  }
+};
+watch(
+  isLoadTestRunning,
+  running => {
+    if (running) {
+      nowMs.value = Date.now();
+      if (!tickTimer) tickTimer = setInterval(() => (nowMs.value = Date.now()), 1000);
+    } else {
+      stopTick();
+    }
+  },
+  { immediate: true },
+);
+onBeforeUnmount(stopTick);
+
+// 진행률(%). 완료=100, startAt/예상초 없으면 null(indeterminate 바). 진행 중엔 2~95%로 캡(종료 전 100% 방지).
+const progressPercent = computed<number | null>(() => {
+  if (isLoadTestCompleted.value) return 100;
+  if (!isLoadTestRunning.value) return 0;
+  const start = props.loadTestStartAt ? Date.parse(props.loadTestStartAt) : NaN;
+  const expectedMs = (props.loadTestExpectedSeconds ?? 0) * 1000;
+  if (!start || Number.isNaN(start) || expectedMs <= 0) return null;
+  const pct = ((nowMs.value - start) / expectedMs) * 100;
+  return Math.max(2, Math.min(95, Math.round(pct)));
+});
 
 // 단계(steps[]) 표현 매핑 — cm-ant ExecutionStep/StepStatus.
 const STEP_LABEL: Record<string, string> = {
@@ -188,6 +224,18 @@ const statusTooltip = computed(() => {
       <span v-if="currentStep?.message" class="progress-step-msg">{{
         currentStep.message
       }}</span>
+      <!-- 진행률 바: startAt·예상 소요로 경과 비율(예상 없으면 indeterminate). -->
+      <div class="load-test-progress-bar" data-testid="load-test-progress-bar">
+        <div
+          class="load-test-progress-fill"
+          :class="{ indeterminate: progressPercent === null }"
+          :style="progressPercent !== null ? { width: progressPercent + '%' } : {}"
+        ></div>
+      </div>
+      <span v-if="progressPercent !== null" class="progress-pct"
+        >{{ progressPercent }}%</span
+      >
+      <br />
       The results will appear here once it finishes.
     </div>
     <div
@@ -293,6 +341,45 @@ const statusTooltip = computed(() => {
   font-size: 13px;
   color: #495057;
   word-break: break-word;
+}
+
+.load-test-progress-bar {
+  width: 60%;
+  max-width: 420px;
+  height: 8px;
+  margin: 10px auto 4px auto;
+  background-color: #e9ecef;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.load-test-progress-fill {
+  height: 100%;
+  background-color: #1971c2;
+  border-radius: 999px;
+  transition: width 0.6s ease;
+}
+
+/* 예상 소요를 모를 때: 좌우로 흐르는 indeterminate 애니메이션 */
+.load-test-progress-fill.indeterminate {
+  width: 35%;
+  animation: load-test-indeterminate 1.4s ease-in-out infinite;
+}
+
+@keyframes load-test-indeterminate {
+  0% {
+    margin-left: -35%;
+  }
+  100% {
+    margin-left: 100%;
+  }
+}
+
+.progress-pct {
+  display: block;
+  font-size: 12px;
+  color: #1971c2;
+  font-weight: 600;
 }
 
 .load-test-status-badge.running {

--- a/front/src/widgets/workload/vm/vmList/ui/VmList.vue
+++ b/front/src/widgets/workload/vm/vmList/ui/VmList.vue
@@ -87,6 +87,12 @@ const currentLoadTestSteps = computed(
     ((resLoadStatus as any).data?.value?.responseData?.result
       ?.steps as any[]) ?? [],
 );
+// 진행률 바용 예상 총 소요(초).
+const currentLoadTestExpectedSeconds = computed(
+  () =>
+    ((resLoadStatus as any).data?.value?.responseData?.result
+      ?.totalExpectedExecutionSecond as number) ?? 0,
+);
 // 성공 모달의 실시간 상태 표시용 — 종료(성공/실패) 여부.
 const currentLoadTestRawStatus = computed(
   () =>
@@ -442,6 +448,7 @@ function handleTemplateManagerClose() {
             :load-test-finish-at="currentLoadTestFinishAt"
             :load-test-failure-message="currentLoadTestFailureMessage"
             :load-test-steps="currentLoadTestSteps"
+            :load-test-expected-seconds="currentLoadTestExpectedSeconds"
             @openLoadconfig="handleLoadStatus"
             @openTemplateManager="handleTemplateManagerOpen"
             @stopLoadTest="handleStopLoadTest"


### PR DESCRIPTION
## 개요

부하테스트 진행 중 **진행률 바**를 추가한다. 모니터링 UI PR([#65](https://github.com/MZC-CSC/cm-butterfly/pull/65))에서 제외했던 후속 항목으로, **base를 `feat-bf-deps-001`(#65)로 스택**해 diff가 진행률 바만 보이게 했다. #65 머지 후 base를 develop으로 재지정한다.

## 변경

- 진행 안내 영역에 진행률 바를 렌더 — `startAt` + `totalExpectedExecutionSecond`(state API)로 경과 비율 계산, **1초 틱**으로 부드럽게 갱신.
- 예상 소요를 모르면(값 없음) **indeterminate 애니메이션**으로 폴백, 완료 시 100%. 종료 전에는 2~95%로 캡(조기 100% 방지).
- 상태 폴링·steps[] 표현과 독립(표시 계층만 추가).

## 검증

- vite build·타입 통과. 원격 서버 e2e(진행 중 상태 주입)로 바 표시 확인.

---
- [BAR-1399](https://mzdevs.atlassian.net/browse/BAR-1399) 부하테스트 진행 상태 모니터링 UI (진행률 바)