### PR TITLE
fix(api): copy the source instead of adding it

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,7 +8,9 @@ ENV CGO_ENABLED=0
 
 RUN mkdir -p /src/cm-butterfly
 WORKDIR /src/cm-butterfly
-ADD . .
+# ADD 는 로컬 파일 복사 외에 URL 다운로드·아카이브 자동 해제까지 하므로, 소스를 그대로
+# 넣기만 하면 되는 자리에는 COPY 를 쓴다(의도한 것만 일어난다).
+COPY . .
 
 RUN go mod download
 RUN go build -ldflags="-s -w" -o /src/cm-butterfly/butterfly ./cmd/app/main.go


### PR DESCRIPTION
## 왜 이걸 하나

저장소 보안 스캔(Trivy)이 `DS-0005`로 잡은 항목입니다. 이미지 하드닝의 마지막 정리이며, 앞선 두 건(#87 이미지에 구워진 DB 비밀번호 제거, #88 non-root 실행 + EOL 베이스 교체)과 같은 흐름입니다.

| 알림 | 심각도 | 내용 |
|------|--------|------|
| `DS-0005` | LOW | `api/Dockerfile:11` 이 `ADD . .` 를 사용 — `COPY . .` 권고 |

## 무엇을 고쳤나

`ADD` → `COPY`.

`ADD`는 로컬 파일 복사 외에 **URL 다운로드와 아카이브 자동 해제**까지 합니다. 이 자리는 소스 트리를 이미지에 그대로 넣기만 하면 되므로, `COPY`를 쓰면 의도한 것만 일어납니다.

## 검증

이미지를 재빌드해 산출물이 그대로인지 확인했습니다.

| 항목 | 결과 |
|------|------|
| 빌드 | 성공 |
| 바이너리 | `/app/butterfly` 14.4MB 그대로 포함 |
| 설정 | `conf/` (api.yaml·authsetting.yaml·menu.yaml·scriptTask.txt 등) 그대로 |
| 소유자 | `butterfly` 유지 (#88의 non-root 설정 영향 없음) |

## 함께 확인한 것 — `GO-2026-5932`는 해당 없음

같은 스캔에서 `golang.org/x/crypto/openpgp`가 unmaintained라고 뜨지만 **우리에겐 해당하지 않습니다.**

```
$ go mod why golang.org/x/crypto/openpgp
(main module does not need package golang.org/x/crypto/openpgp)
```

우리 코드도 의존성 트리 어디도 `openpgp` **패키지**를 쓰지 않습니다. `go.mod`에 `golang.org/x/crypto` **모듈**이 있다는 이유로 잡힌 것이고, 취약한 건 그 모듈의 `openpgp` 하위 패키지뿐입니다. 이 PR에서 조치할 것이 없습니다.

---

- [BAR-1518](https://mzdevs.atlassian.net/browse/BAR-1518) 컨테이너가 root 로 실행되고 HEALTHCHECK 가 없다 — Dockerfile 하드닝