### PR TITLE
feat(workload): add a load-test progress bar (re-target to develop)

### DIFF
--- a/front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue
+++ b/front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { PButton, PTooltip } from '@cloudforet-test/mirinae';
-import { computed, Ref } from 'vue';
+import { computed, Ref, ref, watch, onBeforeUnmount } from 'vue';
 import { ILoadTestExecutionStep } from '@/entities/mci/model';
 import LoadTestEvaluationMetric from '@/widgets/workload/vm/vmEvaluatePerf/ui/LoadTestEvaluationMetric.vue';
 import LoadTestResourceMetric from '@/widgets/workload/vm/vmEvaluatePerf/ui/LoadTestResourceMetric.vue';
@@ -19,6 +19,8 @@ interface IProps {
   loadTestFailureMessage?: string;
   // 세분화 단계 진행(cm-ant FR-007-08 steps[]). 구버전 cm-ant면 빈 배열.
   loadTestSteps?: ILoadTestExecutionStep[];
+  // 진행률 바용 예상 총 소요(초) — cm-ant totalExpectedExecutionSecond.
+  loadTestExpectedSeconds?: number;
 }
 
 const props = defineProps<IProps>();
@@ -37,6 +39,40 @@ const hasLoadTest = computed(() => !!props.loadTestStatus);
 const isLoadTestFailed = computed(() => props.loadTestStatus === 'Failed');
 // 결과(차트·집계)는 성공(Completed)일 때만 노출. 실패/진행 중엔 결과 조회를 하지 않는다.
 const isLoadTestCompleted = computed(() => props.loadTestStatus === 'Completed');
+
+// 진행률 바 — startAt·예상 소요(초)로 경과 비율 계산. 진행 중엔 1초 틱으로 부드럽게 갱신.
+const nowMs = ref(Date.now());
+let tickTimer: ReturnType<typeof setInterval> | null = null;
+const stopTick = () => {
+  if (tickTimer) {
+    clearInterval(tickTimer);
+    tickTimer = null;
+  }
+};
+watch(
+  isLoadTestRunning,
+  running => {
+    if (running) {
+      nowMs.value = Date.now();
+      if (!tickTimer) tickTimer = setInterval(() => (nowMs.value = Date.now()), 1000);
+    } else {
+      stopTick();
+    }
+  },
+  { immediate: true },
+);
+onBeforeUnmount(stopTick);
+
+// 진행률(%). 완료=100, startAt/예상초 없으면 null(indeterminate 바). 진행 중엔 2~95%로 캡(종료 전 100% 방지).
+const progressPercent = computed<number | null>(() => {
+  if (isLoadTestCompleted.value) return 100;
+  if (!isLoadTestRunning.value) return 0;
+  const start = props.loadTestStartAt ? Date.parse(props.loadTestStartAt) : NaN;
+  const expectedMs = (props.loadTestExpectedSeconds ?? 0) * 1000;
+  if (!start || Number.isNaN(start) || expectedMs <= 0) return null;
+  const pct = ((nowMs.value - start) / expectedMs) * 100;
+  return Math.max(2, Math.min(95, Math.round(pct)));
+});
 
 // 단계(steps[]) 표현 매핑 — cm-ant ExecutionStep/StepStatus.
 const STEP_LABEL: Record<string, string> = {
@@ -188,6 +224,18 @@ const statusTooltip = computed(() => {
       <span v-if="currentStep?.message" class="progress-step-msg">{{
         currentStep.message
       }}</span>
+      <!-- 진행률 바: startAt·예상 소요로 경과 비율(예상 없으면 indeterminate). -->
+      <div class="load-test-progress-bar" data-testid="load-test-progress-bar">
+        <div
+          class="load-test-progress-fill"
+          :class="{ indeterminate: progressPercent === null }"
+          :style="progressPercent !== null ? { width: progressPercent + '%' } : {}"
+        ></div>
+      </div>
+      <span v-if="progressPercent !== null" class="progress-pct"
+        >{{ progressPercent }}%</span
+      >
+      <br />
       The results will appear here once it finishes.
     </div>
     <div
@@ -293,6 +341,45 @@ const statusTooltip = computed(() => {
   font-size: 13px;
   color: #495057;
   word-break: break-word;
+}
+
+.load-test-progress-bar {
+  width: 60%;
+  max-width: 420px;
+  height: 8px;
+  margin: 10px auto 4px auto;
+  background-color: #e9ecef;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.load-test-progress-fill {
+  height: 100%;
+  background-color: #1971c2;
+  border-radius: 999px;
+  transition: width 0.6s ease;
+}
+
+/* 예상 소요를 모를 때: 좌우로 흐르는 indeterminate 애니메이션 */
+.load-test-progress-fill.indeterminate {
+  width: 35%;
+  animation: load-test-indeterminate 1.4s ease-in-out infinite;
+}
+
+@keyframes load-test-indeterminate {
+  0% {
+    margin-left: -35%;
+  }
+  100% {
+    margin-left: 100%;
+  }
+}
+
+.progress-pct {
+  display: block;
+  font-size: 12px;
+  color: #1971c2;
+  font-weight: 600;
 }
 
 .load-test-status-badge.running {

--- a/front/src/widgets/workload/vm/vmList/ui/VmList.vue
+++ b/front/src/widgets/workload/vm/vmList/ui/VmList.vue
@@ -87,6 +87,12 @@ const currentLoadTestSteps = computed(
     ((resLoadStatus as any).data?.value?.responseData?.result
       ?.steps as any[]) ?? [],
 );
+// 진행률 바용 예상 총 소요(초).
+const currentLoadTestExpectedSeconds = computed(
+  () =>
+    ((resLoadStatus as any).data?.value?.responseData?.result
+      ?.totalExpectedExecutionSecond as number) ?? 0,
+);
 // 성공 모달의 실시간 상태 표시용 — 종료(성공/실패) 여부.
 const currentLoadTestRawStatus = computed(
   () =>
@@ -442,6 +448,7 @@ function handleTemplateManagerClose() {
             :load-test-finish-at="currentLoadTestFinishAt"
             :load-test-failure-message="currentLoadTestFailureMessage"
             :load-test-steps="currentLoadTestSteps"
+            :load-test-expected-seconds="currentLoadTestExpectedSeconds"
             @openLoadconfig="handleLoadStatus"
             @openTemplateManager="handleTemplateManagerOpen"
             @stopLoadTest="handleStopLoadTest"


### PR DESCRIPTION
## 배경

부하테스트 진행률 바는 PR #67로 구현·검증까지 마쳤으나, PR #67의 base가 `develop`이 아니라 `feat-bf-deps-001`(PR #65의 head)이었다. PR #65가 develop에 머지된 직후 PR #67이 이미 머지가 끝난 브랜치 위로 들어가면서, 진행률 바 변경만 develop에 반영되지 않았다.

본 PR은 동일한 변경(commit `f1020ba`)을 develop 기준으로 다시 올린 것이다. 코드 내용은 PR #67과 동일하다.

## 변경

부하테스트 실행 중 경과 시간 기반 진행률 바를 표시한다.

- `startAt`과 `totalExpectedExecutionSecond`로 경과 비율을 계산해 1초 간격으로 갱신
- 예상 소요 시간이 없으면 indeterminate 바로 표시
- 완료 시 100%로 고정

변경 파일: `front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue`, `front/src/widgets/workload/vm/vmList/ui/VmList.vue`

## 검증

- `vite build` 통과 (develop 최신 기준 cherry-pick, 충돌 없음)
- 기능 검증은 PR #67 시점에 진행률 바 포함 CI 이미지로 원격 개발 서버에서 완료 (부하테스트 미실행/진행/완료/실패 전 상태 매트릭스 PASS)

---

- [BAR-1417](https://mzdevs.atlassian.net/browse/BAR-1417) 부하테스트 진행률 바 (경과/예상 기반 progress bar)
- [BAR-1400](https://mzdevs.atlassian.net/browse/BAR-1400) cm-butterfly v0.5.2 pre-release 추진