### PR TITLE
Show task results in the run viewer and gate its buttons by run history

### DIFF
--- a/front/src/features/workflow/workflowEditor/ui/WorkflowEditor.vue
+++ b/front/src/features/workflow/workflowEditor/ui/WorkflowEditor.vue
@@ -762,9 +762,21 @@ function injectTargetModelIntoSequence() {
   const migrationComponent = isInfra
     ? 'beetle_task_infra_migration'
     : 'grasshopper_task_software_migration';
+  /*
+    두 마이그레이션의 본문 형태가 다르다 — 같은 모양으로 넣으면 안 된다.
+     - 인프라(beetle): cloudInfraModel 의 *내용*(targetInfra/targetVNet 등)이 곧 본문이다.
+     - 소프트웨어(grasshopper): 본문을 `targetSoftwareModel` 로 한 겹 *감싼* 형태로 받는다
+       (smdl `TargetSoftwareModel{ TargetSoftwareModel ... json:"targetSoftwareModel" }`).
+    안쪽 객체({servers:[...]})만 넣으면 grasshopper 가 servers 를 빈 값으로 바인딩해
+    아무 소프트웨어도 처리하지 않은 채 200 + execution_id 를 돌려준다. 그러면 태스크는
+    성공으로 보이는데 결과(target_mappings)는 비어 원인을 찾기 어렵다.
+  */
+  const softwareModel = (tm as any).targetSoftwareModel;
   const literalBody = isInfra
     ? tm.cloudInfraModel
-    : (tm as any).targetSoftwareModel;
+    : softwareModel
+      ? { targetSoftwareModel: softwareModel }
+      : undefined;
 
   const visit = (steps: any[] | undefined) => {
     for (const step of steps ?? []) {

--- a/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
+++ b/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
@@ -9,7 +9,11 @@ import {
   WorkflowRunViewer,
 } from '@/widgets/workflow';
 import { SimpleEditForm } from '@/widgets/layout';
-import { useGetWorkflow, useUpdateWorkflow } from '@/entities';
+import {
+  useGetWorkflow,
+  useUpdateWorkflow,
+  useWorkflowStore,
+} from '@/entities';
 import {
   showErrorMessage,
   showSuccessMessage,
@@ -19,6 +23,7 @@ import WorkflowEditor from '@/features/workflow/workflowEditor/ui/WorkflowEditor
 
 const getWorkflow = useGetWorkflow(null);
 const updateWorkflow = useUpdateWorkflow(null, null);
+const workflowStore = useWorkflowStore();
 
 const pageName = 'Workflows';
 
@@ -35,6 +40,27 @@ function handleEditClone(clonedWorkflowId: string) {
   // 방금 연 편집기가 닫힌다.
   selectedWorkflowId.value = clonedWorkflowId;
   modalState.workflowToolModal.open = true;
+}
+
+/**
+ * 미실행 원본을 그래픽 에디터로 (복제 없이). 실행 이력이 없어 원본을 직접 고쳐도 된다.
+ */
+function handleEditOriginal(workflowId: string) {
+  selectedWorkflowId.value = workflowId;
+  modalState.workflowToolModal.open = true;
+}
+
+/**
+ * 병렬이라 그래픽 에디터가 못 다루는 워크플로우를 JSON 에디터로 연다.
+ * 원본(미실행 Edit) 또는 복제본(실행됨 Clone&Edit) — 어느 쪽이든 id로 스토어에서
+ * 정의를 꺼내 JSON 에디터에 넘긴다. (복제본은 뷰어가 이미 스토어에 넣었다.)
+ */
+function handleEditJson(workflowId: string) {
+  selectedWorkflowId.value = workflowId;
+  const wf = workflowStore.getWorkflowById(workflowId);
+  workflowName.value = wf?.name ?? '';
+  workflowJson.value = wf?.data ?? {};
+  modalState.workflowJsonModal.open = true;
 }
 
 const selectedWorkflowId = ref<string>('');
@@ -228,6 +254,8 @@ async function handleUpdateWorkflow(updatedData: object) {
             <workflow-run-viewer
               :workflow-id="selectedWorkflowId"
               @edit-clone="handleEditClone"
+              @edit-original="handleEditOriginal"
+              @edit-json="handleEditJson"
             />
           </template>
         </p-tab>

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
@@ -90,6 +90,21 @@ export function useWorkflowRunViewerModel() {
 
   const graph = computed<IRunGraph>(() => buildRunGraph(workflow.value));
 
+  /**
+   * 이 워크플로우가 한 번이라도 실행됐는가. 뷰어의 버튼 구성이 여기서 갈린다 —
+   * 실행된 적 없으면 Run·Edit만, 있으면 Start new run·Clone&Edit·Re-run failed.
+   * `Start new run`은 매 실행마다 새 이력을 쌓는 동작이라 쌓을 이력이 있어야 의미가 있고,
+   * 실행된 워크플로우는 원본 직접 수정을 막으므로(엔진이 실행별 정의를 남기지 않는다) Edit도 없다.
+   */
+  const hasRuns = computed(() => runs.value.length > 0);
+
+  /**
+   * 병렬 갈래가 있는가. 그래픽 에디터는 아직 병렬을 다루지 못하므로, Edit·Clone&Edit가
+   * 이 워크플로우를 그래픽으로 열지 JSON으로 열지를 여기서 가른다.
+   * 워크플로우 툴이 병렬 편집을 지원하면(BAR-1454) 이 판정과 폴백을 함께 걷어낸다.
+   */
+  const isParallel = computed(() => graph.value.maxParallel > 1);
+
   const selectedRun = computed(
     () =>
       runs.value.find(r => r.workflow_run_id === selectedRunId.value) ?? null,
@@ -403,6 +418,8 @@ export function useWorkflowRunViewerModel() {
     deletedTaskInstances,
     definitionChangedAfterRun,
     graph,
+    hasRuns,
+    isParallel,
     isPolling,
     cloning,
     loadError,

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -262,7 +262,12 @@ const runOptions = computed(() =>
   한 줄로만 이어지는 워크플로우는 좁게 잡히므로 남는 폭이 상세 패널로 가고, 병렬이
   많으면 그래프가 넓게 자리를 잡는다. 폭이 모자라면 패널이 아래로 내려간다.
 */
-const graphFlexBasis = computed(() => `${graphPixelWidth(graph.value)}px`);
+const graphFlexBasis = computed(
+  // graphPixelWidth는 SVG 자체 폭이다. 그래프 박스는 그 위에 RunGraph의 안쪽 여백
+  // (0.5rem 좌우)과 박스 테두리(1px 좌우)를 더 차지하므로, 그만큼을 flex-basis에
+  // 얹지 않으면 넉넉한 화면에서도 SVG가 상시 잘려 가로 스크롤이 생긴다.
+  () => `calc(${graphPixelWidth(graph.value)}px + 1rem + 2px)`,
+);
 
 /** 값이 JSON 문자열이면 읽기 좋게 펼친다 (cicada는 request_body를 문자열로 담는다) */
 function formatParamValue(value: any): string {
@@ -926,6 +931,8 @@ async function onRunChange(runId: string) {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  /* 다른 탭 내용과 같은 좌우 여백 — 없으면 Run history·그래프가 왼쪽에 바싹 붙는다 */
+  padding: 0 1rem 1rem;
 }
 
 .run-viewer__header {

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -7,6 +7,7 @@ import {
   PTooltip,
 } from '@cloudforet-test/mirinae';
 import RunGraph from './RunGraph.vue';
+import SoftwareMigrationOverlay from '../../workflowHistory/ui/SoftwareMigrationOverlay.vue';
 import { graphPixelWidth } from '@/entities/workflow/lib/runGraph';
 import { useWorkflowRunViewerModel } from '../model/workflowRunViewerModel';
 import {
@@ -22,9 +23,14 @@ interface Props {
 
 const props = defineProps<Props>();
 
-// 복제본으로 에디터를 여는 것은 페이지의 일이다 (에디터 모달이 거기 있다)
+// 에디터(그래픽/JSON)를 여는 것은 페이지의 일이다 (에디터 모달이 거기 있다).
+// - edit-original: 미실행 원본을 그래픽 에디터로
+// - edit-clone   : 실행됨 복제본을 그래픽 에디터로 (기존)
+// - edit-json    : 병렬이라 그래픽이 못 다루는 것을 JSON 에디터로 (원본 또는 복제본 id)
 const emit = defineEmits<{
+  (e: 'edit-original', workflowId: string): void;
   (e: 'edit-clone', clonedWorkflowId: string): void;
+  (e: 'edit-json', workflowId: string): void;
 }>();
 
 const {
@@ -38,6 +44,8 @@ const {
   deletedTaskInstances,
   definitionChangedAfterRun,
   graph,
+  hasRuns,
+  isParallel,
   progress,
   isPolling,
   cloning,
@@ -64,11 +72,45 @@ const {
 /**
  * 값을 바꿔 다시 돌리고 싶을 때 원본을 고치지 않는다.
  * 복제본을 만들어 그것을 편집한다 — 원본과 그 실행 이력은 그대로 남는다.
+ *
+ * 병렬 워크플로우는 그래픽 에디터가 아직 다루지 못하므로 복제본을 JSON 에디터로 연다.
+ * (워크플로우 툴이 병렬을 지원하면 이 분기를 걷어내고 항상 그래픽으로 — BAR-1454)
  */
 async function cloneAndEdit() {
   const clonedId = await cloneForEdit();
-  if (clonedId) emit('edit-clone', clonedId);
+  if (!clonedId) return;
+  if (isParallel.value) emit('edit-json', clonedId);
+  else emit('edit-clone', clonedId);
 }
+
+/**
+ * 미실행 원본 편집. 실행 이력이 없으니 복제 없이 원본을 직접 연다.
+ * 병렬이면 그래픽 에디터가 못 다루므로 확인 후 JSON 에디터로 유도한다.
+ */
+const showEditJsonConfirm = ref(false);
+function requestEdit() {
+  if (isParallel.value) {
+    showEditJsonConfirm.value = true;
+    return;
+  }
+  if (props.workflowId) emit('edit-original', props.workflowId);
+}
+function confirmEditJson() {
+  showEditJsonConfirm.value = false;
+  if (props.workflowId) emit('edit-json', props.workflowId);
+}
+
+/**
+ * 태스크가 만든 결과. 오늘은 SW 마이그레이션만 — 엔진이 태스크에 실어 준 실행 ID가
+ * 있을 때만 조회한다. 컴포넌트 이름이 아니라 그 ID의 유무로 판정하므로, 엔진이 다른
+ * 컴포넌트의 반환값을 실어 주기 시작하면 같은 자리에 붙는다.
+ */
+const showSwResult = ref(false);
+const swExecutionIds = computed(() =>
+  selectedInstance.value?.software_migration_execution_id
+    ? [selectedInstance.value.software_migration_execution_id]
+    : [],
+);
 
 /**
  * 재실행 범위. 기준이 무엇인지 이름에 담는다.
@@ -294,57 +336,96 @@ async function onRunChange(runId: string) {
 
         <div class="run-viewer__actions">
           <!--
-            순서: 이 실행의 실패분을 다시 → 이 워크플로우를 새로 → 값을 바꿔 쓰려면 복제.
-            왼쪽일수록 지금 보고 있는 실행에 가깝고, 오른쪽으로 갈수록 새 것을 만든다.
-            세 동작이 헷갈리기 쉬워 각각 무엇을 하는지 hover로 설명한다.
+            실행 이력이 없는 워크플로우에는 "다시 돌린다"가 없다 — 실행할지, 내용을
+            고칠지 둘뿐이다. 이력이 있으면 지금까지의 버튼(실패분 다시 → 새로 → 복제)을
+            그대로 둔다. 실행된 워크플로우는 원본 직접 수정을 막으므로 여기엔 Edit이 없다.
           -->
-          <p-tooltip
-            :contents="rerunFailedHint"
-            position="bottom"
-            :options="{ classes: ['p-tooltip', 'run-viewer-tooltip'] }"
-          >
-            <p-button
-              data-testid="workflow-rerun-failed-btn"
-              size="sm"
-              style-type="tertiary"
-              :disabled="!hasFailedTask || rerunPending || runInProgress"
-              @click="requestRerunFailed"
+          <template v-if="!hasRuns">
+            <p-tooltip
+              contents="Runs this workflow for the first time."
+              position="bottom"
+              :options="{ classes: ['p-tooltip', 'run-viewer-tooltip'] }"
             >
-              Re-run failed tasks
-            </p-button>
-          </p-tooltip>
+              <p-button
+                data-testid="workflow-viewer-run-first-btn"
+                size="sm"
+                style-type="primary"
+                :disabled="runInProgress"
+                @click="showRunConfirm = true"
+              >
+                Run
+              </p-button>
+            </p-tooltip>
 
-          <p-tooltip
-            contents="Starts a new run of the whole workflow from the first task. This does not re-run the run selected above."
-            position="bottom"
-            :options="{ classes: ['p-tooltip', 'run-viewer-tooltip'] }"
-          >
-            <p-button
-              data-testid="workflow-viewer-run-btn"
-              size="sm"
-              style-type="primary"
-              :disabled="runInProgress"
-              @click="showRunConfirm = true"
+            <p-tooltip
+              contents="Opens this workflow in the editor to change its content. Available before the first run — once a workflow has run, edit a copy instead."
+              position="bottom"
+              :options="{ classes: ['p-tooltip', 'run-viewer-tooltip'] }"
             >
-              Start new run
-            </p-button>
-          </p-tooltip>
+              <p-button
+                data-testid="workflow-viewer-edit-btn"
+                size="sm"
+                style-type="tertiary"
+                @click="requestEdit"
+              >
+                Edit
+              </p-button>
+            </p-tooltip>
+          </template>
 
-          <p-tooltip
-            contents="Copies this workflow and opens the copy in the editor, so you can change values without touching the original or its run history."
-            position="bottom"
-            :options="{ classes: ['p-tooltip', 'run-viewer-tooltip'] }"
-          >
-            <p-button
-              data-testid="workflow-clone-edit-btn"
-              size="sm"
-              style-type="tertiary"
-              :disabled="cloning"
-              @click="showCloneConfirm = true"
+          <template v-else>
+            <!--
+              순서: 이 실행의 실패분을 다시 → 이 워크플로우를 새로 → 값을 바꿔 쓰려면 복제.
+              왼쪽일수록 지금 보고 있는 실행에 가깝고, 오른쪽으로 갈수록 새 것을 만든다.
+            -->
+            <p-tooltip
+              :contents="rerunFailedHint"
+              position="bottom"
+              :options="{ classes: ['p-tooltip', 'run-viewer-tooltip'] }"
             >
-              Clone &amp; Edit
-            </p-button>
-          </p-tooltip>
+              <p-button
+                data-testid="workflow-rerun-failed-btn"
+                size="sm"
+                style-type="tertiary"
+                :disabled="!hasFailedTask || rerunPending || runInProgress"
+                @click="requestRerunFailed"
+              >
+                Re-run failed tasks
+              </p-button>
+            </p-tooltip>
+
+            <p-tooltip
+              contents="Starts a new run of the whole workflow from the first task. This does not re-run the run selected above."
+              position="bottom"
+              :options="{ classes: ['p-tooltip', 'run-viewer-tooltip'] }"
+            >
+              <p-button
+                data-testid="workflow-viewer-run-btn"
+                size="sm"
+                style-type="primary"
+                :disabled="runInProgress"
+                @click="showRunConfirm = true"
+              >
+                Start new run
+              </p-button>
+            </p-tooltip>
+
+            <p-tooltip
+              contents="Copies this workflow and opens the copy in the editor, so you can change values without touching the original or its run history."
+              position="bottom"
+              :options="{ classes: ['p-tooltip', 'run-viewer-tooltip'] }"
+            >
+              <p-button
+                data-testid="workflow-clone-edit-btn"
+                size="sm"
+                style-type="tertiary"
+                :disabled="cloning"
+                @click="showCloneConfirm = true"
+              >
+                Clone &amp; Edit
+              </p-button>
+            </p-tooltip>
+          </template>
         </div>
       </div>
 
@@ -479,6 +560,31 @@ async function onRunChange(runId: string) {
             <dt>Duration</dt>
             <dd>{{ formatDuration(selectedInstance?.duration_date) }}</dd>
           </dl>
+
+          <!--
+            이 태스크가 무엇을 만들었는지. 오늘은 SW 마이그레이션 결과만 — 엔진이 태스크에
+            실어 준 실행 ID가 있을 때만 조회한다. 없으면 조용히 빈 화면을 두지 않고 그렇게
+            말한다(빈 화면은 "설치된 소프트웨어가 없다"로 읽힌다).
+          -->
+          <div class="run-viewer__result" data-testid="workflow-run-result">
+            <h5>Result</h5>
+            <p-button
+              v-if="swExecutionIds.length"
+              data-testid="workflow-run-result-sw-btn"
+              size="sm"
+              style-type="tertiary"
+              @click="showSwResult = true"
+            >
+              View installed software
+            </p-button>
+            <p
+              v-else
+              class="run-viewer__hint"
+              data-testid="workflow-run-result-empty"
+            >
+              No result to show for this task.
+            </p>
+          </div>
 
           <!-- 실패했으면 왜 실패했는지를 그 자리에서 -->
           <div
@@ -738,6 +844,18 @@ async function onRunChange(runId: string) {
           Each copy is kept as its own workflow, so make one when you actually
           intend to change values — not to look around.
         </p>
+        <!--
+          병렬 워크플로우는 그래픽 에디터가 아직 다루지 못한다 — 복제본은 JSON
+          에디터로 연다. (툴이 병렬을 지원하면 이 안내는 사라진다 — BAR-1454)
+        -->
+        <p
+          v-if="isParallel"
+          class="run-viewer__hint"
+          data-testid="workflow-clone-parallel-note"
+        >
+          This workflow runs tasks in parallel, which the graphical editor
+          cannot edit yet, so the copy opens in the JSON editor.
+        </p>
         <div class="run-viewer__modal-actions">
           <p-button
             data-testid="workflow-clone-confirm-cancel"
@@ -757,6 +875,49 @@ async function onRunChange(runId: string) {
         </div>
       </div>
     </div>
+
+    <!--
+      미실행 원본을 편집하려는데 병렬이라 그래픽 에디터가 못 다루는 경우. JSON 에디터로
+      갈지 물어본다. (툴이 병렬을 지원하면 이 모달과 폴백을 함께 걷어낸다 — BAR-1454)
+    -->
+    <div
+      v-if="showEditJsonConfirm"
+      class="run-viewer__modal"
+      data-testid="workflow-parallel-edit-confirm"
+    >
+      <div class="run-viewer__modal-box">
+        <h4>Edit in the JSON editor?</h4>
+        <p class="run-viewer__hint">
+          This workflow runs tasks in parallel. The graphical editor cannot edit
+          parallel workflows yet, so its structure would be lost. You can edit
+          it directly in the JSON editor instead.
+        </p>
+        <div class="run-viewer__modal-actions">
+          <p-button
+            data-testid="workflow-parallel-edit-cancel-btn"
+            style-type="tertiary"
+            @click="showEditJsonConfirm = false"
+          >
+            Cancel
+          </p-button>
+          <p-button
+            data-testid="workflow-parallel-edit-json-btn"
+            style-type="primary"
+            @click="confirmEditJson"
+          >
+            Edit in JSON editor
+          </p-button>
+        </div>
+      </div>
+    </div>
+
+    <!-- 태스크가 만든 결과(SW 마이그레이션 설치 목록) — 기존 결과 화면을 재사용한다 -->
+    <software-migration-overlay
+      :is-visible="showSwResult"
+      :selected-run="selectedRun"
+      :execution-ids="swExecutionIds"
+      @close="showSwResult = false"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
실행 뷰어(Run Status)에 세 가지를 함께 넣었다. 모두 같은 화면(`WorkflowRunViewer`)과 상위 페이지(`WorkflowsPage`)를 건드려 서로 얽혀 있어 한 PR로 묶었다.

## 무엇이 바뀌나

**태스크 결과 조회** — 태스크를 고르면 상세에 "결과" 영역이 생긴다. 엔진이 결과 식별자를 실어 준 태스크(오늘은 소프트웨어 마이그레이션)는 설치된 소프트웨어 목록을 보여주고, 그렇지 않은 태스크는 "결과 없음"을 명시한다. 표시 여부를 컴포넌트 이름이 아니라 *결과 식별자의 유무*로 정했기 때문에, 새 컴포넌트가 들어와도 이 화면을 고칠 필요가 없다. 결과 화면은 기존 오버레이를 그대로 재사용한다.

**실행 이력에 따른 버튼 제어** — 한 번도 실행하지 않은 워크플로우에는 "다시 돌린다"가 없다. 실행할지, 내용을 고칠지 둘뿐이라 Run·Edit만 보여준다. 실행된 워크플로우는 원본 직접 수정을 막는 내부 정책에 따라 Edit을 빼고 기존 세 버튼(Start new run·Clone & Edit·Re-run failed tasks)을 둔다. 미실행 상태에서는 태스크를 골라도 Re-run이 나오지 않는다.

**병렬 워크플로우 편집 폴백** — 워크플로우 에디터가 아직 병렬 구조를 다루지 못한다. 병렬 워크플로우를 편집하려 하면 그 사실을 알리고 JSON 에디터로 직접 편집할지 물어본다. 에디터가 병렬을 지원하면 이 폴백은 걷어낸다.

## 함께 고친 것

- 뷰어 내용이 다른 탭과 달리 좌측에 바싹 붙어 있어 좌우 여백을 줬다.
- 그래프 상자 폭이 SVG 폭만 잡아 안쪽 여백과 테두리만큼 모자랐다. 넉넉한 화면에서도 가로 스크롤이 상시 생기던 원인이라 그만큼을 폭에 반영했다.
- 소프트웨어 마이그레이션 요청 본문이 `targetSoftwareModel` 래퍼 없이 나가고 있었다. grasshopper는 이 래퍼 안의 목록을 읽으므로 서버 목록이 빈 채로 바인딩됐고, 아무것도 처리하지 않은 채 200과 실행 ID를 돌려줬다. 그래서 태스크는 성공으로 보이는데 결과는 비어 있었다. 인프라(beetle)는 모델 내용이 곧 본문이라 형태가 다르다 — 소프트웨어만 감싸도록 했다.

## 검증

원격 개발 서버 실화면으로 미실행/실행됨/병렬 전 케이스를 확인했다(page error 0). 소프트웨어 결과는 실제 마이그레이션 44건을 돌려 확인했다 — 결과 화면에 프로그램별로 이름·버전·설치 유형·상태·대상 노드가 나오고, 41건 성공 3건 실패가 있는 그대로 표시된다. 정적 검증은 빌드 오류 0, eslint 신규 오류 0.

e2e 셀렉터가 화면 문구에 의존하지 않도록 버튼·결과 영역·모달에 `data-testid`를 함께 넣었다.

---

- [BAR-1456](https://mzdevs.atlassian.net/browse/BAR-1456) 워크플로우 실행 결과(마이그레이션 산출물) 조회를 실행 뷰어에 통합
- [BAR-1498](https://mzdevs.atlassian.net/browse/BAR-1498) 실행 이력 유무에 따른 실행 뷰어 버튼 제어
- [BAR-1500](https://mzdevs.atlassian.net/browse/BAR-1500) 병렬 워크플로우 편집 시 JSON 에디터 폴백
- [BAR-1493](https://mzdevs.atlassian.net/browse/BAR-1493) 마이그레이션 태스크 본문 전달 방식 현행화 (FR-02 본문 래퍼)

테스트 결과서: `notion/cm-bf-ep-전환워크플로우웹플래닝고도화/016_워크플로우실행상태시각화/ST3_단위테스트/TR-BAR-1456-1498-1500-결과통합및버튼제어.md`