### PR TITLE
Show why the software migration recommendations failed

### DIFF
--- a/front/src/widgets/models/recommendedSoftwareModel/ui/RecommendedSoftwareModel.vue
+++ b/front/src/widgets/models/recommendedSoftwareModel/ui/RecommendedSoftwareModel.vue
@@ -81,26 +81,50 @@ onMounted(() => {
 });
 
 // Watch for source model changes and expand all
-watch(sourceSoftwareModelData, (newVal) => {
-  if (newVal) {
-    console.log('Source model data changed, expanding...');
-    setTimeout(() => {
-      sourceEditorRef.value?.expandAll();
-    }, 300);
-  }
-}, { immediate: true, deep: true });
+watch(
+  sourceSoftwareModelData,
+  newVal => {
+    if (newVal) {
+      console.log('Source model data changed, expanding...');
+      setTimeout(() => {
+        sourceEditorRef.value?.expandAll();
+      }, 300);
+    }
+  },
+  { immediate: true, deep: true },
+);
 
 // Watch for recommended model changes and expand all
-watch(recommendedModelData, (newVal) => {
-  if (newVal) {
-    console.log('Recommended model data changed, expanding...');
-    setTimeout(() => {
-      recommendedEditorRef.value?.expandAll();
-    }, 300);
-  }
-}, { immediate: true, deep: true });
+watch(
+  recommendedModelData,
+  newVal => {
+    if (newVal) {
+      console.log('Recommended model data changed, expanding...');
+      setTimeout(() => {
+        recommendedEditorRef.value?.expandAll();
+      }, 300);
+    }
+  },
+  { immediate: true, deep: true },
+);
 
-// Get-Migration-List API 호출 (실패 시 더미 데이터 사용)
+/**
+ * 실패 사유를 화면에 남긴다. 토스트는 5초 뒤 사라지는데, 사용자가 결과를 기다리는 자리는
+ * 오른쪽 결과 패널이다. 사유가 거기 남아 있지 않으면 "그냥 빈 화면"으로만 보인다.
+ */
+const loadErrorReason = ref<string | null>(null);
+
+/**
+ * 백엔드가 준 실패 사유를 꺼낸다. 두 가지 형태로 들어온다:
+ *  - HTTP 오류 → execute()가 `{ error, errorMsg, status }`(ref)로 reject
+ *  - 본문에 에러 상태가 실려 온 경우 → 아래에서 Error로 던진 것
+ */
+function toFailureReason(e: any): string | null {
+  const fromRequest = e?.errorMsg?.value ?? e?.errorMsg;
+  const reason = fromRequest ?? e?.message ?? null;
+  return typeof reason === 'string' && reason.trim() ? reason.trim() : null;
+}
+
 async function handleGetMigrationList() {
   if (!sourceSoftwareModelData.value) {
     console.warn('Source software model data is not available');
@@ -108,35 +132,39 @@ async function handleGetMigrationList() {
   }
 
   isLoading.value = true;
+  loadErrorReason.value = null;
 
   try {
-    // 먼저 실제 API 호출 시도
-    const response = await recommendSoftwareModel.getSoftwareMigrationListData(sourceSoftwareModelData.value);
+    const response = await recommendSoftwareModel.getSoftwareMigrationListData(
+      sourceSoftwareModelData.value,
+    );
 
     // 응답의 status.code를 확인하여 에러 여부 판단
     const statusCode = response?.data?.status?.code;
     if (statusCode && statusCode >= 400) {
-      console.warn(
-        'API returned error status, using dummy data:',
-        response.data.status,
-      );
       throw new Error(
-        `API Error: ${statusCode} - ${response.data.status?.message || 'Unknown error'}`,
+        response.data.status?.message ||
+          `The server returned status ${statusCode}.`,
       );
     }
 
     // API 응답 데이터를 recommendedModelData에 저장
-    recommendedModelData.value = recommendSoftwareModel.tableModel.tableState.items[0]?.originalData || null;
-
-    console.log('API migration data loaded:', recommendedModelData.value);
+    recommendedModelData.value =
+      recommendSoftwareModel.tableModel.tableState.items[0]?.originalData ||
+      null;
   } catch (error) {
     // Let a failure look like a failure. This used to fall back to dummy recommendations, so a dead
     // cm-grasshopper still rendered a plausible-looking result and the breakage went unnoticed.
+    //
+    // 사유까지 함께 보여준다 — cm-grasshopper는 소스 그룹·커넥션을 실행 시점에 다시 조회하므로,
+    // 수집 당시엔 있었으나 그 뒤 지워진 커넥션을 참조하는 소스 모델은 "not found"로 정당하게 실패한다.
+    // 그때 사유가 없으면 사용자는 무엇이 없어서 실패했는지 알 길이 없다.
     console.error('Failed to load software migration list:', error);
     recommendedModelData.value = null;
+    loadErrorReason.value = toFailureReason(error);
     showErrorMessage(
-      'Error',
       'Failed to load the software migration recommendations.',
+      loadErrorReason.value ?? 'The server did not say why.',
     );
   } finally {
     isLoading.value = false;
@@ -168,7 +196,8 @@ function handleCreateTargetModel(e) {
   saveTargetModelModal.context.description = e.description;
 
   // Source Software Model에서 isInitUserModel 값 가져오기
-  const isInitUserModel = sourceSoftwareModelData.value?.isInitUserModel ?? false;
+  const isInitUserModel =
+    sourceSoftwareModelData.value?.isInitUserModel ?? false;
   const userId = authStore.id; // 로그인 유저의 ID 사용
   const userModelVersion = sourceModel.value?.userModelVersion ?? 'v0.1';
 
@@ -253,7 +282,31 @@ function handleCreateTargetModel(e) {
           <!-- 오른쪽: Recommended Model 결과 JSON Viewer -->
           <p-pane-layout class="json-editor-pane">
             <p class="editor-title">Migration Recommendations</p>
-            <div class="editor-wrapper">
+            <!--
+              실패하면 빈 뷰어 대신 사유를 이 자리에 남긴다. 사용자가 결과를 기다리는 자리가
+              여기이고, 토스트는 5초 뒤 사라져 "왜 비었는지"가 남지 않는다.
+            -->
+            <div
+              v-if="loadErrorReason"
+              class="recommend-error"
+              data-testid="sw-recommend-error"
+            >
+              <p class="recommend-error__title">
+                Could not load the migration recommendations.
+              </p>
+              <p
+                class="recommend-error__reason"
+                data-testid="sw-recommend-error-reason"
+              >
+                {{ loadErrorReason }}
+              </p>
+              <p class="recommend-error__hint">
+                The recommendations are built from the source group and
+                connection this model was collected from. If either no longer
+                exists, collect the source again and retry.
+              </p>
+            </div>
+            <div v-else class="editor-wrapper">
               <EnhancedJsonEditor
                 ref="recommendedEditorRef"
                 :model-value="recommendedModelString"
@@ -329,7 +382,7 @@ function handleCreateTargetModel(e) {
     font-size: 0.75rem;
     color: #6b7280;
     font-weight: 700;
-    background-color: #F7F7F7;
+    background-color: #f7f7f7;
     padding: 0.25rem 0.75rem;
     border-radius: 6px 0;
   }
@@ -340,6 +393,41 @@ function handleCreateTargetModel(e) {
     width: 100%;
     min-width: 280px;
     min-height: 400px;
+  }
+
+  /* 실패 사유 — 결과 뷰어와 같은 자리를 차지해 "빈 화면"이 되지 않게 한다 */
+  .recommend-error {
+    background-color: white;
+    padding: 1.25rem;
+    width: 100%;
+    min-width: 280px;
+    min-height: 400px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+  }
+
+  .recommend-error__title {
+    color: #b93c3c;
+    font-weight: 700;
+    font-size: 0.875rem;
+  }
+
+  /* 서버가 준 문구는 그대로 보여준다 — 길거나 식별자가 섞여 있어도 잘리지 않게 */
+  .recommend-error__reason {
+    color: #3b3b3b;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    word-break: break-word;
+    background-color: #fdf3f3;
+    border-radius: 0.25rem;
+    padding: 0.625rem 0.75rem;
+  }
+
+  .recommend-error__hint {
+    color: #6b6e78;
+    font-size: 0.75rem;
+    line-height: 1.5;
   }
 }
 


### PR DESCRIPTION
소프트웨어 마이그레이션 추천을 불러오지 못했을 때, 화면이 그 이유를 말하지 않았다. 결과 패널은 그냥 비고 토스트만 "Failed to load the software migration recommendations." 한 줄을 남긴 채 5초 뒤 사라졌다.

## 왜 실패하나 (버그가 아니다)

추천은 소스 모델이 수집된 소스 그룹·커넥션을 **실행 시점에 다시 조회해서** 만든다. 그래서 수집 당시엔 있었지만 그 뒤 누군가 지운 커넥션을 참조하는 소스 모델은 `connection info (ID=…) not found`로 실패한다. 이건 정당한 응답이고 서버도 정상이다 — 문제는 그 사실이 사용자에게 닿지 않는다는 것이었다.

## 무엇이 바뀌나

서버가 준 사유를 **결과가 놓일 자리(오른쪽 패널)에** 그대로 옮긴다. 토스트가 사라져도 남아 있고, 사용자가 결과를 기다리던 바로 그 자리다. 함께 무엇을 하면 되는지(커넥션이 사라졌으면 소스를 다시 수집하고 재시도)도 적는다.

보여주는 문구는 **서버가 말한 그대로**다. 실패를 그럴듯하게 포장하거나 추측해서 지어내지 않는다.

주석 두 곳도 정리했다. 더미 데이터로 폴백한다고 설명하고 있었는데 그 폴백은 이미 오래전에 없어졌다 — 코드와 반대되는 주석은 다음 사람을 없는 코드를 찾게 만든다.

나머지 diff는 포매터다. 로컬 게이트가 건드린 파일 전체를 lint 하므로 함께 정리됐다.

## 검증

원격 개발 서버 실화면으로 양쪽 경로를 확인했다.

- 커넥션이 지워진 옛 모델 → 결과 패널에 `connection info (ID=3bc4b0d4-…) not found` 와 안내가 표시된다. 왼쪽 소스 모델의 `connection_id`가 그 ID와 일치해, 어느 커넥션이 없는지 화면 안에서 바로 대조된다.
- 커넥션이 살아있는 모델 → 추천 목록이 그대로 나온다(회귀 없음).
- 화면이 "없다"고 한 커넥션을 honeybee에 직접 물어 실제로 없음을 확인했다. 정상 모델의 커넥션은 존재한다.

빌드 오류 0, eslint 신규 오류 0.

e2e가 이 실패를 잡을 수 있도록 `sw-recommend-error`·`sw-recommend-error-reason` 셀렉터를 함께 넣었다.

---

- [BAR-1521](https://mzdevs.atlassian.net/browse/BAR-1521) 소프트웨어 마이그레이션 추천 실패 시 에러 표현 고도화

테스트 결과서: `notion/cm-bf-ep-소스정보수집및분석기능고도화/013_소프트웨어마이그레이션추천현행화/ST3_단위테스트/TR-BAR-1521-추천실패-에러표현.md`