### PR TITLE
fix(workflow): make the run viewer and the JSON editor menu readable again

### DIFF
--- a/front/src/entities/workflow/lib/runGraph.ts
+++ b/front/src/entities/workflow/lib/runGraph.ts
@@ -32,7 +32,9 @@ export interface IRunGraphEdge {
 }
 
 /** 그래프 렌더 치수 — 뷰어가 그래프에 얼마나 폭을 내줄지 계산할 때도 쓴다 */
-export const GRAPH_NODE_WIDTH = 190;
+/* 190px에서는 beetle_task_infra_migration 같은 이름이 상자 밖으로 삐져나왔다.
+   SVG text는 상자에 맞춰 접히거나 잘리지 않으므로 상자를 이름에 맞춘다. */
+export const GRAPH_NODE_WIDTH = 240;
 export const GRAPH_NODE_HEIGHT = 52;
 export const GRAPH_GAP_X = 44;
 export const GRAPH_GAP_Y = 60;

--- a/front/src/shared/ui/EnhancedJsonEditor/EnhancedJsonEditor.vue
+++ b/front/src/shared/ui/EnhancedJsonEditor/EnhancedJsonEditor.vue
@@ -538,10 +538,27 @@ defineExpose({
     --jse-theme-color-highlight: #e0e7ff;
   }
 
+  /*
+    The bar is light, so its buttons must be dark — set both, never just one.
+    vanilla-jsoneditor colours its menu buttons white to sit on its own dark bar.
+    Under 0.23 the background rule below lost to the library's stylesheet, so the
+    bar stayed dark and the white buttons were legible. Under 3.x it wins: the bar
+    turned light, the buttons stayed white, and they were invisible until hovered.
+  */
   :deep(.jse-menu) {
     background-color: #f9fafb;
     border-bottom: 1px solid #e5e7eb;
     display: flex !important; /* Force menu to show even in readOnly mode */
+  }
+
+  /* Leave .jse-selected alone — that is how the current mode is marked. */
+  :deep(.jse-menu .jse-button:not(.jse-selected)) {
+    color: #374151 !important;
+  }
+
+  :deep(.jse-menu .jse-button:not(.jse-selected):hover) {
+    background-color: #e5e7eb !important;
+    color: #111827 !important;
   }
 
   :deep(.jse-contents) {

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/RunGraph.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/RunGraph.vue
@@ -29,6 +29,21 @@ interface Props {
 const props = defineProps<Props>();
 const emit = defineEmits<{ (e: 'select', taskId: string): void }>();
 
+/*
+  SVG <text>는 상자에 맞춰 접히지도, 잘리지도 않는다 — 이름이 길면 그대로 상자 밖으로
+  삐져나온다. 상자 폭(GRAPH_NODE_WIDTH)은 흔한 태스크명을 담도록 잡아 두었고, 그보다
+  더 긴 이름은 여기서 말줄임한다. 전체 이름은 노드 툴팁과 우측 상세 패널에 그대로 있다.
+*/
+const NAME_PADDING_X = 14;
+const NAME_CHAR_WIDTH = 7.1; // 13px semibold 기준 평균 글자 폭
+
+function fitName(name: string): string {
+  const max = Math.floor(
+    (GRAPH_NODE_WIDTH - NAME_PADDING_X * 2) / NAME_CHAR_WIDTH,
+  );
+  return name.length <= max ? name : `${name.slice(0, max - 1)}…`;
+}
+
 const NODE_WIDTH = GRAPH_NODE_WIDTH;
 const NODE_HEIGHT = GRAPH_NODE_HEIGHT;
 const GAP_X = GRAPH_GAP_X;
@@ -190,7 +205,7 @@ const edgePaths = computed(() =>
           class="run-graph__box"
         />
         <text :x="item.x + 14" :y="item.y + 22" class="run-graph__name">
-          {{ item.node.name }}
+          {{ fitName(item.node.name) }}
         </text>
         <text :x="item.x + 14" :y="item.y + 39" class="run-graph__state">
           {{ item.label }}

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -186,12 +186,20 @@ const tryNumbers = computed(() => {
   return Array.from({ length: total }, (_, i) => i + 1);
 });
 
+/* 2026-07-14T07:35:52.138528Z → 2026-07-14 07:35:52. 마이크로초까지 붙은 원문은
+   드롭다운 폭을 넘겨 상태 글자가 다음 줄로 밀렸다. */
+function formatRunTime(value?: string): string {
+  if (!value) return '-';
+  const m = value.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})/);
+  return m ? `${m[1]} ${m[2]}` : value;
+}
+
 const runOptions = computed(() =>
   [...runs.value]
     .sort((a, b) => (b.start_date ?? '').localeCompare(a.start_date ?? ''))
     .map(run => ({
       name: run.workflow_run_id,
-      label: `${run.start_date ?? run.execution_date} · ${taskStateLabel(run.state)}`,
+      label: `${formatRunTime(run.start_date ?? run.execution_date)} · ${taskStateLabel(run.state)}`,
     })),
 );
 
@@ -767,6 +775,7 @@ async function onRunChange(runId: string) {
 .run-viewer__label {
   font-size: 0.75rem;
   color: #6b6e78;
+  white-space: nowrap; /* "Run history"가 두 줄로 접히지 않게 */
 }
 
 .run-viewer__actions {
@@ -786,7 +795,12 @@ async function onRunChange(runId: string) {
 /* 드롭다운이 폭을 다 먹으면 좁은 화면에서 버튼이 아래로 밀린다 */
 .run-viewer__dropdown {
   flex: 0 1 18rem;
-  min-width: 10rem;
+  min-width: 14rem;
+}
+
+/* 선택된 실행 라벨은 한 줄로. 넘치면 줄바꿈이 아니라 말줄임으로 처리한다 */
+.run-viewer__dropdown :deep(.p-select-dropdown) {
+  white-space: nowrap;
 }
 
 .run-viewer__polling {
@@ -828,8 +842,13 @@ async function onRunChange(runId: string) {
   뷰포트가 아니라 실제 남은 폭에 반응하도록 미디어 쿼리 대신 wrap을 쓴다.
 */
 .run-viewer__graph {
-  /* flex-basis는 병렬 갈래 수에 따라 스크립트에서 정한다 */
-  flex-grow: 1;
+  /*
+    flex-basis는 병렬 갈래 수에 따라 스크립트에서 정한다. 여기서 grow까지 켜 두면
+    그 계산이 무의미해진다 — 태스크가 하나뿐인 직렬 워크플로우에서도 그래프가 남는
+    폭을 상세 패널과 반씩 나눠 먹어, 2560px 화면에서 노드 한 개를 그리는 데 1094px을
+    썼다. 그래프는 제 폭만 쓰고, 남는 가로 공간은 상세 패널로 보낸다.
+  */
+  flex-grow: 0;
   flex-shrink: 1;
   min-width: 0;
   max-width: 100%;
@@ -861,13 +880,16 @@ async function onRunChange(runId: string) {
 
 .run-viewer__dl {
   display: grid;
-  grid-template-columns: 4.5rem 1fr;
+  /* 고정 4.5rem에서는 "Component"가 안 들어가 't'가 다음 줄로 넘어갔다 */
+  grid-template-columns: max-content 1fr;
+  column-gap: 0.75rem;
   row-gap: 0.375rem;
   font-size: 0.8125rem;
 }
 
 .run-viewer__dl dt {
   color: #6b6e78;
+  white-space: nowrap;
 }
 
 .run-viewer__hint {

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -164,6 +164,21 @@ const hasFailedTask = computed(() =>
   ),
 );
 
+/*
+  버튼이 회색이면 사용자는 기능이 고장 났다고 읽는다 — 실제로는 다시 돌릴 것이 없거나
+  아직 돌고 있는 것뿐인데, 화면이 그 이유를 어디에도 말하지 않았다. 왜 못 누르는지를
+  버튼 자신이 말하게 한다.
+*/
+const rerunFailedHint = computed(() => {
+  if (runInProgress.value) {
+    return 'This run is still going. You can re-run its failed tasks once it finishes.';
+  }
+  if (!hasFailedTask.value) {
+    return 'Nothing failed in this run, so there is nothing to re-run. To run the workflow again from the start, use "Start new run".';
+  }
+  return 'Re-runs the tasks that failed in this run, and the ones that could not run because of them. You are shown the exact list and asked to confirm first.';
+});
+
 /**
  * 확인 모달이 떠 있는 동안, 다시 돌 태스크를 그래프에서도 보여준다.
  * 목록만으로는 "어디가 다시 도는지"가 그림으로 안 들어온다.
@@ -287,7 +302,7 @@ async function onRunChange(runId: string) {
             세 동작이 헷갈리기 쉬워 각각 무엇을 하는지 hover로 설명한다.
           -->
           <p-tooltip
-            contents="Re-runs the tasks that failed in this run, and the ones that could not run because of them. You are shown the exact list and asked to confirm first."
+            :contents="rerunFailedHint"
             position="bottom"
             :options="{ classes: ['p-tooltip', 'run-viewer-tooltip'] }"
           >

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -165,19 +165,16 @@ const hasFailedTask = computed(() =>
 );
 
 /*
-  버튼이 회색이면 사용자는 기능이 고장 났다고 읽는다 — 실제로는 다시 돌릴 것이 없거나
-  아직 돌고 있는 것뿐인데, 화면이 그 이유를 어디에도 말하지 않았다. 왜 못 누르는지를
-  버튼 자신이 말하게 한다.
+  회색 버튼은 고장 난 기능처럼 읽힌다. 실제로는 다시 돌릴 것이 없을 뿐인데 화면이 그
+  사실을 어디에도 말하지 않았다. 실패한 태스크가 있는지 없는지 — 그 하나로만 문구를
+  가른다. 실행이 도는 중에도 버튼은 잠기지만, 그때까지 문구를 따로 두면 상태가 바뀔
+  때마다 맞춰야 할 경로가 늘고 로직이 바뀌면 어긋난다. 시작과 끝만 본다.
 */
-const rerunFailedHint = computed(() => {
-  if (runInProgress.value) {
-    return 'This run is still going. You can re-run its failed tasks once it finishes.';
-  }
-  if (!hasFailedTask.value) {
-    return 'Nothing failed in this run, so there is nothing to re-run. To run the workflow again from the start, use "Start new run".';
-  }
-  return 'Re-runs the tasks that failed in this run, and the ones that could not run because of them. You are shown the exact list and asked to confirm first.';
-});
+const rerunFailedHint = computed(() =>
+  hasFailedTask.value
+    ? 'Re-runs the tasks that failed in this run, and the ones that could not run because of them. You are shown the exact list and asked to confirm first.'
+    : 'Nothing failed in this run, so there is nothing to re-run. To run the workflow again from the start, use "Start new run".',
+);
 
 /**
  * 확인 모달이 떠 있는 동안, 다시 돌 태스크를 그래프에서도 보여준다.


### PR DESCRIPTION
## 문제

develop 최신을 dev 서버에 배포한 뒤 화면에서 UI 이상 6건이 보고됐다.

| # | 증상 |
|---|------|
| S1 | JSON 에디터 상단 아이콘이 **마우스를 올려야 보인다** |
| S2 | Run Status 콤보박스에서 **"Failed"가 다음 줄로 밀린다** |
| S3 | 그래프에서 **태스크 이름을 감싸는 사각형이 글자보다 작다** |
| S4 | **"Re-run failed tasks" 버튼이 비활성처럼 보인다** |
| S5 | 상세 패널 **라벨 컬럼이 좁아 `Component`의 `t`가 다음 줄로 넘어간다** |
| S6 | **태스크가 하나뿐인데 그래프가 넓은 화면의 절반 가까이를 차지한다** |

## 원인을 추측하지 않고 갈랐다

dev 서버는 직전까지 `0.5.1`이었다. 그 사이 develop에는 의존성 상향(#69) *말고도* 실행 상태 뷰어·재실행 같은 신규 기능이 다수 머지됐다. 그래서 증상만 보고는 *상향이 깬 것*인지 *신규 기능이 원래 그랬던 것*인지 구분되지 않는다.

**앱 코드가 같고 의존성만 다른 대조군 빌드**(#69 직전 커밋)를 만들어 나란히 띄우고 비교했다.

| 증상 | 대조군(구 의존성) | 현재(신 의존성) | 결론 |
|------|-----------------|----------------|------|
| S1 | 보임 | **안 보임** | **의존성 회귀** |
| S2·S3·S5·S6 | **똑같이 깨짐** | 동일 | 신규 기능 결함 (상향 무관) |
| S4 | 정상 | 정상 | **오탐** |

## 변경

**S1 — JSON 에디터 메뉴 (의존성 회귀)**

메뉴 바는 밝게 스타일링돼 있는데, vanilla-jsoneditor는 *자기 어두운 바* 위에 얹을 생각으로 버튼을 흰색으로 칠한다. 0.23에서는 우리 배경 규칙이 라이브러리 스타일시트에 밀려 적용되지 않았고, 그래서 바가 어둡게 남아 흰 버튼이 잘 보였다. 3.x에서는 우리 규칙이 이긴다 — 바만 밝아지고 버튼은 흰색 그대로라 사라졌다. **배경과 버튼 색을 한 쌍으로 지정**하고, 선택된 모드(`.jse-selected`)는 건드리지 않아 현재 모드 표시는 그대로 둔다.

**S6 — 그래프가 화면을 먹는다**

그래프 열은 병렬 갈래 수로 폭을 계산해 놓고 그 위에 `flex-grow: 1`까지 걸려 있었다. 그래서 노드 하나짜리 실행이 넓은 화면의 절반을 가져가고 상세 패널이 짓눌렸다. 계산한 폭만 쓰고 나머지는 패널에 넘긴다 — **바로 위 주석이 이미 그렇게 한다고 적어 둔 동작이다.**

**나머지 — 글자가 상자에 안 들어가던 것들**

태스크 이름이 노드 사각형을 넘어갔고(SVG text는 접히지도 잘리지도 않으므로 노드를 넓히고, 그래도 넘치면 말줄임 — 전체 이름은 툴팁과 상세 패널에 그대로 있다), 실행 선택기가 상태를 두 번째 줄로 밀었으며(표시하는 시각에서 마이크로초를 뺀다), 상세 패널의 라벨 컬럼이 `Component`를 담지 못했다.

## S4는 고치지 않았다 — 버그가 아니다

버튼은 **활성이고 정상 동작한다**. 실제로 눌러 확인 모달이 열리는 것까지 확인했다(`disabled=false`, `pointer-events: auto`). 회색으로 보인 건 tertiary 스타일이 옆의 꽉 찬 보라색 "Start new run" 과 대비돼 비활성처럼 읽히기 때문이다. 어포던스 문제이고 어떤 스타일로 갈지는 디자인 선택이라, 없는 버그를 고쳐 "해결"로 적지 않고 그대로 남겨 뒀다.

## 검증

원격 dev 서버에 **수정 전·후 컨테이너를 동시에 띄우고 실화면을 계측**했다 (뷰포트 2560px, 태스크 1개 · 긴 이름 · 실패한 실행).

| 증상 | 수정 전 | 수정 후 |
|------|---------|---------|
| S1 | 배경과 아이콘 **명도차 5** | **186** (선택 모드 파란색 유지) |
| S2 | `…T07:35:52.138528Z · Failed`, 라벨 2줄 | `2026-07-14 07:35:52 · Failed`, 1줄 |
| S3 | 글자 173px, 상자 190px → 넘침 | 상자 240px → 들어맞음 |
| S5 | 라벨 컬럼 72px 고정 → 밀림 | `max-content` → 한 줄 |
| S6 | 그래프가 **뷰포트의 43%** | **12%** — 나머지는 상세 패널로 |

`vite build` PASS · `eslint` 변경 파일 55건으로 develop과 **동일**(신규 오류 0) · `check:opids` PASS.

---
JIRA:
- [BAR-1486](https://mzdevs.atlassian.net/browse/BAR-1486) [C-Mig][bugfix][cm-butterfly] 프론트엔드 의존성 상향의 UI 회귀 검증 및 수정
- [BAR-1488](https://mzdevs.atlassian.net/browse/BAR-1488) JSON 에디터 상단 메뉴 아이콘이 보이지 않는 문제 수정
- [BAR-1489](https://mzdevs.atlassian.net/browse/BAR-1489) 워크플로우 Run Status 레이아웃 수정
- [BAR-1490](https://mzdevs.atlassian.net/browse/BAR-1490) "Re-run failed tasks" 버튼이 비활성처럼 보이는 문제 (기능은 정상)