### PR TITLE
fix(source): keep view Infra/Software slot non-empty to prevent raw isShow dump

### DIFF
--- a/front/src/widgets/source/sourceServices/sourceServiceDetail/ui/SourceServiceDetail.vue
+++ b/front/src/widgets/source/sourceServices/sourceServiceDetail/ui/SourceServiceDetail.vue
@@ -186,6 +186,8 @@ function handleSoftwareModal() {
         >
           View Infra(Meta) -&gt;
         </p>
+        <!-- keep the slot non-empty so PDefinitionTable does not fall back to dumping the raw cell object -->
+        <span v-else />
       </template>
 
       <template #data-viewSoftware="{ data }">
@@ -197,6 +199,8 @@ function handleSoftwareModal() {
         >
           View Software(Meta) -&gt;
         </p>
+        <!-- keep the slot non-empty so PDefinitionTable does not fall back to dumping the raw cell object -->
+        <span v-else />
       </template>
 
       <template #extra="{ name }">

--- a/front/src/widgets/source/sourceServices/sourceServiceDetail/ui/SourceServiceDetail.vue
+++ b/front/src/widgets/source/sourceServices/sourceServiceDetail/ui/SourceServiceDetail.vue
@@ -72,7 +72,9 @@ watch(
 );
 
 watchEffect(() => {
-  const serviceName = sourceServiceStore.getServiceById(props.selectedServiceId)?.name;
+  const serviceName = sourceServiceStore.getServiceById(
+    props.selectedServiceId,
+  )?.name;
   if (serviceName) {
     emit('update:source-connection-name', serviceName);
   }
@@ -93,7 +95,7 @@ function getSourceGroupInfras() {
         );
         infraModel.value = res.data.responseData;
         loadSourceServiceData(props.selectedServiceId);
-        
+
         // 데이터를 가져온 후 자동으로 모달 열기
         modalState.open = true;
       }
@@ -119,7 +121,7 @@ function getSourceGroupSoftware() {
         );
         softwareModel.value = res.data.responseData;
         loadSourceServiceData(props.selectedServiceId);
-        
+
         // 데이터를 가져온 후 자동으로 모달 열기
         softwareModalState.open = true;
       }


### PR DESCRIPTION
## 무엇을 고쳤나

Source Computing > Source Services에서 커넥션을 선택하면 하단 Detail의 `view Infra`·`view Software` 칸에 회색 `isShow:false` 태그가 찍히던 문제를 고칩니다. 아직 infra/software를 수집하지 않은 커넥션이면 그 칸은 비어 있어야 합니다.

## 원인

이 셀의 값은 객체 `viewInfra: { isShow: !!infraModel }` 입니다. 커스텀 슬롯을 `v-if`로 통째로 감싸면 `isShow`가 false일 때 슬롯에 빈 코멘트만 남고, Vue 2는 이를 빈 슬롯으로 봅니다. 그러면 `PDefinitionTable`이 자기 기본 폴백을 렌더하는데, 그 폴백은 셀 값이 객체이면 `Object.entries`를 태그로 찍습니다. 그래서 `{isShow:false}`가 화면에 그대로 노출됐습니다.

이전에는 `{{ data.isShow ? 'View Infra(Meta) ->' : null }}` 형태라 `<p>` 엘리먼트가 항상 렌더돼(내용만 비움) 폴백이 트리거되지 않았습니다.

## 어떻게 고쳤나

`v-else`로 빈 `<span>`을 두어 슬롯이 항상 엘리먼트를 렌더하게 했습니다. `data-testid`와 링크 동작은 그대로입니다. `view Infra`·`view Software` 두 곳에 동일 적용했습니다.

커밋은 둘로 나눴습니다.

- `style(source)` — 이 파일에 남아 있던 기존 포맷 위반 정정(동작 변경 없음). 로컬 포맷 게이트가 파일 전체를 검사해 먼저 정리해야 했습니다.
- `fix(source)` — 실제 수정(슬롯 2곳에 `v-else` 빈 노드 추가).

## 검증

- 로컬: 변경 파일 eslint — 변경 구간 무경고
- 개발 서버(포트 5174)에 이 브랜치 이미지를 올려 확인 — 수집 전 커넥션 선택 시 회색 `isShow:false` 태그 미노출. **PASS**

## 알려진 사항

자동화 e2e로는 검증하지 못했습니다. 현재 `develop`에서 `bddgen`이 `front/tests/e2e/steps/models.steps.ts:103`의 첫 인자가 구조분해 패턴이 아니라 실패해 e2e 생성 자체가 안 됩니다. 본 PR과 별개 건이라 여기서 함께 고치지 않고 별도로 처리합니다.

---

- [BAR-1512](https://mzdevs.atlassian.net/browse/BAR-1512) Source Services 상세 view Infra/Software의 isShow:false 원시 태그 노출 회귀 수정