### PR TITLE
fix(table): make the list search box filter reliably on any input

### DIFF
--- a/front/src/shared/hooks/table/toolboxTable/useToolboxTableModel.ts
+++ b/front/src/shared/hooks/table/toolboxTable/useToolboxTableModel.ts
@@ -88,20 +88,28 @@ export const useToolboxTableModel = <T>() => {
     }
   };
 
+  const matches = (haystack: unknown, needle: string): boolean =>
+    typeof haystack === 'string' &&
+    haystack.toLowerCase().includes(needle.toLowerCase());
+
   const applyQueryTags = (e: ChangeEvent) => {
     if (e?.queryTags?.length) {
+      // 검색어를 넣으면 필터 결과를 1페이지부터 보여준다. 이전 페이지 위치(startPage)를
+      // 그대로 두면 필터된 항목 수가 그 페이지보다 적을 때 빈 화면이 나온다.
+      tableState.currentPage = 1;
+      tableState.startPage = 1;
+
+      // 부분 문자열(대소문자 무시) 매칭. 정규식을 쓰지 않는 이유: (1) 사용자가 입력한
+      // '.'·'(' 같은 문자가 정규식 메타문자로 해석돼 깨지고, (2) /g 플래그가 붙은 정규식의
+      // .test()는 lastIndex를 누적하는 stateful 동작이라 한 행의 값들을 순회하며 테스트하면
+      // 결과가 들쭉날쭉해진다. 실제로 검색이 필터에 걸리지 않던 원인이 이것이다.
       tableState.sortedItems = tableState.items.filter((row: any) =>
         e.queryTags!.every(queryTag => {
-          const regex = new RegExp(queryTag.value.name, 'gi');
-
+          const needle = queryTag.value.name;
           if (queryTag.key === null) {
-            return Object.values(row).some(
-              value => typeof value === 'string' && regex.test(value),
-            );
+            return Object.values(row).some(value => matches(value, needle));
           }
-
-          const fieldValue = row[queryTag.key.name];
-          return typeof fieldValue === 'string' && regex.test(fieldValue);
+          return matches(row[queryTag.key.name], needle);
         }),
       );
     } else if (e?.queryTags?.length === 0) {
@@ -130,8 +138,11 @@ export const useToolboxTableModel = <T>() => {
     applyQueryTags(e);
     applySorting(e);
 
+    // 현재 페이지 창을 그대로 잘라 낸다. 기존 endIdx 는 startPage(아이템 오프셋)에
+    // pageSize 를 더해 startIdx(페이지 번호 기반)와 의미가 섞여 페이지마다 한 건씩
+    // 모자라거나 검색 후 잘못된 구간을 잘랐다. startIdx 기준으로 일관되게 맞춘다.
     const startIdx = tableOptions.pageSize * (tableState.currentPage - 1);
-    const endIdx = tableState.startPage + tableOptions.pageSize - 1;
+    const endIdx = startIdx + tableOptions.pageSize;
 
     tableState.displayItems = tableState.sortedItems.slice(startIdx, endIdx);
 


### PR DESCRIPTION
## Why

The list search box (mirinae `PToolboxTable` query search, shared by every list) could leave the list unchanged for certain inputs — the user sees a search tag appear but the rows don't narrow. Verified against the dev server: plain-text search, multi-tag AND, and pagination already work on current develop; the input that actually breaks is **regex metacharacters**. The shared hook fed the raw search term into `new RegExp(term, "gi")`, so:

- `.` becomes a wildcard that matches every row → the filter does nothing (this is the reported "tag appears but list stays the same").
- `(`, `[`, etc. are invalid patterns → the filter throws and silently does nothing.

A `/g` regex reused across a row's values is also stateful (`lastIndex` carries between `.test()` calls), which can drop matches unpredictably.

## What

`front/src/shared/hooks/table/toolboxTable/useToolboxTableModel.ts`:

- `applyQueryTags` — replace the regex match with a case-insensitive **substring** match (`toLowerCase().includes()`). A search box should treat what the user types as literal text; this can't be thrown off by metacharacters or `/g` state.
- `handleChange` slice — `startIdx` was page-number based while `endIdx` came from `startPage` (an item offset). Unify to `endIdx = startIdx + pageSize`, and reset to the first page when a new search is applied.

## Verification

Ran the fixed image side-by-side with develop against the same dev API/DB (Playwright, workflow list — 18 rows, 2 pages):

- `.` search — develop keeps all 15 rows (1/2); fixed narrows correctly (1/1, NO_DATA).
- `bash` search — both 15 → 7 (no regression on plain text).
- multi-tag `sw` + `424669` — both narrow to 1 (AND intact).
- pagination — both 1p=15 / 2p=3, no duplicates or lost rows.

Local `npm ci` → lint + `vite build` pass.