### PR TITLE
feat(workflow): add a run status viewer that draws the real execution graph

### DIFF
--- a/front/src/entities/workflow/lib/runGraph.ts
+++ b/front/src/entities/workflow/lib/runGraph.ts
@@ -1,0 +1,189 @@
+import {
+  ITaskGroupResponse,
+  ITaskResponse,
+  IWorkflowResponse,
+} from '@/entities/workflow/model/types';
+
+/**
+ * 워크플로우 정의에서 실행 그래프를 만든다.
+ *
+ * 실행 순서는 각 task의 `dependencies`에서만 나온다. task_group은 엔진에서
+ * 실행 단위가 아니라 묶음일 뿐이므로 그룹 순서로 의존성을 지어내지 않는다.
+ * 따라서 병렬·다이아몬드·다중 시작점이 정의에 있으면 그대로 그래프에 나타난다.
+ */
+
+export interface IRunGraphNode {
+  /** cm-cicada task.id — 실행 상태(taskInstances)의 task_id와 같은 값 */
+  id: string;
+  name: string;
+  taskComponent: string;
+  groupName: string;
+  /** 세로 위치. 자기보다 앞선 모든 task보다 뒤에 놓인다 */
+  level: number;
+  /** 같은 level 안에서의 가로 위치 */
+  order: number;
+}
+
+export interface IRunGraphEdge {
+  from: string;
+  to: string;
+}
+
+export interface IRunGraph {
+  nodes: IRunGraphNode[];
+  edges: IRunGraphEdge[];
+  levelCount: number;
+  /** 한 줄로 이어지는 단일 체인인가 (편집기가 표현할 수 있는 유일한 형태) */
+  isLinear: boolean;
+  /** 정의가 온전하지 않을 때 남기는 메모. 감추지 말고 화면에 드러낸다 */
+  warnings: string[];
+}
+
+function flattenTasks(
+  groups: Array<ITaskGroupResponse> | undefined,
+  out: Array<{ task: ITaskResponse; groupName: string }> = [],
+): Array<{ task: ITaskResponse; groupName: string }> {
+  (groups ?? []).forEach(group => {
+    (group.tasks ?? []).forEach(task => {
+      out.push({ task, groupName: group.name });
+    });
+    // 정의상 중첩 그룹이 올 수 있으므로 함께 펼친다
+    flattenTasks(group.task_groups, out);
+  });
+  return out;
+}
+
+function taskIdOf(task: ITaskResponse): string {
+  return task.id ?? task.name;
+}
+
+export function buildRunGraph(workflow: IWorkflowResponse | null): IRunGraph {
+  const warnings: string[] = [];
+  const flat = flattenTasks(workflow?.data?.task_groups);
+
+  const nodes: IRunGraphNode[] = flat.map(({ task, groupName }) => ({
+    id: taskIdOf(task),
+    name: task.name,
+    taskComponent: task.task_component,
+    groupName,
+    level: 0,
+    order: 0,
+  }));
+
+  const idByName = new Map<string, string>();
+  flat.forEach(({ task }) => {
+    // 엔진은 그룹을 가로질러 task 이름이 전역 유일할 것을 요구한다.
+    if (idByName.has(task.name)) {
+      warnings.push(`태스크 이름이 중복됩니다: ${task.name}`);
+    }
+    idByName.set(task.name, taskIdOf(task));
+  });
+
+  const edges: IRunGraphEdge[] = [];
+  const depsByNode = new Map<string, string[]>();
+
+  flat.forEach(({ task }) => {
+    const id = taskIdOf(task);
+    const deps: string[] = [];
+    (task.dependencies ?? []).forEach((depName: any) => {
+      const depId = idByName.get(String(depName));
+      if (!depId) {
+        warnings.push(
+          `${task.name}이(가) 존재하지 않는 태스크에 의존합니다: ${depName}`,
+        );
+        return;
+      }
+      deps.push(depId);
+      edges.push({ from: depId, to: id });
+    });
+    depsByNode.set(id, deps);
+  });
+
+  assignLevels(nodes, depsByNode, warnings);
+  assignOrders(nodes);
+
+  const levelCount = nodes.length
+    ? Math.max(...nodes.map(n => n.level)) + 1
+    : 0;
+
+  return {
+    nodes,
+    edges,
+    levelCount,
+    isLinear: isSingleChain(nodes, edges),
+    warnings,
+  };
+}
+
+/**
+ * level = 가장 긴 선행 경로의 깊이. 같은 level의 노드는 서로 의존하지 않으므로
+ * 가로로 나란히 놓아도 되고, 그래서 병렬이 병렬로 보인다.
+ */
+function assignLevels(
+  nodes: IRunGraphNode[],
+  depsByNode: Map<string, string[]>,
+  warnings: string[],
+): void {
+  const nodeById = new Map(nodes.map(n => [n.id, n]));
+  const resolved = new Set<string>();
+
+  let remaining = nodes.slice();
+  while (remaining.length) {
+    const ready = remaining.filter(node =>
+      (depsByNode.get(node.id) ?? []).every(dep => resolved.has(dep)),
+    );
+
+    if (!ready.length) {
+      // 엔진이 순환 의존을 거부하므로 정상 워크플로우에서는 도달하지 않는다.
+      // 그래도 화면이 멈추지 않도록 남은 노드를 마지막 level에 몰아 넣고 알린다.
+      warnings.push(
+        '순환 의존이 있어 실행 순서를 확정할 수 없는 태스크가 있습니다.',
+      );
+      const fallbackLevel = resolved.size
+        ? Math.max(...[...resolved].map(id => nodeById.get(id)!.level)) + 1
+        : 0;
+      remaining.forEach(node => {
+        node.level = fallbackLevel;
+      });
+      return;
+    }
+
+    ready.forEach(node => {
+      const deps = depsByNode.get(node.id) ?? [];
+      node.level = deps.length
+        ? Math.max(...deps.map(dep => nodeById.get(dep)!.level)) + 1
+        : 0;
+    });
+    ready.forEach(node => resolved.add(node.id));
+    remaining = remaining.filter(node => !resolved.has(node.id));
+  }
+}
+
+function assignOrders(nodes: IRunGraphNode[]): void {
+  const seen = new Map<number, number>();
+  nodes.forEach(node => {
+    const next = seen.get(node.level) ?? 0;
+    node.order = next;
+    seen.set(node.level, next + 1);
+  });
+}
+
+/** 노드가 한 줄로만 이어지는가 — level마다 노드가 정확히 하나면 단일 체인이다 */
+function isSingleChain(
+  nodes: IRunGraphNode[],
+  edges: IRunGraphEdge[],
+): boolean {
+  if (nodes.length <= 1) return true;
+
+  const perLevel = new Map<number, number>();
+  nodes.forEach(node => {
+    perLevel.set(node.level, (perLevel.get(node.level) ?? 0) + 1);
+  });
+  if ([...perLevel.values()].some(count => count > 1)) return false;
+
+  // level마다 하나씩이라도, 엣지가 인접 level을 건너뛰면 체인이 아니다
+  const levelById = new Map(nodes.map(n => [n.id, n.level]));
+  return edges.every(
+    edge => levelById.get(edge.to)! - levelById.get(edge.from)! === 1,
+  );
+}

--- a/front/src/entities/workflow/lib/runGraph.ts
+++ b/front/src/entities/workflow/lib/runGraph.ts
@@ -18,6 +18,8 @@ export interface IRunGraphNode {
   name: string;
   taskComponent: string;
   groupName: string;
+  /** 이 task에 저장돼 있는 값. 실행에 쓰인 값이 아니라 *현재 정의*의 값이다 */
+  spec: Record<string, any>;
   /** 세로 위치. 자기보다 앞선 모든 task보다 뒤에 놓인다 */
   level: number;
   /** 같은 level 안에서의 가로 위치 */
@@ -57,6 +59,26 @@ function taskIdOf(task: ITaskResponse): string {
   return task.id ?? task.name;
 }
 
+/**
+ * task에 저장된 값을 화면에 보여줄 형태로 모은다.
+ *
+ * cm-cicada의 새 형식은 `spec`에 값을 담고, 예전 형식은 request_body/path_params/
+ * query_params를 따로 둔다. 둘 다 올 수 있으므로 있는 것만 모은다.
+ */
+function taskSpecOf(task: ITaskResponse): Record<string, any> {
+  const spec: Record<string, any> = { ...(task.spec ?? {}) };
+  if (task.request_body !== undefined && spec.request_body === undefined) {
+    spec.request_body = task.request_body;
+  }
+  if (task.path_params !== undefined && spec.path_params === undefined) {
+    spec.path_params = task.path_params;
+  }
+  if (task.query_params !== undefined && spec.query_params === undefined) {
+    spec.query_params = task.query_params;
+  }
+  return spec;
+}
+
 export function buildRunGraph(workflow: IWorkflowResponse | null): IRunGraph {
   const warnings: string[] = [];
   const flat = flattenTasks(workflow?.data?.task_groups);
@@ -66,6 +88,7 @@ export function buildRunGraph(workflow: IWorkflowResponse | null): IRunGraph {
     name: task.name,
     taskComponent: task.task_component,
     groupName,
+    spec: taskSpecOf(task),
     level: 0,
     order: 0,
   }));

--- a/front/src/entities/workflow/lib/runGraph.ts
+++ b/front/src/entities/workflow/lib/runGraph.ts
@@ -31,10 +31,19 @@ export interface IRunGraphEdge {
   to: string;
 }
 
+/** 그래프 렌더 치수 — 뷰어가 그래프에 얼마나 폭을 내줄지 계산할 때도 쓴다 */
+export const GRAPH_NODE_WIDTH = 190;
+export const GRAPH_NODE_HEIGHT = 52;
+export const GRAPH_GAP_X = 44;
+export const GRAPH_GAP_Y = 60;
+export const GRAPH_PADDING = 28;
+
 export interface IRunGraph {
   nodes: IRunGraphNode[];
   edges: IRunGraphEdge[];
   levelCount: number;
+  /** 한 단계에 가장 많이 놓이는 노드 수 = 그래프가 필요로 하는 가로 칸 수 */
+  maxParallel: number;
   /** 한 줄로 이어지는 단일 체인인가 (편집기가 표현할 수 있는 유일한 형태) */
   isLinear: boolean;
   /** 정의가 온전하지 않을 때 남기는 메모. 감추지 말고 화면에 드러낸다 */
@@ -133,6 +142,7 @@ export function buildRunGraph(workflow: IWorkflowResponse | null): IRunGraph {
     nodes,
     edges,
     levelCount,
+    maxParallel: maxNodesPerLevel(nodes),
     isLinear: isSingleChain(nodes, edges),
     warnings,
   };
@@ -180,6 +190,27 @@ function assignLevels(
     ready.forEach(node => resolved.add(node.id));
     remaining = remaining.filter(node => !resolved.has(node.id));
   }
+}
+
+function maxNodesPerLevel(nodes: IRunGraphNode[]): number {
+  const counts = new Map<number, number>();
+  nodes.forEach(node => {
+    counts.set(node.level, (counts.get(node.level) ?? 0) + 1);
+  });
+  return Math.max(1, ...counts.values());
+}
+
+/**
+ * 그래프를 다 그리는 데 필요한 가로 픽셀.
+ *
+ * 병렬 갈래가 없는 워크플로우(인프라·SW 마이그레이션처럼 컴포넌트가 하나뿐인
+ * 경우)는 좁게 잡히므로, 뷰어가 남는 폭을 상세 패널에 내줄 수 있다.
+ */
+export function graphPixelWidth(graph: IRunGraph): number {
+  const columns = graph.maxParallel;
+  return (
+    GRAPH_PADDING * 2 + columns * GRAPH_NODE_WIDTH + (columns - 1) * GRAPH_GAP_X
+  );
 }
 
 function assignOrders(nodes: IRunGraphNode[]): void {

--- a/front/src/entities/workflow/lib/taskState.ts
+++ b/front/src/entities/workflow/lib/taskState.ts
@@ -1,0 +1,79 @@
+/**
+ * 실행 상태 표시 규칙.
+ *
+ * cm-cicada는 자체 상태 상수를 두지 않고 실행 엔진의 상태 문자열을 그대로
+ * 통과시킨다. 따라서 여기서 모르는 값이 들어올 수 있고, 그때 정상인 것처럼
+ * 보이게 만들면 안 된다 — `unknown`으로 분류해 상태 문자열을 그대로 노출한다.
+ */
+
+export type TaskStateKind =
+  | 'running'
+  | 'success'
+  | 'failed'
+  | 'upstreamFailed'
+  | 'retry'
+  | 'skipped'
+  | 'pending'
+  | 'unknown';
+
+const KIND_BY_STATE: Record<string, TaskStateKind> = {
+  running: 'running',
+  restarting: 'running',
+  success: 'success',
+  failed: 'failed',
+  upstream_failed: 'upstreamFailed',
+  up_for_retry: 'retry',
+  up_for_reschedule: 'retry',
+  deferred: 'retry',
+  skipped: 'skipped',
+  removed: 'skipped',
+  queued: 'pending',
+  scheduled: 'pending',
+  none: 'pending',
+};
+
+/** 아직 시작하지 않은 태스크는 state가 "None" 문자열로 온다 */
+export function taskStateKind(state?: string | null): TaskStateKind {
+  if (!state) return 'pending';
+  return KIND_BY_STATE[state.toLowerCase()] ?? 'unknown';
+}
+
+const LABEL_BY_KIND: Record<TaskStateKind, string> = {
+  running: '실행 중',
+  success: '성공',
+  failed: '실패',
+  upstreamFailed: '앞 태스크 실패로 미실행',
+  retry: '재시도 대기',
+  skipped: '건너뜀',
+  pending: '대기',
+  unknown: '알 수 없는 상태',
+};
+
+/** 모르는 상태는 원래 문자열을 그대로 보여준다 */
+export function taskStateLabel(state?: string | null): string {
+  const kind = taskStateKind(state);
+  if (kind === 'unknown') return `${LABEL_BY_KIND.unknown} (${state})`;
+  return LABEL_BY_KIND[kind];
+}
+
+/** mirinae PBadge의 badge-type */
+const BADGE_BY_KIND: Record<TaskStateKind, string> = {
+  running: 'blue',
+  success: 'green',
+  failed: 'red',
+  upstreamFailed: 'yellow',
+  retry: 'yellow',
+  skipped: 'gray',
+  pending: 'gray',
+  unknown: 'gray',
+};
+
+export function taskStateBadgeType(state?: string | null): string {
+  return BADGE_BY_KIND[taskStateKind(state)];
+}
+
+/** 실행(run) 상태가 종료에 도달했는가 — 폴링 중단 조건 */
+export function isRunFinished(runState?: string | null): boolean {
+  if (!runState) return false;
+  return ['success', 'failed'].includes(runState.toLowerCase());
+}

--- a/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
+++ b/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
@@ -6,6 +6,7 @@ import {
   WorkflowDetail,
   WorkflowJsonViewer,
   WorkflowHistory,
+  WorkflowRunViewer,
 } from '@/widgets/workflow';
 import { SimpleEditForm } from '@/widgets/layout';
 import { useGetWorkflow, useUpdateWorkflow } from '@/entities';
@@ -50,6 +51,10 @@ const mainTabState = reactive({
     {
       name: 'history',
       label: 'History',
+    },
+    {
+      name: 'runViewer',
+      label: 'Run Status',
     },
   ],
 });
@@ -200,6 +205,12 @@ async function handleUpdateWorkflow(updatedData: object) {
               <p>Workflow History</p>
             </div>
             <workflow-history :selected-workflow-id="selectedWorkflowId" />
+          </template>
+          <template #runViewer>
+            <div class="tab-section-header">
+              <p>Workflow Run Status</p>
+            </div>
+            <workflow-run-viewer :workflow-id="selectedWorkflowId" />
           </template>
         </p-tab>
       </div>

--- a/front/src/widgets/workflow/workflows/index.ts
+++ b/front/src/widgets/workflow/workflows/index.ts
@@ -2,3 +2,4 @@ export * from '@/widgets/workflow/workflows/workflowDetail';
 export * from '@/widgets/workflow/workflows/workflowList';
 export * from '@/widgets/workflow/workflows/workflowJsonViewer';
 export * from '@/widgets/workflow/workflows/workflowHistory';
+export * from '@/widgets/workflow/workflows/workflowRunViewer';

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/index.ts
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/index.ts
@@ -1,0 +1,3 @@
+import WorkflowRunViewer from '@/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue';
+
+export { WorkflowRunViewer };

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
@@ -1,0 +1,177 @@
+import { computed, onScopeDispose, ref } from 'vue';
+import { useIntervalFn } from '@vueuse/core';
+import {
+  useGetTaskInstances,
+  useGetWorkflow,
+  useGetWorkflowRuns,
+} from '@/entities/workflow/api/index';
+import {
+  ITaskInstance,
+  IWorkflowResponse,
+  IWorkflowRun,
+} from '@/entities/workflow/model/types';
+import { buildRunGraph, IRunGraph } from '@/entities/workflow/lib/runGraph';
+import { isRunFinished } from '@/entities/workflow/lib/taskState';
+
+/**
+ * 실행 상태를 주기적으로 조회한다.
+ *
+ * 엔진에 상태 변경을 알려주는 채널이 없어 조회 말고는 방법이 없다. 그런데 그
+ * 조회가 엔진 안에서 워크플로우 단위로 직렬화되므로, 주기를 짧게 잡으면 실행·
+ * 재실행 같은 작업을 지연시킨다. 그래서 주기는 넉넉히 두고, 실행이 끝나면
+ * 곧바로 멈춘다.
+ */
+const POLL_INTERVAL_MS = 3000;
+const MIN_POLL_INTERVAL_MS = 2000;
+
+export function useWorkflowRunViewerModel() {
+  const workflow = ref<IWorkflowResponse | null>(null);
+  const runs = ref<IWorkflowRun[]>([]);
+  const selectedRunId = ref<string | null>(null);
+  const instances = ref<ITaskInstance[]>([]);
+  const selectedTaskId = ref<string | null>(null);
+  const loadError = ref<string | null>(null);
+  const isPolling = ref(false);
+
+  const graph = computed<IRunGraph>(() => buildRunGraph(workflow.value));
+
+  const selectedRun = computed(
+    () =>
+      runs.value.find(r => r.workflow_run_id === selectedRunId.value) ?? null,
+  );
+
+  const selectedInstance = computed(
+    () => instances.value.find(i => i.task_id === selectedTaskId.value) ?? null,
+  );
+
+  const selectedNode = computed(
+    () => graph.value.nodes.find(n => n.id === selectedTaskId.value) ?? null,
+  );
+
+  /**
+   * 실행 이력에는 있는데 현재 정의에는 없는 태스크. 그래프에 그릴 자리가 없으므로
+   * 조용히 버리지 않고 따로 보여준다.
+   */
+  const deletedTaskInstances = computed(() => {
+    const known = new Set(graph.value.nodes.map(n => n.id));
+    return instances.value.filter(i => !known.has(i.task_id));
+  });
+
+  async function loadWorkflow(wfId: string) {
+    const { data, execute } = useGetWorkflow(wfId);
+    await execute();
+    workflow.value = data.value?.responseData ?? null;
+  }
+
+  async function loadRuns(wfId: string) {
+    const { data, execute } = useGetWorkflowRuns(wfId);
+    await execute();
+    runs.value = data.value?.responseData ?? [];
+  }
+
+  let inFlight = false;
+
+  async function fetchInstances(wfId: string, runId: string) {
+    // 같은 워크플로우를 동시에 조회하면 엔진 쪽 직렬화와 경합한다
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      // 이 컴포저블은 생성 시점에 파라미터를 묶으므로 호출마다 새로 만든다
+      const { data, execute } = useGetTaskInstances(wfId, runId);
+      await execute();
+      instances.value = data.value?.responseData ?? [];
+      loadError.value = null;
+    } catch (e: any) {
+      // 실행 직후에는 엔진이 아직 준비되지 않아 실패할 수 있다.
+      // 곧바로 에러로 단정하지 않고 다음 주기에 다시 시도한다.
+      loadError.value = e?.message ?? '실행 상태를 가져오지 못했습니다.';
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  async function refreshRunState(wfId: string) {
+    // 실행 하나만 조회하는 엔드포인트가 없어 목록을 다시 받는다
+    await loadRuns(wfId);
+  }
+
+  const { pause, resume } = useIntervalFn(
+    async () => {
+      const wfId = workflow.value?.id;
+      const runId = selectedRunId.value;
+      if (!wfId || !runId) return;
+
+      await fetchInstances(wfId, runId);
+      await refreshRunState(wfId);
+
+      if (isRunFinished(selectedRun.value?.state)) {
+        // 종료를 확인한 주기에 마지막 상태까지 담았으므로 여기서 멈춘다
+        stopPolling();
+      }
+    },
+    Math.max(POLL_INTERVAL_MS, MIN_POLL_INTERVAL_MS),
+    { immediate: false },
+  );
+
+  function startPolling() {
+    if (isPolling.value) return;
+    isPolling.value = true;
+    resume();
+  }
+
+  function stopPolling() {
+    if (!isPolling.value) return;
+    isPolling.value = false;
+    pause();
+  }
+
+  async function selectRun(wfId: string, runId: string) {
+    stopPolling();
+    selectedRunId.value = runId;
+    selectedTaskId.value = null;
+    instances.value = [];
+
+    await fetchInstances(wfId, runId);
+
+    if (!isRunFinished(selectedRun.value?.state)) startPolling();
+  }
+
+  async function open(wfId: string, runId?: string | null) {
+    loadError.value = null;
+    await Promise.all([loadWorkflow(wfId), loadRuns(wfId)]);
+
+    const target =
+      runId ??
+      [...runs.value].sort((a, b) =>
+        (b.start_date ?? '').localeCompare(a.start_date ?? ''),
+      )[0]?.workflow_run_id;
+
+    if (target) await selectRun(wfId, target);
+  }
+
+  function selectTask(taskId: string) {
+    selectedTaskId.value = taskId;
+  }
+
+  // 화면을 벗어나면 조회가 남지 않게 한다
+  onScopeDispose(stopPolling);
+
+  return {
+    workflow,
+    runs,
+    selectedRunId,
+    selectedRun,
+    instances,
+    selectedTaskId,
+    selectedInstance,
+    selectedNode,
+    deletedTaskInstances,
+    graph,
+    isPolling,
+    loadError,
+    open,
+    selectRun,
+    selectTask,
+    stopPolling,
+  };
+}

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
@@ -49,6 +49,20 @@ export function useWorkflowRunViewerModel() {
   );
 
   /**
+   * 이 실행이 끝난 뒤에 워크플로우가 수정됐는가.
+   *
+   * 엔진은 "그 실행에 쓰인 정의"를 돌려주지 않는다. 화면이 보여주는 파라미터는
+   * 언제나 *현재 정의*의 값이므로, 실행 이후 정의가 바뀌었으면 화면 값과 실제
+   * 실행에 쓰인 값이 다를 수 있다. 그 사실을 감추지 않고 알린다.
+   */
+  const definitionChangedAfterRun = computed(() => {
+    const updatedAt = workflow.value?.updated_at;
+    const startedAt = selectedRun.value?.start_date;
+    if (!updatedAt || !startedAt) return false;
+    return new Date(updatedAt).getTime() > new Date(startedAt).getTime();
+  });
+
+  /**
    * 실행 이력에는 있는데 현재 정의에는 없는 태스크. 그래프에 그릴 자리가 없으므로
    * 조용히 버리지 않고 따로 보여준다.
    */
@@ -166,6 +180,7 @@ export function useWorkflowRunViewerModel() {
     selectedInstance,
     selectedNode,
     deletedTaskInstances,
+    definitionChangedAfterRun,
     graph,
     isPolling,
     loadError,

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/RunGraph.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/RunGraph.vue
@@ -1,0 +1,265 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { IRunGraph, IRunGraphNode } from '@/entities/workflow/lib/runGraph';
+import { ITaskInstance } from '@/entities/workflow/model/types';
+import {
+  taskStateKind,
+  taskStateLabel,
+} from '@/entities/workflow/lib/taskState';
+
+interface Props {
+  graph: IRunGraph;
+  instances: ITaskInstance[];
+  selectedTaskId: string | null;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<{ (e: 'select', taskId: string): void }>();
+
+const NODE_WIDTH = 190;
+const NODE_HEIGHT = 52;
+const GAP_X = 44;
+const GAP_Y = 60;
+const PADDING = 28;
+
+const instanceByTaskId = computed(
+  () => new Map(props.instances.map(i => [i.task_id, i])),
+);
+
+// 같은 level의 노드는 서로 의존하지 않으므로 가로로 나란히 둔다.
+// 그래서 병렬이 병렬로 보인다.
+const nodesPerLevel = computed(() => {
+  const counts = new Map<number, number>();
+  props.graph.nodes.forEach(node => {
+    counts.set(node.level, (counts.get(node.level) ?? 0) + 1);
+  });
+  return counts;
+});
+
+const widestLevel = computed(() =>
+  Math.max(1, ...[...nodesPerLevel.value.values()]),
+);
+
+const canvasWidth = computed(
+  () =>
+    PADDING * 2 +
+    widestLevel.value * NODE_WIDTH +
+    (widestLevel.value - 1) * GAP_X,
+);
+
+const canvasHeight = computed(
+  () =>
+    PADDING * 2 +
+    Math.max(1, props.graph.levelCount) * NODE_HEIGHT +
+    Math.max(0, props.graph.levelCount - 1) * GAP_Y,
+);
+
+function nodeX(node: IRunGraphNode): number {
+  const countInLevel = nodesPerLevel.value.get(node.level) ?? 1;
+  const rowWidth = countInLevel * NODE_WIDTH + (countInLevel - 1) * GAP_X;
+  const rowLeft = (canvasWidth.value - rowWidth) / 2;
+  return rowLeft + node.order * (NODE_WIDTH + GAP_X);
+}
+
+function nodeY(node: IRunGraphNode): number {
+  return PADDING + node.level * (NODE_HEIGHT + GAP_Y);
+}
+
+const positioned = computed(() =>
+  props.graph.nodes.map(node => {
+    const instance = instanceByTaskId.value.get(node.id);
+    const label = taskStateLabel(instance?.state);
+    const tryNumber = instance?.try_number ?? 0;
+    return {
+      node,
+      x: nodeX(node),
+      y: nodeY(node),
+      state: instance?.state,
+      kind: taskStateKind(instance?.state),
+      label,
+      tryNumber,
+      tooltip:
+        tryNumber > 1
+          ? `${node.name} — ${label} (시도 ${tryNumber}회)`
+          : `${node.name} — ${label}`,
+    };
+  }),
+);
+
+const positionById = computed(
+  () => new Map(positioned.value.map(p => [p.node.id, p])),
+);
+
+const edgePaths = computed(() =>
+  props.graph.edges.flatMap(edge => {
+    const from = positionById.value.get(edge.from);
+    const to = positionById.value.get(edge.to);
+    if (!from || !to) return [];
+
+    const x1 = from.x + NODE_WIDTH / 2;
+    const y1 = from.y + NODE_HEIGHT;
+    const x2 = to.x + NODE_WIDTH / 2;
+    const y2 = to.y;
+    const midY = (y1 + y2) / 2;
+
+    return [
+      {
+        key: `${edge.from}->${edge.to}`,
+        d: `M ${x1} ${y1} C ${x1} ${midY}, ${x2} ${midY}, ${x2} ${y2}`,
+      },
+    ];
+  }),
+);
+</script>
+
+<template>
+  <div class="run-graph">
+    <svg
+      :width="canvasWidth"
+      :height="canvasHeight"
+      :viewBox="`0 0 ${canvasWidth} ${canvasHeight}`"
+    >
+      <defs>
+        <marker
+          id="run-graph-arrow"
+          markerWidth="8"
+          markerHeight="8"
+          refX="7"
+          refY="4"
+          orient="auto"
+        >
+          <path d="M 0 0 L 8 4 L 0 8 z" class="run-graph__arrow" />
+        </marker>
+      </defs>
+
+      <path
+        v-for="edge in edgePaths"
+        :key="edge.key"
+        :d="edge.d"
+        class="run-graph__edge"
+        marker-end="url(#run-graph-arrow)"
+      />
+
+      <g
+        v-for="item in positioned"
+        :key="item.node.id"
+        class="run-graph__node"
+        :class="[
+          `run-graph__node--${item.kind}`,
+          { 'run-graph__node--selected': item.node.id === selectedTaskId },
+        ]"
+        @click="emit('select', item.node.id)"
+      >
+        <title>{{ item.tooltip }}</title>
+        <rect
+          :x="item.x"
+          :y="item.y"
+          :width="NODE_WIDTH"
+          :height="NODE_HEIGHT"
+          rx="8"
+          class="run-graph__box"
+        />
+        <text :x="item.x + 14" :y="item.y + 22" class="run-graph__name">
+          {{ item.node.name }}
+        </text>
+        <text :x="item.x + 14" :y="item.y + 39" class="run-graph__state">
+          {{ item.label }}
+          <template v-if="item.tryNumber > 1">
+            · 시도 {{ item.tryNumber }}
+          </template>
+        </text>
+      </g>
+    </svg>
+  </div>
+</template>
+
+<style lang="postcss" scoped>
+.run-graph {
+  overflow: auto;
+  padding: 0.5rem;
+}
+
+.run-graph__edge {
+  fill: none;
+  stroke: #b8bcc4;
+  stroke-width: 1.5;
+}
+
+.run-graph__arrow {
+  fill: #b8bcc4;
+}
+
+.run-graph__node {
+  cursor: pointer;
+}
+
+.run-graph__box {
+  fill: #ffffff;
+  stroke: #d4d7dc;
+  stroke-width: 1.5;
+}
+
+.run-graph__name {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  fill: #232533;
+}
+
+.run-graph__state {
+  font-size: 0.6875rem;
+  fill: #6b6e78;
+}
+
+.run-graph__node--selected .run-graph__box {
+  stroke-width: 2.5;
+  stroke: #4e42d4;
+}
+
+.run-graph__node--success .run-graph__box {
+  fill: #f2fbf5;
+  stroke: #34a853;
+}
+
+.run-graph__node--failed .run-graph__box {
+  fill: #fdf3f3;
+  stroke: #e14f4f;
+}
+
+/* 앞 태스크가 실패해 돌지 못한 것 — 이 태스크가 잘못된 게 아니므로 실패와 구분한다 */
+.run-graph__node--upstreamFailed .run-graph__box {
+  fill: #fff8ef;
+  stroke: #f4a63c;
+}
+
+.run-graph__node--retry .run-graph__box {
+  fill: #fffbe9;
+  stroke: #e6c229;
+}
+
+.run-graph__node--skipped .run-graph__box {
+  fill: #f7f7f8;
+  stroke: #c2c5cb;
+}
+
+.run-graph__node--running .run-graph__box {
+  fill: #eef2ff;
+  stroke: #3e6ee8;
+  animation: run-graph-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes run-graph-pulse {
+  0%,
+  100% {
+    stroke-opacity: 1;
+  }
+  50% {
+    stroke-opacity: 0.25;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .run-graph__node--running .run-graph__box {
+    animation: none;
+  }
+}
+</style>

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/RunGraph.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/RunGraph.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { IRunGraph, IRunGraphNode } from '@/entities/workflow/lib/runGraph';
+import {
+  GRAPH_GAP_X,
+  GRAPH_GAP_Y,
+  GRAPH_NODE_HEIGHT,
+  GRAPH_NODE_WIDTH,
+  GRAPH_PADDING,
+  IRunGraph,
+  IRunGraphNode,
+} from '@/entities/workflow/lib/runGraph';
 import { ITaskInstance } from '@/entities/workflow/model/types';
 import {
   taskStateKind,
@@ -16,11 +24,11 @@ interface Props {
 const props = defineProps<Props>();
 const emit = defineEmits<{ (e: 'select', taskId: string): void }>();
 
-const NODE_WIDTH = 190;
-const NODE_HEIGHT = 52;
-const GAP_X = 44;
-const GAP_Y = 60;
-const PADDING = 28;
+const NODE_WIDTH = GRAPH_NODE_WIDTH;
+const NODE_HEIGHT = GRAPH_NODE_HEIGHT;
+const GAP_X = GRAPH_GAP_X;
+const GAP_Y = GRAPH_GAP_Y;
+const PADDING = GRAPH_PADDING;
 
 const instanceByTaskId = computed(
   () => new Map(props.instances.map(i => [i.task_id, i])),

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -25,6 +25,7 @@ const {
   selectedInstance,
   selectedNode,
   deletedTaskInstances,
+  definitionChangedAfterRun,
   graph,
   isPolling,
   loadError,
@@ -41,6 +42,26 @@ const runOptions = computed(() =>
       label: `${run.start_date ?? run.execution_date} · ${taskStateLabel(run.state)}`,
     })),
 );
+
+/** 값이 JSON 문자열이면 읽기 좋게 펼친다 (cicada는 request_body를 문자열로 담는다) */
+function formatParamValue(value: any): string {
+  if (value === null || value === undefined) return '-';
+  if (typeof value === 'string') {
+    try {
+      return JSON.stringify(JSON.parse(value), null, 2);
+    } catch {
+      return value;
+    }
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+const selectedParams = computed(() => {
+  const spec = selectedNode.value?.spec ?? {};
+  return Object.entries(spec)
+    .filter(([, value]) => value !== undefined && value !== '')
+    .map(([key, value]) => ({ key, value: formatParamValue(value) }));
+});
 
 function formatDuration(seconds?: number): string {
   if (seconds === undefined || seconds === null) return '-';
@@ -139,6 +160,30 @@ async function onRunChange(runId: string) {
             <dt>소요</dt>
             <dd>{{ formatDuration(selectedInstance?.duration_date) }}</dd>
           </dl>
+
+          <div class="run-viewer__params">
+            <h5>파라미터</h5>
+            <!--
+              엔진은 그 실행에 쓰인 값을 돌려주지 않는다. 아래는 언제나
+              *현재 정의*의 값이므로, 실행 후 정의가 바뀌었으면 다를 수 있다.
+            -->
+            <p
+              v-if="definitionChangedAfterRun"
+              class="run-viewer__param-warning"
+            >
+              ⚠ 이 실행 이후 워크플로우가 수정됐습니다. 아래 값은 현재 정의의
+              값이며, 실제 실행에 쓰인 값과 다를 수 있습니다.
+            </p>
+            <p v-else class="run-viewer__hint">현재 정의 기준입니다.</p>
+
+            <p v-if="!selectedParams.length" class="run-viewer__hint">
+              저장된 파라미터가 없습니다.
+            </p>
+            <div v-for="param in selectedParams" :key="param.key">
+              <div class="run-viewer__param-key">{{ param.key }}</div>
+              <pre class="run-viewer__param-value">{{ param.value }}</pre>
+            </div>
+          </div>
         </template>
         <p v-else class="run-viewer__hint">
           태스크를 선택하면 상세가 표시됩니다.
@@ -215,12 +260,18 @@ async function onRunChange(runId: string) {
 
 .run-viewer__body {
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   align-items: flex-start;
 }
 
+/*
+  폭이 모자라면 상세 패널이 그래프 아래로 내려간다. 좌측 메뉴가 펼쳐져 있거나
+  병렬 갈래가 늘어 그래프가 넓어져도 그래프가 짓눌리지 않게 하기 위함이다.
+  뷰포트가 아니라 실제 남은 폭에 반응하도록 미디어 쿼리 대신 wrap을 쓴다.
+*/
 .run-viewer__graph {
-  flex: 1 1 auto;
+  flex: 1 1 30rem;
   min-width: 0;
   border: 1px solid #e5e5e8;
   border-radius: 0.375rem;
@@ -235,7 +286,8 @@ async function onRunChange(runId: string) {
 }
 
 .run-viewer__panel {
-  flex: 0 0 18rem;
+  flex: 1 1 18rem;
+  max-width: 100%;
   border: 1px solid #e5e5e8;
   border-radius: 0.375rem;
   padding: 0.875rem;
@@ -261,6 +313,47 @@ async function onRunChange(runId: string) {
 .run-viewer__hint {
   font-size: 0.8125rem;
   color: #6b6e78;
+}
+
+.run-viewer__params {
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #e5e5e8;
+}
+
+.run-viewer__params h5 {
+  font-weight: 700;
+  font-size: 0.8125rem;
+  margin-bottom: 0.25rem;
+}
+
+.run-viewer__param-warning {
+  font-size: 0.75rem;
+  color: #8a5a17;
+  background: #fff8ef;
+  border-radius: 0.25rem;
+  padding: 0.375rem 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.run-viewer__param-key {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b6e78;
+}
+
+.run-viewer__param-value {
+  margin-top: 0.125rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.25rem;
+  background: #f7f7f8;
+  font-size: 0.6875rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 14rem;
+  overflow: auto;
 }
 
 .run-viewer__deleted {

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -1,0 +1,277 @@
+<script setup lang="ts">
+import { computed, watch } from 'vue';
+import { PBadge, PSelectDropdown } from '@cloudforet-test/mirinae';
+import RunGraph from './RunGraph.vue';
+import { useWorkflowRunViewerModel } from '../model/workflowRunViewerModel';
+import {
+  taskStateBadgeType,
+  taskStateLabel,
+} from '@/entities/workflow/lib/taskState';
+
+interface Props {
+  workflowId: string | null;
+  /** 비우면 가장 최근 실행을 연다 */
+  runId?: string | null;
+}
+
+const props = defineProps<Props>();
+
+const {
+  runs,
+  selectedRunId,
+  selectedRun,
+  instances,
+  selectedTaskId,
+  selectedInstance,
+  selectedNode,
+  deletedTaskInstances,
+  graph,
+  isPolling,
+  loadError,
+  open,
+  selectRun,
+  selectTask,
+} = useWorkflowRunViewerModel();
+
+const runOptions = computed(() =>
+  [...runs.value]
+    .sort((a, b) => (b.start_date ?? '').localeCompare(a.start_date ?? ''))
+    .map(run => ({
+      name: run.workflow_run_id,
+      label: `${run.start_date ?? run.execution_date} · ${taskStateLabel(run.state)}`,
+    })),
+);
+
+function formatDuration(seconds?: number): string {
+  if (seconds === undefined || seconds === null) return '-';
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const m = Math.floor(seconds / 60);
+  return `${m}m ${Math.round(seconds - m * 60)}s`;
+}
+
+watch(
+  () => [props.workflowId, props.runId],
+  async () => {
+    if (props.workflowId) await open(props.workflowId, props.runId);
+  },
+  { immediate: true },
+);
+
+async function onRunChange(runId: string) {
+  if (props.workflowId) await selectRun(props.workflowId, runId);
+}
+</script>
+
+<template>
+  <div class="run-viewer">
+    <div class="run-viewer__header">
+      <div class="run-viewer__run-select">
+        <p-select-dropdown
+          :menu="runOptions"
+          :selected.sync="selectedRunId"
+          class="run-viewer__dropdown"
+          @select="onRunChange"
+        />
+        <p-badge
+          v-if="selectedRun"
+          :badge-type="taskStateBadgeType(selectedRun.state)"
+        >
+          {{ taskStateLabel(selectedRun.state) }}
+        </p-badge>
+        <span v-if="isPolling" class="run-viewer__polling">
+          자동 갱신 중 · 3초
+        </span>
+      </div>
+      <div v-if="selectedRun" class="run-viewer__meta">
+        시작 {{ selectedRun.start_date || '-' }} · 종료
+        {{ selectedRun.end_date || '-' }} · 소요
+        {{ formatDuration(selectedRun.duration_date) }}
+      </div>
+    </div>
+
+    <!-- 조회가 실패했는데 정상인 것처럼 보이면 안 된다 -->
+    <div v-if="loadError" class="run-viewer__error">
+      실행 상태를 가져오지 못했습니다: {{ loadError }}
+    </div>
+
+    <div v-if="graph.warnings.length" class="run-viewer__warning">
+      <div v-for="(warning, i) in graph.warnings" :key="i">
+        ⚠ {{ warning }}
+      </div>
+    </div>
+
+    <div class="run-viewer__body">
+      <div class="run-viewer__graph">
+        <div v-if="!graph.nodes.length" class="run-viewer__empty">
+          표시할 태스크가 없습니다.
+        </div>
+        <run-graph
+          v-else
+          :graph="graph"
+          :instances="instances"
+          :selected-task-id="selectedTaskId"
+          @select="selectTask"
+        />
+      </div>
+
+      <aside class="run-viewer__panel">
+        <template v-if="selectedNode">
+          <h4 class="run-viewer__panel-title">{{ selectedNode.name }}</h4>
+          <dl class="run-viewer__dl">
+            <dt>상태</dt>
+            <dd>
+              <p-badge
+                :badge-type="taskStateBadgeType(selectedInstance?.state)"
+              >
+                {{ taskStateLabel(selectedInstance?.state) }}
+              </p-badge>
+            </dd>
+            <dt>컴포넌트</dt>
+            <dd>{{ selectedNode.taskComponent }}</dd>
+            <dt>그룹</dt>
+            <dd>{{ selectedNode.groupName }}</dd>
+            <dt>시도</dt>
+            <dd>{{ selectedInstance?.try_number ?? 0 }}회</dd>
+            <dt>시작</dt>
+            <dd>{{ selectedInstance?.start_date || '-' }}</dd>
+            <dt>종료</dt>
+            <dd>{{ selectedInstance?.end_date || '-' }}</dd>
+            <dt>소요</dt>
+            <dd>{{ formatDuration(selectedInstance?.duration_date) }}</dd>
+          </dl>
+        </template>
+        <p v-else class="run-viewer__hint">
+          태스크를 선택하면 상세가 표시됩니다.
+        </p>
+
+        <!-- 정의에서 지워졌지만 이 실행에는 남아 있는 태스크 -->
+        <div v-if="deletedTaskInstances.length" class="run-viewer__deleted">
+          <h5>삭제된 태스크 ({{ deletedTaskInstances.length }})</h5>
+          <p class="run-viewer__hint">
+            현재 워크플로우 정의에는 없지만 이 실행에는 포함돼 있습니다.
+          </p>
+          <ul>
+            <li v-for="item in deletedTaskInstances" :key="item.task_id">
+              {{ item.task_name }} —
+              <p-badge :badge-type="taskStateBadgeType(item.state)">
+                {{ taskStateLabel(item.state) }}
+              </p-badge>
+            </li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </div>
+</template>
+
+<style lang="postcss" scoped>
+.run-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.run-viewer__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.run-viewer__run-select {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.run-viewer__dropdown {
+  min-width: 20rem;
+}
+
+.run-viewer__polling {
+  font-size: 0.75rem;
+  color: #6b6e78;
+}
+
+.run-viewer__meta {
+  font-size: 0.75rem;
+  color: #6b6e78;
+}
+
+.run-viewer__error {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.25rem;
+  background: #fdf3f3;
+  color: #b93c3c;
+  font-size: 0.8125rem;
+}
+
+.run-viewer__warning {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.25rem;
+  background: #fff8ef;
+  color: #8a5a17;
+  font-size: 0.8125rem;
+}
+
+.run-viewer__body {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.run-viewer__graph {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 1px solid #e5e5e8;
+  border-radius: 0.375rem;
+  background: #fafafb;
+}
+
+.run-viewer__empty {
+  padding: 2rem;
+  text-align: center;
+  color: #6b6e78;
+  font-size: 0.8125rem;
+}
+
+.run-viewer__panel {
+  flex: 0 0 18rem;
+  border: 1px solid #e5e5e8;
+  border-radius: 0.375rem;
+  padding: 0.875rem;
+}
+
+.run-viewer__panel-title {
+  font-size: 0.875rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.run-viewer__dl {
+  display: grid;
+  grid-template-columns: 4.5rem 1fr;
+  row-gap: 0.375rem;
+  font-size: 0.8125rem;
+}
+
+.run-viewer__dl dt {
+  color: #6b6e78;
+}
+
+.run-viewer__hint {
+  font-size: 0.8125rem;
+  color: #6b6e78;
+}
+
+.run-viewer__deleted {
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #e5e5e8;
+  font-size: 0.8125rem;
+}
+
+.run-viewer__deleted h5 {
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+</style>

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -2,6 +2,7 @@
 import { computed, watch } from 'vue';
 import { PBadge, PSelectDropdown } from '@cloudforet-test/mirinae';
 import RunGraph from './RunGraph.vue';
+import { graphPixelWidth } from '@/entities/workflow/lib/runGraph';
 import { useWorkflowRunViewerModel } from '../model/workflowRunViewerModel';
 import {
   taskStateBadgeType,
@@ -42,6 +43,13 @@ const runOptions = computed(() =>
       label: `${run.start_date ?? run.execution_date} · ${taskStateLabel(run.state)}`,
     })),
 );
+
+/*
+  그래프에 내주는 폭을 병렬 갈래 수로 정한다. 인프라·SW 마이그레이션처럼 태스크가
+  한 줄로만 이어지는 워크플로우는 좁게 잡히므로 남는 폭이 상세 패널로 가고, 병렬이
+  많으면 그래프가 넓게 자리를 잡는다. 폭이 모자라면 패널이 아래로 내려간다.
+*/
+const graphFlexBasis = computed(() => `${graphPixelWidth(graph.value)}px`);
 
 /** 값이 JSON 문자열이면 읽기 좋게 펼친다 (cicada는 request_body를 문자열로 담는다) */
 function formatParamValue(value: any): string {
@@ -122,7 +130,7 @@ async function onRunChange(runId: string) {
     </div>
 
     <div class="run-viewer__body">
-      <div class="run-viewer__graph">
+      <div class="run-viewer__graph" :style="{ flexBasis: graphFlexBasis }">
         <div v-if="!graph.nodes.length" class="run-viewer__empty">
           표시할 태스크가 없습니다.
         </div>
@@ -271,8 +279,11 @@ async function onRunChange(runId: string) {
   뷰포트가 아니라 실제 남은 폭에 반응하도록 미디어 쿼리 대신 wrap을 쓴다.
 */
 .run-viewer__graph {
-  flex: 1 1 30rem;
+  /* flex-basis는 병렬 갈래 수에 따라 스크립트에서 정한다 */
+  flex-grow: 1;
+  flex-shrink: 1;
   min-width: 0;
+  max-width: 100%;
   border: 1px solid #e5e5e8;
   border-radius: 0.375rem;
   background: #fafafb;


### PR DESCRIPTION
## 배경

워크플로우를 실행한 뒤 정상 진행 여부를 확인하려면 스케줄러 관리 화면(Airflow UI)을 직접 열어봐야 했다. 콘솔의 실행 이력은 실행 목록과 태스크 목록을 표로만 보여주고, 워크플로우의 *흐름*이 드러나지 않으며 화면이 자동으로 갱신되지도 않는다.

엔진이 상태를 안 줘서가 아니다. 콘솔이 이미 받아온 상태를 표로만 보여줄 뿐이었다.

## 변경

워크플로우 상세에 **Run Status** 탭을 추가한다. 워크플로우를 그래프로 그리고, 선택한 실행에서의 상태를 각 태스크에 칠하며, 실행이 진행되는 동안 자동으로 갱신한다.

### 편집 캔버스를 재사용하지 않은 이유

**그래프를 워크플로우 정의에서 직접 만든다.** 실행 순서는 각 태스크의 선행 관계에서만 나오므로, 같은 선행을 공유하는 태스크는 나란히 놓이고 **병렬 워크플로우가 병렬로 그려진다.**

편집 캔버스는 직선밖에 그리지 못한다. 그것을 재사용했다면 병렬 워크플로우를 직선으로 잘못 그렸을 것이다. 읽기 전용 렌더러는 드래그·삽입 규칙·저장 경로가 없어 훨씬 가볍고, 나중에 편집기가 병렬을 지원할 때 그 토대가 된다.

**신규 의존성 없음** — 레이아웃(위상 정렬 + 계층 배치)과 렌더(SVG)를 직접 구현했다. 그래프가 차지하는 폭은 병렬 갈래 수로 정해지므로, 태스크가 한 줄로 이어지는 워크플로우는 좁게 잡히고 남는 폭이 상세 패널로 간다. 폭이 모자라면 패널이 그래프 아래로 내려간다.

### 구독이 아니라 주기적 조회

엔진에 상태 변경을 알려주는 채널이 없다. 주기는 넉넉히 두고 실행이 끝나면 즉시 멈춘다 — 엔진이 스케줄러 호출을 워크플로우 단위로 직렬화하므로, 잦은 조회는 실행·재실행을 지연시킨다. 화면을 벗어나면 정리한다.

### 감추지 않는다

- 모르는 상태 문자열은 정상 색으로 칠하지 않고 그대로 드러낸다
- 조회가 실패하면 빈 그래프가 아니라 오류로 알린다
- 정의에서 사라진 태스크의 과거 실행분은 버리지 않고 따로 보여준다
- 파라미터는 **현재 정의 기준**임을 명시하고, 실행 이후 워크플로우가 수정됐으면 값이 다를 수 있다고 경고한다 — 엔진이 그 실행에 쓰인 정의를 돌려주지 않기 때문이다

## 테스트

편집기로는 그릴 수조차 없는 구조로 원격 검증 환경에서 확인했다 — 병렬 3갈래 중 하나가 실패하고 다시 합류하는 워크플로우. 그래프 배치·상태 색·자동 갱신·파라미터 표시가 엔진이 보고한 상태와 일치했다. 기존 단일 태스크 워크플로우도 정상 표시된다.

빌드·린트 통과. 백엔드·엔진 변경 없음.