### PR TITLE
Word the first-run confirm as Run, not a new run

### DIFF
--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -803,7 +803,40 @@ async function onRunChange(runId: string) {
       class="run-viewer__modal"
       data-testid="workflow-run-confirm"
     >
-      <div class="run-viewer__modal-box">
+      <!--
+        같은 모달을 최초 실행(Run)과 이후 실행(Start new run)이 함께 쓴다. 두 경우는
+        사용자가 아는 것이 다르다 — 최초 실행에는 "고를 실행"도 "다시 돌릴 것"도 없으므로
+        새 실행 기준으로 설명하면 틀린 말이 된다. 대신 이 시점에만 할 수 있는 것,
+        즉 *수정은 지금까지만 가능하다*를 알려 준다.
+      -->
+      <div v-if="!hasRuns" class="run-viewer__modal-box">
+        <h4>Run this workflow?</h4>
+        <p class="run-viewer__hint">
+          The tasks will do their work on the target systems.
+        </p>
+        <p class="run-viewer__hint run-viewer__hint--caution">
+          You can edit this workflow only before its first run. Once it has run,
+          edit a copy instead — use Clone &amp; Edit.
+        </p>
+        <div class="run-viewer__modal-actions">
+          <p-button
+            data-testid="workflow-run-confirm-cancel"
+            style-type="tertiary"
+            @click="showRunConfirm = false"
+          >
+            Cancel
+          </p-button>
+          <p-button
+            data-testid="workflow-run-confirm-ok"
+            style-type="primary"
+            @click="confirmRun"
+          >
+            Run
+          </p-button>
+        </div>
+      </div>
+
+      <div v-else class="run-viewer__modal-box">
         <h4>Start a new run of this workflow?</h4>
         <p class="run-viewer__hint">
           This does not re-run the run selected above. It starts a new run of
@@ -1075,6 +1108,14 @@ async function onRunChange(runId: string) {
 .run-viewer__hint {
   font-size: 0.8125rem;
   color: #6b6e78;
+}
+
+/* 되돌릴 수 없는 것을 알리는 줄 — 나머지 설명과 같은 회색이면 그냥 지나친다 */
+.run-viewer__hint--caution {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.25rem;
+  background: #fff8ef;
+  color: #8a5a17;
 }
 
 .run-viewer__params {


### PR DESCRIPTION
실행 뷰어의 **Run**(최초 실행)과 **Start new run**(이후 실행)이 확인 모달 하나를 공유하고 있었다. 그래서 최초 실행인데도 새 실행 기준으로 설명됐다 — 제목은 "Start a new run of this workflow?", 본문은 "this does not re-run **the run selected above**", 안내는 "select a task and use **Re-run**", 확인 버튼마저 **Start new run**이었다. 최초 실행 시점에는 고를 실행도, 다시 돌릴 것도 없으니 어느 문장도 맞지 않는다.

## 무엇이 바뀌나

모달을 실행 이력 유무로 갈랐다.

| 상태 | 제목 | 확인 버튼 |
|---|---|---|
| 미실행 | **Run this workflow?** | **Run** |
| 실행됨 | Start a new run of this workflow? *(그대로)* | Start new run *(그대로)* |

최초 실행 모달에는 **그 시점에만 할 수 있는 말**을 넣었다 — 워크플로우는 실행 전까지만 고칠 수 있고, 한 번 실행하면 원본은 못 고치니 복제해서 고쳐야 한다(Clone & Edit). 실행된 워크플로우의 원본 수정을 막는 것은 내부 정책인데, 그 사실을 사용자가 **마지막으로 되돌릴 수 있는 지점**에서 알려 준다. 되돌릴 수 없는 안내라 나머지 설명 줄과 구분되게 뒀다 — 같은 회색이면 그냥 지나친다.

실행됨 상태의 모달은 손대지 않았다.

## 검증

원격 개발 서버 실화면에서 두 상태를 모두 확인했다. 미실행 워크플로우는 "Run this workflow?"와 버튼 **Run**, 그리고 수정 시점 안내가 뜬다. 실행 이력이 있는 워크플로우는 기존 "Start a new run…"과 버튼 **Start new run**이 그대로 나온다.

---

- [BAR-1498](https://mzdevs.atlassian.net/browse/BAR-1498) 실행 상태 뷰어 상태별 액션 버튼 제어 (FR-10 후속 — 확인 모달 문구)

테스트 결과서: `notion/cm-bf-ep-전환워크플로우웹플래닝고도화/016_워크플로우실행상태시각화/ST3_단위테스트/TR-BAR-1456-1498-1500-결과통합및버튼제어.md` (§2.5)