### PR TITLE
chore(api): bump cm-damselfly to 0.5.2 in api.yaml

### DIFF
--- a/api/conf/api.yaml
+++ b/api/conf/api.yaml
@@ -92,7 +92,7 @@ services:
       type: none
 
   cm-damselfly:
-    version: 0.5.1(latest)
+    version: 0.5.2(latest)
     baseurl: http://cm-damselfly:8088/damselfly
     auth: # cm-damselfly checks these only when DAMSELFLY_API_AUTH_ENABLED=true; otherwise they are ignored.
       type: basic
@@ -2875,6 +2875,10 @@ serviceActions:
       method: post
       resourcePath: /cloudmodel
       description: "Create a new cloud user model with the given information."
+    CreateInfraModel:
+      method: post
+      resourcePath: /infra-model
+      description: "Create a new infra migration user model. Use 'modelType' to select on-premise or cloud, and 'isTargetModel' to select source or target model."
     CreateOnPremModel:
       method: post
       resourcePath: /onpremmodel
@@ -2891,6 +2895,10 @@ serviceActions:
       method: delete
       resourcePath: /cloudmodel/{id}
       description: "Delete a cloud user model with the given information."
+    DeleteInfraModel:
+      method: delete
+      resourcePath: /infra-model/{id}
+      description: "Delete a specific infra migration user model by ID. Works for both on-premise and cloud models without requiring the caller to specify the model type."
     DeleteOnPremModel:
       method: delete
       resourcePath: /onpremmodel/{id}
@@ -2911,6 +2919,14 @@ serviceActions:
       method: get
       resourcePath: /cloudmodel
       description: "Get a list of cloud user models."
+    GetInfraModel:
+      method: get
+      resourcePath: /infra-model/{id}
+      description: "Get a specific infra migration user model by ID. Use 'modelType' to specify whether it is an on-premise or cloud model."
+    GetInfraModels:
+      method: get
+      resourcePath: /infra-model
+      description: "Get a list of infra migration user models filtered by model type and source/target classification."
     GetModels:
       method: get
       resourcePath: /model/{isTargetModel}
@@ -2955,6 +2971,10 @@ serviceActions:
       method: put
       resourcePath: /cloudmodel/{id}
       description: "Update a cloud user model with the given information."
+    UpdateInfraModel:
+      method: put
+      resourcePath: /infra-model/{id}
+      description: "Update a specific infra migration user model by ID. Use 'modelType' to specify whether it is an on-premise or cloud model."
     UpdateOnPremModel:
       method: put
       resourcePath: /onpremmodel/{id}


### PR DESCRIPTION
cm-damselfly 0.5.2 라인업 현행화(cm-mayfly)와 짝을 이루는 변경이다. cm-butterfly는 서브프레임워크 호출 스펙을 `api/conf/api.yaml`로 자체 보유하고 `POST /api/{operationId}` 프록시가 이 파일을 읽으므로, 여기까지 갱신해야 콘솔에서 신규 API를 호출할 수 있다.

## 변경 내용

`api/conf/api.yaml` 의 cm-damselfly 항목만 변경한다.

- `version: 0.5.1(latest)` → `0.5.2(latest)`
- serviceActions 24개 → 29개 — infra-model CRUD 5종(`CreateInfraModel`·`GetInfraModel`·`GetInfraModels`·`UpdateInfraModel`·`DeleteInfraModel`) 추가, 사라진 API 없음

serviceActions는 손으로 편집하지 않고 cm-mayfly의 `api tool`로 cm-damselfly v0.5.2 swagger에서 생성했다. 다른 서비스·인증 설정은 변경하지 않았다.

## 검증

원격 dev 서버에서 cm-damselfly 0.5.2 라인업을 기동하고, 갱신한 api.yaml을 cm-butterfly-api에 반영한 상태로 확인했다.

- 신규 operationId — `POST /api/getinframodels` → **200**. 갱신 전에는 같은 호출이 404 `getApiSpec not found` 였다
- 기존 operationId 회귀 — `POST /api/getcloudmodels` → 200 (실제 모델 목록 반환)
- 대조군 — 스펙에 없는 operationId → 404
- cm-butterfly-api 컨테이너 healthy, 스펙 로드 정상(파싱 오류 없음)
- 라인업 22종 전부 healthy

---

- [BAR-1466](https://mzdevs.atlassian.net/browse/BAR-1466) [feat][cm-butterfly] cm-damselfly 0.5.2 스펙 api.yaml 반영 (serviceActions 24 → 29)
- [BAR-1465](https://mzdevs.atlassian.net/browse/BAR-1465) [feat][cm-mayfly] cm-damselfly 0.5.2 라인업 현행화 (짝 PR: MZC-CSC/cm-mayfly#58)