### PR TITLE
fix(source): validate and send only user-edited fields on connection update

### DIFF
--- a/front/src/features/sourceServices/sourceConnection/ui/SourceConnectionForm.vue
+++ b/front/src/features/sourceServices/sourceConnection/ui/SourceConnectionForm.vue
@@ -6,7 +6,7 @@ import {
   PPaneLayout,
   PI,
 } from '@cloudforet-test/mirinae';
-import { reactive, watchEffect } from 'vue';
+import { computed, reactive, watchEffect } from 'vue';
 
 interface ConnectionInfo {
   id?: string;
@@ -24,12 +24,16 @@ interface Props {
   mode?: 'create' | 'edit';
   showDeleteButton?: boolean;
   readonly?: string[]; // readonly로 만들 필드 목록
+  // 이미 등록된 연결을 수정할 때, 서버에 저장된 값. 입력란을 채우지 않고
+  // placeholder 로만 보여주기 위한 것이라 절대 payload 에 쓰지 않는다.
+  existing?: Partial<ConnectionInfo> | null;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   mode: 'create',
   showDeleteButton: false,
   readonly: () => [],
+  existing: null,
   sourceConnection: () => ({
     name: '',
     description: '',
@@ -43,58 +47,113 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits(['delete', 'update:valid']);
 
+// 이미 등록된 연결의 수정인지. 이 경우 입력란은 비어서 열리고, 사용자가 실제로
+// 입력한 항목만 검증·전송한다. 입력하지 않은 항목은 기존 값이 그대로 유지된다.
+const isExistingEdit = computed(
+  () => props.mode === 'edit' && !!props.existing,
+);
+
+const KEEP_HINT = 'Leave blank to keep the current value';
+
+const placeholderFor = (field: keyof ConnectionInfo, fallback: string) => {
+  if (!isExistingEdit.value) return fallback;
+  const current = props.existing?.[field];
+  // 인증 항목은 서버가 암호화해 내려주므로 보여줄 평문이 없다.
+  return current !== undefined && current !== null && current !== ''
+    ? String(current)
+    : KEEP_HINT;
+};
+
+const isFilled = (value: unknown) =>
+  value !== undefined && value !== null && String(value).trim() !== '';
+
+const IPV4 = /^(\d{1,3}\.){3}\d{1,3}$/;
+
+const isIpValid = (value: unknown) => {
+  const raw = String(value ?? '').trim();
+  if (!IPV4.test(raw)) return false;
+  return raw.split('.').every(octet => Number(octet) <= 255);
+};
+
+// 포트는 1~65535 의 정수만 허용한다. 기존 조건은 유효한 65535 를 거부하는 한편
+// 소수·공백 섞인 값은 걸러내지 못했다.
+const isPortValid = (value: unknown) => {
+  const raw = String(value ?? '').trim();
+  if (!/^\d+$/.test(raw)) return false;
+  const port = Number(raw);
+  return port >= 1 && port <= 65535;
+};
+
 const invalidState = reactive({
   isIpAddressValid: false,
   isPortValid: false,
 });
 
-// 공통 Validation 로직
 watchEffect(() => {
-  if (!props.sourceConnection) {
-    console.log('[SourceConnectionForm] sourceConnection is null/undefined');
-    return;
+  const conn = props.sourceConnection;
+  if (!conn) return;
+
+  const ipFilled = isFilled(conn.ip_address);
+  const portFilled = isFilled(conn.ssh_port);
+
+  invalidState.isIpAddressValid = ipFilled && isIpValid(conn.ip_address);
+  invalidState.isPortValid = portFilled && isPortValid(conn.ssh_port);
+
+  let isValid: boolean;
+
+  if (isExistingEdit.value) {
+    // 사용자가 입력한 항목만 본다. 아무것도 입력하지 않았으면 바꿀 것이 없으므로
+    // 유효한 상태이고, 저장 시 이 행은 요청 자체를 보내지 않는다.
+    isValid =
+      (!ipFilled || invalidState.isIpAddressValid) &&
+      (!portFilled || invalidState.isPortValid);
+  } else {
+    // 신규 등록은 기존 규칙 그대로 — 아이디 필수 + 비밀번호나 개인키 중 하나.
+    isValid = Boolean(
+      isFilled(conn.name) &&
+        invalidState.isIpAddressValid &&
+        invalidState.isPortValid &&
+        isFilled(conn.user) &&
+        (isFilled(conn.password) || isFilled(conn.private_key)),
+    );
   }
 
-  console.log(
-    '[SourceConnectionForm] watchEffect triggered, sourceConnection:',
-    {
-      name: props.sourceConnection.name,
-      ip_address: props.sourceConnection.ip_address,
-      ssh_port: props.sourceConnection.ssh_port,
-      user: props.sourceConnection.user,
-      password: props.sourceConnection.password,
-    },
-  );
-
-  invalidState.isIpAddressValid =
-    props.sourceConnection.ip_address === '' ||
-    !props.sourceConnection.ip_address.match(/^(\d{1,3}\.){3}\d{1,3}$/)
-      ? false
-      : true;
-
-  if (typeof Number(props.sourceConnection.ssh_port) === 'number') {
-    invalidState.isPortValid =
-      Number(props.sourceConnection.ssh_port) > 0 &&
-      Number(props.sourceConnection.ssh_port) < 65535
-        ? true
-        : false;
-  }
-
-  // 전체 validation 상태를 parent에 emit
-  const isValid =
-    props.sourceConnection.name &&
-    invalidState.isIpAddressValid &&
-    invalidState.isPortValid &&
-    props.sourceConnection.user &&
-    (props.sourceConnection.password || props.sourceConnection.private_key);
-
-  console.log('[SourceConnectionForm] validation result:', {
-    isValid,
-    invalidState,
-  });
-
-  emit('update:valid', !!isValid);
+  emit('update:valid', isValid);
 });
+
+// 입력하지 않은 항목까지 빨갛게 보이지 않도록, 값이 있을 때만 오류로 표시한다.
+const showIpError = computed(
+  () =>
+    (isExistingEdit.value
+      ? isFilled(props.sourceConnection?.ip_address)
+      : true) && !invalidState.isIpAddressValid,
+);
+
+const showPortError = computed(
+  () =>
+    (isExistingEdit.value
+      ? isFilled(props.sourceConnection?.ssh_port)
+      : true) && !invalidState.isPortValid,
+);
+
+const showNameError = computed(
+  () => !isExistingEdit.value && !isFilled(props.sourceConnection?.name),
+);
+
+const showUserError = computed(
+  () => !isExistingEdit.value && !isFilled(props.sourceConnection?.user),
+);
+
+// 신규 등록에서 인증 조합이 성립하지 않는 경우. 아이디 없이 비밀번호만,
+// 또는 아이디 없이 개인키만은 서버가 거부한다.
+const showCredentialError = computed(
+  () =>
+    !isExistingEdit.value &&
+    !(
+      isFilled(props.sourceConnection?.password) ||
+      isFilled(props.sourceConnection?.private_key)
+    ),
+);
 
 const isFieldReadonly = (fieldName: string) => {
   return props.readonly.includes(fieldName);
@@ -109,69 +168,105 @@ const handleDelete = () => {
   <div class="source-connection-layout">
     <p-pane-layout class="source-connection-info">
       <div class="left-layer">
-        <p-field-group label="Source Connection Name" invalid required>
+        <p-field-group
+          label="Source Connection Name"
+          :invalid="showNameError"
+          :required="!isExistingEdit"
+        >
           <p-text-input
             v-model="sourceConnection.name"
             data-testid="source-connection-name"
-            placeholder="Source Connection Name"
-            :invalid="!sourceConnection.name"
+            :placeholder="placeholderFor('name', 'Source Connection Name')"
+            :invalid="showNameError"
             :disabled="isFieldReadonly('name')"
           />
         </p-field-group>
         <p-field-group label="Description">
           <p-textarea
             v-model="sourceConnection.description"
+            data-testid="source-connection-description"
+            :placeholder="placeholderFor('description', '')"
             :disabled="isFieldReadonly('description')"
           />
         </p-field-group>
       </div>
       <div class="right-layer">
-        <p-field-group label="IP Address" invalid required>
+        <p-field-group
+          label="IP Address"
+          :invalid="showIpError"
+          :required="!isExistingEdit"
+        >
           <p-text-input
             v-model="sourceConnection.ip_address"
             data-testid="source-connection-ip"
-            :invalid="!invalidState.isIpAddressValid"
-            placeholder="###.###.###.###"
+            :invalid="showIpError"
+            :placeholder="placeholderFor('ip_address', '###.###.###.###')"
             :disabled="isFieldReadonly('ip_address')"
           />
         </p-field-group>
-        <p-field-group label="Port (for SSH)" invalid required>
+        <p-field-group
+          label="Port (for SSH)"
+          :invalid="showPortError"
+          :required="!isExistingEdit"
+        >
           <p-text-input
             v-model="sourceConnection.ssh_port"
             data-testid="source-connection-ssh-port"
-            placeholder="1~65535"
-            :invalid="!invalidState.isPortValid"
+            :placeholder="placeholderFor('ssh_port', '1~65535')"
+            :invalid="showPortError"
             :disabled="isFieldReadonly('ssh_port')"
           />
         </p-field-group>
-        <p-field-group label="User" invalid required>
+        <p-field-group
+          label="User"
+          :invalid="showUserError"
+          :required="!isExistingEdit"
+        >
           <p-text-input
             v-model="sourceConnection.user"
             data-testid="source-connection-user"
-            placeholder="User ID"
-            :invalid="!sourceConnection.user"
+            :placeholder="isExistingEdit ? KEEP_HINT : 'User ID'"
+            :invalid="showUserError"
             :disabled="isFieldReadonly('user')"
           />
         </p-field-group>
-        <p-field-group label="Password">
+        <p-field-group
+          label="Password"
+          :invalid="showCredentialError"
+          :invalid-text="
+            showCredentialError
+              ? 'Enter User + Password or User + Private Key.'
+              : ''
+          "
+        >
           <p-text-input
             v-model="sourceConnection.password"
             data-testid="source-connection-password"
-            placeholder="Password"
+            :placeholder="isExistingEdit ? KEEP_HINT : 'Password'"
+            :invalid="showCredentialError"
             :disabled="isFieldReadonly('password')"
           />
         </p-field-group>
-        <p-field-group class="private-key" label="Private Key">
+        <p-field-group
+          class="private-key"
+          label="Private Key"
+          :invalid="showCredentialError"
+        >
           <p-textarea
             v-model="sourceConnection.private_key"
             data-testid="source-connection-private-key"
+            :placeholder="isExistingEdit ? KEEP_HINT : ''"
             :rows="5"
             :disabled="isFieldReadonly('private_key')"
           />
         </p-field-group>
       </div>
     </p-pane-layout>
-    <button v-if="showDeleteButton" @click="handleDelete">
+    <button
+      v-if="showDeleteButton"
+      data-testid="source-connection-remove-row"
+      @click="handleDelete"
+    >
       <p-i name="ic_close" />
     </button>
   </div>

--- a/front/src/widgets/source/sourceConnections/sourceConnectionModal/ui/EditSourceConnectionModal.vue
+++ b/front/src/widgets/source/sourceConnections/sourceConnectionModal/ui/EditSourceConnectionModal.vue
@@ -98,30 +98,35 @@ const sourceConnectionsByIds = ref<any[]>([]);
 const uniqueSourceConnectionsByIds = ref<any[]>([]);
 let isInitialized = false;
 
+// 이미 등록된 연결은 입력란을 모두 비운 채로 연다. 기존 값은 placeholder 로만
+// 보여주고, 사용자가 실제로 입력한 항목만 검증·전송한다. 특히 인증 3항목은
+// 서버가 암호화해 내려주므로 그 값을 입력란에 되돌려 넣으면 저장된 평문을
+// 암호문으로 덮어써 연결이 깨진다.
+const toEditableRow = (connId: string) => {
+  const stored = sourceConnectionStore.getConnectionById(connId) as any;
+  return {
+    _id: connectionIdCounter++,
+    id: stored?.id,
+    _original: stored,
+    name: '',
+    description: '',
+    ip_address: '',
+    ssh_port: '',
+    user: '',
+    password: '',
+    private_key: '',
+  };
+};
+
 // 선택된 Connection ID에 따라 데이터 로드
 watchEffect(() => {
   if (props.multiSelectedConnectionIds.length === 1) {
     sourceConnectionsByIds.value = [
-      {
-        _id: connectionIdCounter++,
-        ...sourceConnectionStore.getConnectionById(
-          props.multiSelectedConnectionIds[0],
-        ),
-        user: '',
-        password: '',
-        private_key: '',
-      },
+      toEditableRow(props.multiSelectedConnectionIds[0]),
     ];
   } else if (props.multiSelectedConnectionIds.length > 1) {
-    sourceConnectionsByIds.value = props.multiSelectedConnectionIds.map(
-      (connId: string) => ({
-        _id: connectionIdCounter++,
-        ...sourceConnectionStore.getConnectionById(connId),
-        user: '',
-        password: '',
-        private_key: '',
-      }),
-    );
+    sourceConnectionsByIds.value =
+      props.multiSelectedConnectionIds.map(toEditableRow);
   } else if (
     props.multiSelectedConnectionIds.length === 0 &&
     props.selectedConnectionId.length === 0
@@ -179,17 +184,43 @@ watchEffect(
   { flush: 'sync' },
 );
 
-// readonly 필드 계산 - 기존 connection 중 다중 선택 시에만 user, password, private_key readonly
+// 입력란이 비어 있으면 "그대로 두겠다"는 뜻이므로 요청에 담지 않는다.
+//
+// 이름은 뺀다. 연계 시스템이 커넥션 이름에 전역 유니크 제약을 걸어 두어
+// (`connection_infos.name`, 대소문자 무시) 다른 소스 그룹의 커넥션과도 부딪히는데,
+// 이 화면은 여러 건을 한 번에 저장하므로 중간에 실패하면 어디까지 반영됐는지
+// 알기 어렵다. 이름은 목록·상세의 개별 수정에서 한 건씩 처리한다.
+const UPDATABLE_FIELDS = [
+  'description',
+  'ip_address',
+  'ssh_port',
+  'user',
+  'password',
+  'private_key',
+] as const;
+
+const buildUpdateRequest = (info: any) => {
+  const request: Record<string, unknown> = {};
+  UPDATABLE_FIELDS.forEach(field => {
+    const value = info[field];
+    if (value === undefined || value === null) return;
+    const trimmed = String(value).trim();
+    if (trimmed === '') return;
+    // 입력했지만 기존 값과 같으면 보낼 이유가 없다.
+    const current = info._original?.[field];
+    if (current !== undefined && String(current) === trimmed) return;
+    request[field] = trimmed;
+  });
+  return request;
+};
+
+// 이미 등록된 연결은 이름을 잠근다. 이름 충돌은 저장 시점에야 서버가 알려주는데,
+// 이 화면은 여러 건을 순차 저장하므로 한 건이 실패해도 나머지가 이미 반영된
+// 뒤일 수 있다. 이름 변경은 목록·상세의 개별 수정에서 한 건씩 처리한다.
 const getReadonlyFields = (connection: any) => {
-  // 새로 추가하는 connection (id 없음)은 모든 필드 입력 가능
-  if (!connection.id) {
-    return [];
-  }
-  // 기존 connection이 2개 이상 선택되었을 때만 일부 필드 readonly
-  if (props.multiSelectedConnectionIds.length > 1) {
-    return ['user', 'password', 'private_key'];
-  }
-  return [];
+  // 새로 추가하는 연결은 이름을 입력해야 하므로 잠그지 않는다.
+  if (!connection.id) return [] as string[];
+  return ['name'];
 };
 
 const handleAddSourceConnection = async () => {
@@ -202,21 +233,20 @@ const handleAddSourceConnection = async () => {
     );
     const newConnections = connectionInfoData.value.filter(info => !info.id);
 
-    // 기존 connection 업데이트
+    // 기존 connection 업데이트 — 사용자가 실제로 입력한 항목만 담는다.
+    // 연계 시스템은 전달된 항목만 반영하고 나머지는 기존 값을 유지하므로,
+    // 빈 값을 함께 보낼 필요가 없다.
     for (const info of existingConnections) {
+      const request = buildUpdateRequest(info);
+      // 바꾼 것이 없으면 요청을 보내지 않는다.
+      if (Object.keys(request).length === 0) continue;
+
       await updateConnectionInfo.execute({
         pathParams: {
           sgId: props.sourceServiceId,
           connId: info.id,
         },
-        request: {
-          description: info.description,
-          ip_address: info.ip_address,
-          password: info.password,
-          private_key: info.private_key,
-          ssh_port: info.ssh_port,
-          user: info.user,
-        },
+        request,
       });
     }
 
@@ -249,7 +279,13 @@ const handleAddSourceConnection = async () => {
       (error as any).errorMsg?.value ===
       'constraint failed: UNIQUE constraint failed: connection_infos.name (2067)'
     ) {
-      showErrorMessage('failed', 'Connection Info Name Already Exists');
+      // 이름 유니크 제약은 소스 그룹 단위가 아니라 전체 범위이고 대소문자를
+      // 구분하지 않는다. 지금 보고 있는 그룹에 같은 이름이 없어도 다른 그룹의
+      // 연결과 부딪힐 수 있어, 어디서 충돌했는지 알 수 없는 채로 막힌다.
+      showErrorMessage(
+        'failed',
+        'Connection name already in use. Names must be unique across all source groups, ignoring case.',
+      );
     } else {
       showErrorMessage('failed', 'Connection Save Failed');
     }
@@ -284,6 +320,7 @@ const handleAddSourceConnection = async () => {
           <source-connection-form
             :source-connection="uniqueSourceConnectionsByIds[i]"
             mode="edit"
+            :existing="info._original ?? null"
             :show-delete-button="uniqueSourceConnectionsByIds.length > 1"
             :readonly="getReadonlyFields(info)"
             @delete="deleteSourceConnection(info._id || info.id)"


### PR DESCRIPTION
## 무엇이 문제였나

연결 정보를 수정할 때 **IP 주소 하나만 바꾸려 해도 아이디·비밀번호를 다시 입력해야** 저장할 수 있었습니다. 연결을 두 건 이상 선택하면 **저장 자체가 불가능**했습니다.

원인은 하나로 수렴합니다 — **수정 화면이 등록 화면과 같은 검증 로직을 쓰고 있었습니다.** 인증 항목은 연계 시스템이 암호화해서 내려주므로 화면에 미리 채울 수 없어 빈 칸으로 열리는데, 검증은 그 항목들을 여전히 필수로 요구했습니다. 검증이 *사용자가 입력한 값*이 아니라 *폼의 최종 상태*를 보고 있었던 것입니다.

## 무엇을 바꿨나

- 기존 연결은 **모든 입력란이 빈 상태로 열리고**, 저장된 값은 연한 안내 문구로 보여줍니다. 바꾼 항목과 그대로 두는 항목이 한눈에 구분됩니다.
- 검증과 요청 모두 **사용자가 입력했고 기존 값과 다른 항목만** 대상으로 합니다. 바꾼 것이 없으면 요청을 아예 보내지 않습니다. 연계 시스템이 전달된 항목만 반영하고 나머지는 유지하므로 동작이 일치합니다.
- **조회 응답의 인증 값을 입력란에 되돌려 넣지 않습니다.** 이 값들은 응답할 때만 암호화되고 저장은 평문이라, 되돌려 보내면 저장값이 암호문으로 덮여 연결이 끊깁니다.
- 기존 연결의 **이름은 잠갔습니다.** 이름 충돌은 저장 시점에야 드러나는데 이 화면은 여러 건을 순차 저장하므로, 중간에 실패하면 어디까지 반영됐는지 알기 어렵습니다. 이름 변경은 개별 수정 경로에서 처리합니다.
- **포트 검증을 1~65535 정수로 정합화**했습니다. 기존 조건은 유효한 65535를 거부하면서 소수·문자는 통과시켰습니다. IP는 각 옥텟 상한 255까지 검사합니다.

**등록 화면은 건드리지 않았습니다.** 등록 검증은 이미 연계 시스템 규칙과 일치하고, 재사용처가 많아 불필요한 회귀 위험을 만들지 않았습니다.

## 검증

개발 서버에 이 브랜치 빌드를 임시로 올리고 **실제 화면을 브라우저로 구동**해, 화면이 보내는 요청 본문을 가로채 확인했습니다. **16개 케이스 전건 PASS.**

| 확인 | 결과 |
|------|------|
| IP만 입력 후 저장 | 요청 본문이 `{"ip_address":"…"}` 하나뿐 |
| 아무것도 입력하지 않음 | 요청을 보내지 않음 |
| 연결 2건 선택 수정 | 저장됨 — 변경한 행의 변경한 항목만 전송 |
| 포트 `1`·`65535` / `0`·`65536`·`22.5`·`abc` | 허용 / 차단 |
| 잘못된 IP | 차단 (차단 상태 클릭 시 요청 미발생까지 확인) |
| **IP만 바꾼 뒤 실제 SSH 재연결** | **`success` 유지** |

마지막 항목이 핵심입니다. 인증 값이 덮였다면 SSH가 끊겼을 텐데 그대로 붙는다는 것이 보존됐다는 직접 증거입니다.

정적 검증은 타입 검사·린트·빌드 모두 통과했습니다.

---

- [BAR-1523](https://mzdevs.atlassian.net/browse/BAR-1523) 연결 정보 수정 시 입력한 항목만 검증·반영
- [BAR-1522](https://mzdevs.atlassian.net/browse/BAR-1522) 소스 그룹 / 연결 등록 관리 기능 개선 (Epic)
