### PR TITLE
fix(docker): run the images as a normal user and drop the EOL api base

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -14,7 +14,15 @@ RUN go mod download
 RUN go build -ldflags="-s -w" -o /src/cm-butterfly/butterfly ./cmd/app/main.go
 
 ## Stage 2 - Application Deploy
-FROM debian:buster-slim AS deploy
+#
+# 정적 바이너리(CGO_ENABLED=0)라 런타임 베이스에 libc 의존이 없다. build 스테이지가 이미
+# alpine 이고, cb-tumblebug·cm-honeybee·cm-butterfly front 도 alpine 을 쓴다.
+# 직전까지 쓰던 debian:buster-slim 은 Debian 10 으로 EOL 이라 apt 저장소가 내려가
+# 패키지 설치조차 되지 않는 상태였다.
+FROM alpine:3.20 AS deploy
+
+# TLS 로 나가는 호출을 위해 루트 인증서가 필요하다(정적 바이너리는 이것까지 담지 않는다).
+RUN apk add --no-cache ca-certificates
 
 WORKDIR /app
 
@@ -34,6 +42,13 @@ ENV POSTGRES_USER=${POSTGRES_USER:-butterflyadmin}
 ENV POSTGRES_DATABASE_HOST=${POSTGRES_DATABASE_HOST:-cm-butterfly-db}
 ENV POSTGRES_PORT=${POSTGRES_PORT:-5432}
 ENV POSTGRES_DB=${POSTGRES_DB:-butterfly-db}
+
+# root 로 돌지 않는다. 앱이 기동 시 conf/ 에 user.dat 를 만들므로 /app 소유권을 넘긴다.
+# 4000 번은 비특권 포트라 포트 관련 추가 설정은 필요 없다.
+RUN addgroup -S butterfly && adduser -S -G butterfly butterfly \
+ && chown -R butterfly:butterfly /app
+
+USER butterfly
 
 EXPOSE 4000
 

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -38,6 +38,19 @@ RUN rm /etc/nginx/conf.d/default.conf
 
 RUN chmod +x /app/entrypoint.sh
 
+# root 로 돌지 않는다. 포트는 그대로 80 을 듣는다 — 도커가 컨테이너 안에서
+# net.ipv4.ip_unprivileged_port_start=0 을 기본으로 두므로 비특권 사용자도 80 을 바인드할 수 있고,
+# 그래서 compose 의 포트 매핑이나 실행 방법은 바뀌지 않는다.
+#
+# 필요한 것은 nginx 가 쓰는 경로의 소유권뿐이다. pid 는 /var/run 이 /run 심링크라
+# 소유권 변경이 먹지 않으므로 쓰기 가능한 /tmp 로 옮긴다.
+RUN mkdir -p /var/cache/nginx \
+ && chown -R nginx:nginx /var/cache/nginx /etc/nginx/conf.d /usr/share/nginx/html /app \
+ && sed -i 's|^pid .*|pid /tmp/nginx.pid;|' /etc/nginx/nginx.conf \
+ && sed -i '/^user /d' /etc/nginx/nginx.conf
+
+USER nginx
+
 EXPOSE 80
 
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
## 왜 이걸 하나

저장소 보안 스캔(Trivy)이 컨테이너 이미지에서 잡아낸 문제를 처리합니다. 기능 변경이 아니라 **이미지 하드닝** 작업입니다.

| 잡힌 것 | 심각도 | 내용 |
|---------|--------|------|
| `DS-0002` | **HIGH** | api·front 이미지가 **root로 실행**됨 (`USER` 지시자 없음) |
| — | — | api 베이스 `debian:buster-slim`이 **EOL** — 저장소가 아카이브돼 **패치 자체가 불가능** |

두 항목 모두 새로 생긴 문제가 아니라 **처음부터 있던 것**입니다. 최근 이미지 관련 변경으로 스캐너가 해당 파일을 다시 보면서 드러났고, 이참에 정리합니다. 같은 흐름의 앞선 작업으로 이미지에 구워져 있던 DB 기본 비밀번호를 제거했습니다(#87).

## 무엇을 고쳤나

- api·front 이미지가 **일반 사용자로 실행**되도록 (`DS-0002` 해소)
- api의 **EOL 베이스**(`debian:buster-slim`)를 `alpine:3.20`으로 교체

## 실행 방법은 바뀌지 않습니다

가장 걱정되는 부분이라 먼저 확인했습니다. **사전 명령이 늘거나 compose를 손댈 필요가 없습니다.**

| 확인 | 결과 |
|------|------|
| 컨테이너 기본 `net.ipv4.ip_unprivileged_port_start` | **`0`** — 도커가 비특권 포트 제한을 이미 풀어 둡니다 |
| non-root nginx로 80 바인드 | **성공** |
| `cap_add`·sysctl·compose 변경 | **불필요** |

front는 **80을 그대로 듣습니다.** 실제로 필요한 건 nginx가 쓰는 경로의 소유권뿐이었습니다. (`/var/run`이 `/run` 심링크라 `chown`이 뚫고 가지 않아 pid만 `/tmp`로 옮겼습니다.) api는 기동 시 `conf/user.dat`를 쓰므로 `/app` 소유권을 넘겼고, 4000번은 비특권 포트라 추가 설정이 없습니다.

## api 베이스를 바꾼 이유

`debian:buster-slim`은 Debian 10으로 **EOL이라 저장소가 아카이브돼 `apt-get update`부터 실패**합니다. 즉 베이스를 패치할 방법이 없습니다.

`alpine`을 고른 근거:

- 바이너리가 `CGO_ENABLED=0` **정적 빌드**라 libc 의존이 없습니다
- **build 스테이지가 이미 `golang:1.26-alpine`** 이었습니다 — 런타임만 데비안이었습니다
- cb-tumblebug(3.19)·cm-honeybee(3.20)·cm-butterfly front(nginx-alpine)도 alpine입니다
- 데비안을 쓰던 이유는 **Buffalo 호환**이었는데, Buffalo는 이미 제거돼 `go.mod`에 흔적이 없습니다
- 외부 TLS 호출용으로 `ca-certificates`만 추가했습니다

## 검증

단독 기동은 DB·upstream 미해결로 죽으므로(non-root와 무관), **실제 postgres를 붙인 네트워크**에서 확인했습니다.

| 항목 | 결과 |
|------|------|
| api 실행 유저 | `butterfly` (root 아님) |
| api `/readyz` | HTTP 200 |
| api가 non-root로 `conf/user.dat` 쓰기 | 성공 (`butterfly` 소유 273B) |
| front 실행 유저 | `nginx` |
| front 80 LISTEN · index·번들 서빙 | 정상 |
| front → api 프록시 | HTTP 400 (= API 정상 응답) |
| 이미지 크기 | api 37.7MB · front 77.6MB |

## HEALTHCHECK는 넣지 않았습니다

`DS-0026`(HEALTHCHECK 없음)도 함께 뜨지만 **의도적으로 넣지 않습니다.** compose가 이미 외부에서 주입한 `mayfly` 바이너리로 healthcheck를 하고 있고, **compose의 healthcheck는 이미지 HEALTHCHECK를 덮어씁니다.** 이미지에 넣으려면 curl 등을 설치해야 하는데, healthcheck 하나 하자고 CVE 표면과 용량을 늘리는 셈이라 순손실입니다. 도구 없는 이미지 + 외부 healthcheck는 의도된 설계입니다.

---

- [BAR-1518](https://mzdevs.atlassian.net/browse/BAR-1518) 컨테이너가 root 로 실행되고 HEALTHCHECK 가 없다 — Dockerfile 하드닝