### PR TITLE
fix(api): ship the env file as a sample instead of committing a filled one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ api/conf/serverinfo
 
 ## env
 front/.env
+api/.env
 
 ## Logs
 front/logs

--- a/README.md
+++ b/README.md
@@ -15,14 +15,15 @@
     - [Recommend Envionment (Test Finished)](#recommend-envionment-test-finished)
   - [How to Run](#how-to-run)
     - [1. Project clone from remote git repository](#1-project-clone-from-remote-git-repository)
-    - [2. CM-Butterfly needs to run with cloud-migrator subsystems.](#2-cm-butterfly-needs-to-run-with-cloud-migrator-subsystems)
-    - [3.CSP User credential registration ⭐⭐](#3csp-user-credential-registration-)
-    - [4. Subsystem's api host and endpoint configuration](#4-subsystems-api-host-and-endpoint-configuration)
-    - [5. Self auth settings (Optional)](#5-self-auth-settings-optional)
-    - [6. Configure Nginx for Backend API and Access Control](#6-configure-nginx-for-backend-api-and-access-control)
+    - [2. Create the api environment file ⭐](#2-create-the-api-environment-file)
+    - [3. CM-Butterfly needs to run with cloud-migrator subsystems.](#3-cm-butterfly-needs-to-run-with-cloud-migrator-subsystems)
+    - [4. CSP User credential registration ⭐⭐](#4-csp-user-credential-registration)
+    - [5. Subsystem's api host and endpoint configuration](#5-subsystems-api-host-and-endpoint-configuration)
+    - [6. Self auth settings (Optional)](#6-self-auth-settings-optional)
+    - [7. Configure Nginx for Backend API and Access Control](#7-configure-nginx-for-backend-api-and-access-control)
       - [Update backend url nginx reverse proxy configuration](#update-backend-url-nginx-reverse-proxy-configuration)
       - [Restrict aceess based on the `Origin` header](#restrict-aceess-based-on-the-origin-header)
-    - [7. Explore Awesome cm-butterfly](#7-explore-awesome-cm-butterfly)
+    - [8. Explore Awesome cm-butterfly](#8-explore-awesome-cm-butterfly)
 ***
 
 # cm-butterfly
@@ -49,7 +50,17 @@ or if you need specific version with minimize the size
 git clone --depth 1 --branch v0.3.0 https://github.com/cloud-barista/cm-butterfly.git
 ```
 
-### 2. CM-Butterfly needs to run with cloud-migrator subsystems.
+### 2. Create the api environment file ⭐
+
+The api reads its database connection and file paths from environment variables. `api/.env` is not tracked by git, so create it from the sample before running anything that loads it (for example `api/docker-compose.dev.yaml`, which reads it through `env_file`).
+
+```bash
+cp api/.env.sample api/.env
+```
+
+The sample ships development defaults, so it runs as-is for local development. **Change them for any real use** — `POSTGRES_PASSWORD` in particular. If you run the api through cm-mayfly, the compose file supplies these values and you do not need `api/.env`.
+
+### 3. CM-Butterfly needs to run with cloud-migrator subsystems.
 cm-butterfly requires execution on each server because it uses the open APIs of several subsystems that make up the cloud migrator project.
 
 To execute each subsystem, you can clone it from the repository of each subsystem.
@@ -74,7 +85,7 @@ If you want to check the detailed information about each subsystem, please visit
 
 
 
-### 3.CSP User credential registration ⭐⭐
+### 4. CSP User credential registration ⭐⭐
 > This step is very important, so I've marked it with stars. 
 
 In cm-butterfly, it is necessary to register user credentials for each CSP. Registered user's CSP credentials are used for tasks such as provisioning virtual machines in CSP's remote environment while executing workflow, performnace test preperation, or for retrieving price or cost information from CSP.
@@ -86,7 +97,7 @@ Follow the guide for initializing CB-Tumblebug to configure multi-cloud informat
 > 👉 [Initialize CB-Tumblebug to configure Multi-Cloud info](https://github.com/cloud-barista/cb-tumblebug?tab=readme-ov-file#3-initialize-cb-tumblebug-to-configure-multi-cloud-info)
 
 
-### 4. Subsystem's api host and endpoint configuration
+### 5. Subsystem's api host and endpoint configuration
 
 ⭐ cm-butterfly reads the `cm-butterfly/api/conf/api.yaml` file to configure the host of the subsystem called by cm-butterfly and the API endpoint of each subsystem.
 
@@ -128,7 +139,7 @@ Modify the value of services.{subsystem-name}.baseurl. The host currently in use
 ```
  
 
-### 5. Self auth settings (Optional)
+### 6. Self auth settings (Optional)
 By default, cm-butterfly supports one user with migration privileges. (The featrue that add and delete users are not currently provided.)
 
 When the application starts, it reads `./api/conf/authsetting.yaml`, creates `user.dat` in the same conf folder, and then reads the dat file to process user login.
@@ -152,7 +163,7 @@ sed -i 's/password: cmiguserPassword!/password: what-ever-you-want-password/' ./
 
 
 
-### 6. Configure Nginx for Backend API and Access Control
+### 7. Configure Nginx for Backend API and Access Control
 #### Update backend url nginx reverse proxy configuration
 The frontend of cm-butterfly includes a web server, `nginx`. It uses nginx's reverse proxy to make http calls to the backend API.
 
@@ -188,6 +199,6 @@ To enable this functionaliy, simply remove the `#` symbols.
 ---
 
 
-### 7. Explore Awesome cm-butterfly
+### 8. Explore Awesome cm-butterfly
 If you run it through docker compose, you can see the login page by accessing `http://localhost/auth/login`. The user credentials are registered with the default ID and password, and if you log in, you can use cm-butterfly, which supports cloud migration.
 

--- a/api/.env.sample
+++ b/api/.env.sample
@@ -1,3 +1,13 @@
+# cm-butterfly api 환경변수 샘플
+#
+# 사용법: 이 파일을 복사해 .env 를 만든 뒤 값을 채운다.
+#
+#   cp api/.env.sample api/.env
+#
+# .env 는 git 에 올리지 않는다(.gitignore). 아래 값은 개발용 기본값이라
+# 그대로 써도 로컬 개발은 되지만, 실제 사용 시에는 반드시 바꾼다.
+# 특히 POSTGRES_PASSWORD 는 배포 환경에서 그대로 두지 않는다.
+
 API_ADDR=0.0.0.0
 API_PORT=4000
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -28,7 +28,9 @@ ENV USER_AUTH_CONF_PATH=${USER_AUTH_CONF_PATH:-conf/authsetting.yaml}
 ENV MENU_CONF_DATA_PATH=${MENU_CONF_DATA_PATH:-conf/menu.yaml}
 
 ENV POSTGRES_USER=${POSTGRES_USER:-butterflyadmin}
-ENV POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-pw123butterflyadmin}
+# POSTGRES_PASSWORD 는 기본값을 두지 않는다. 여기에 적으면 그 값이 이미지 메타데이터로 구워져
+# `docker inspect` 로 그대로 보이고, 공개 저장소에도 남는다. 값은 실행 시점에 주입한다
+# (compose 의 environment / env_file). 주입하지 않으면 앱이 연결에 실패해 문제가 드러난다.
 ENV POSTGRES_DATABASE_HOST=${POSTGRES_DATABASE_HOST:-cm-butterfly-db}
 ENV POSTGRES_PORT=${POSTGRES_PORT:-5432}
 ENV POSTGRES_DB=${POSTGRES_DB:-butterfly-db}


### PR DESCRIPTION
## 왜 이걸 하나

저장소 보안 스캔(Trivy)이 `DS-0031`(**CRITICAL**)로 **DB 비밀번호가 이미지에 구워져 있다**고 잡았습니다. 기능 변경이 아니라 **이미지 하드닝** 작업입니다.

같은 비밀번호가 두 곳에 있었습니다.

- `api/.env` — git에 추적되며 값이 채워져 있음
- `api/Dockerfile` — `ENV POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-<값>}` 로 같은 값을 기본값으로

Dockerfile 쪽은 그 값이 **이미지에 구워져 `docker inspect`로 그대로 보입니다.** 개발용 기본값이라 노출 자체가 사고는 아니지만, 이미지에 박아 둘 이유가 없습니다.

## 기본값을 지워도 되는 근거

주입 경로를 전수 확인했습니다. **어느 경로도 Dockerfile 기본값을 쓰지 않습니다.**

| 경로 | 비밀번호를 어디서 받나 |
|------|----------------------|
| 로컬 개발 (`api/docker-compose.dev.yaml`) | `env_file: .env` |
| `scripts/docker-compose.yaml` | `${POSTGRES_PASSWORD}` |
| cm-mayfly 통합환경 | `${BUTTERFLY_DB_PASSWORD}` — `.env.example`에 있어 미입력 시 기동 차단 |
| Go 코드 | `getEnv("POSTGRES_PASSWORD", "postgres")` 자체 fallback |

## 어떻게 고쳤나

- `api/.env` → **`api/.env.sample`** 로 전환. 값은 개발용 기본값이라 그대로 두고, 추적되던 `.env`만 없앱니다. `.gitignore`가 앞으로를 막습니다. (`.gitignore`는 이미 추적 중인 파일에 적용되지 않으므로 추적 해제는 파일 이동으로 처리)
- **README에 `cp api/.env.sample api/.env` 절차 추가**(신규 §2). README가 이미 이 흐름을 전제하고 있었는데 정작 sample 파일이 없었습니다.
- Dockerfile의 `POSTGRES_PASSWORD` 기본값 제거. 값은 런타임 주입 필수가 되고, 안 주면 조용히 알려진 비밀번호를 쓰는 대신 연결에 실패해 문제가 드러납니다.

## 검증

업스트림 CD와 같은 방식(build-arg 없이)으로 변경 전/후 이미지를 빌드해 대조했습니다.

```
[변경 전] POSTGRES_PASSWORD=<비밀번호가 구워져 있음>
[변경 후] (항목 자체가 없음)
```

나머지 ENV(`POSTGRES_USER`·`DATABASE_HOST`·`PORT`·`DB`)는 변화 없고, `.env.sample` 키 10개는 원본과 동일합니다.

## 참고

이 값은 개발용 기본값이라 노출 자체가 문제가 되지는 않아, 비밀번호 교체나 히스토리 정리는 하지 않았습니다. 같은 변경을 업스트림에도 반영해야 그쪽 `.env`도 사라집니다.

---

- [BAR-1518](https://mzdevs.atlassian.net/browse/BAR-1518) 컨테이너가 root 로 실행되고 HEALTHCHECK 가 없다 — Dockerfile 하드닝