### PR TITLE
feat(workload): track infra deletes on the server so any browser can resume

### DIFF
--- a/api/cmd/app/main.go
+++ b/api/cmd/app/main.go
@@ -96,6 +96,13 @@ func main() {
 	api.POST("/getworkspaceuserrolemappinglistbyuserid", workspaceHandler.GetWorkspaceUserRoleMappingListByUserId)
 
 	// API Test endpoints
+	// 워크로드 삭제 상태 추적 — 브라우저가 아니라 서버에 남겨 어느 자리에서든 이어받는다.
+	deleteRequestHandler := handler.NewDeleteRequestHandler(db)
+	api.POST("/listdeleterequests", deleteRequestHandler.ListDeleteRequests)
+	api.POST("/savedeleterequest", deleteRequestHandler.SaveDeleteRequest)
+	api.POST("/updatedeleterequeststatus", deleteRequestHandler.UpdateDeleteRequestStatus)
+	api.POST("/removedeleterequest", deleteRequestHandler.RemoveDeleteRequest)
+
 	api.POST("/test", handler.ApiTestController)
 
 	// API list endpoint (no auth required)

--- a/api/internal/handler/delete_request.go
+++ b/api/internal/handler/delete_request.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"log"
+
+	"api/internal/middleware"
+	"api/internal/model"
+	"api/internal/repository"
+	"api/internal/util/response"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// DeleteRequestHandler exposes the tracked infra deletes.
+//
+// These are shared, not per-user. A delete is something that happened to an infra, not a
+// private action: if one operator's delete failed, the next person to open the console
+// needs to see that too, otherwise they retry into the same wall.
+type DeleteRequestHandler struct {
+	repo *repository.DeleteRequestRepository
+}
+
+// NewDeleteRequestHandler creates a new DeleteRequestHandler
+func NewDeleteRequestHandler(db *gorm.DB) *DeleteRequestHandler {
+	return &DeleteRequestHandler{repo: repository.NewDeleteRequestRepository(db)}
+}
+
+// DeleteRequestPayload is what the console sends when recording or updating a delete.
+type DeleteRequestPayload struct {
+	Uid         string `json:"uid"`
+	NsId        string `json:"ns_id"`
+	InfraId     string `json:"infra_id"`
+	ReqId       string `json:"req_id"`
+	Option      string `json:"option"`
+	Status      string `json:"status"`
+	ErrorReason string `json:"error_reason"`
+}
+
+// UidPayload identifies a tracked delete by infra uid.
+type UidPayload struct {
+	Uid string `json:"uid"`
+}
+
+// ListDeleteRequests returns every tracked delete.
+//
+// The console calls this on start-up and after login so that any browser resumes watching
+// whatever is still in flight, and shows failures that happened while nobody was looking.
+func (h *DeleteRequestHandler) ListDeleteRequests(c echo.Context) error {
+	reqs, err := h.repo.FindAll()
+	if err != nil {
+		log.Printf("Failed to list delete requests: %v", err)
+		return c.JSON(500, response.CommonResponseStatusInternalServerError(err.Error()))
+	}
+	return c.JSON(200, response.CommonResponseStatusOK(reqs))
+}
+
+// SaveDeleteRequest records a delete, replacing any earlier attempt on the same infra.
+//
+// Keyed by uid rather than name: in cb-tumblebug an infra's id is its name, so deleting
+// "infra101" and creating another "infra101" would otherwise inherit the old record.
+func (h *DeleteRequestHandler) SaveDeleteRequest(c echo.Context) error {
+	payload := new(DeleteRequestPayload)
+	if err := c.Bind(payload); err != nil {
+		return c.JSON(400, response.CommonResponseStatusBadRequest(err.Error()))
+	}
+	if payload.Uid == "" || payload.ReqId == "" {
+		return c.JSON(400, response.CommonResponseStatusBadRequest("uid and req_id are required"))
+	}
+
+	requestedBy, _ := c.Get(middleware.ContextKeyUserID).(string)
+	status := payload.Status
+	if status == "" {
+		status = model.DeleteStatusHandling
+	}
+
+	req := &model.DeleteRequest{
+		Uid:         payload.Uid,
+		NsId:        payload.NsId,
+		InfraId:     payload.InfraId,
+		ReqId:       payload.ReqId,
+		Option:      payload.Option,
+		Status:      status,
+		ErrorReason: payload.ErrorReason,
+		RequestedBy: requestedBy,
+	}
+	if err := h.repo.Upsert(req); err != nil {
+		log.Printf("Failed to save delete request: %v", err)
+		return c.JSON(500, response.CommonResponseStatusInternalServerError(err.Error()))
+	}
+	return c.JSON(200, response.CommonResponseStatusOK(req))
+}
+
+// UpdateDeleteRequestStatus moves a tracked delete to failed or unknown.
+//
+// Success is not an update - it deletes the row (see RemoveDeleteRequest). There is nothing
+// to show for a delete that worked: the infra is gone from the list.
+func (h *DeleteRequestHandler) UpdateDeleteRequestStatus(c echo.Context) error {
+	payload := new(DeleteRequestPayload)
+	if err := c.Bind(payload); err != nil {
+		return c.JSON(400, response.CommonResponseStatusBadRequest(err.Error()))
+	}
+	if payload.Uid == "" || payload.Status == "" {
+		return c.JSON(400, response.CommonResponseStatusBadRequest("uid and status are required"))
+	}
+	if err := h.repo.UpdateStatus(payload.Uid, payload.Status, payload.ErrorReason); err != nil {
+		log.Printf("Failed to update delete request: %v", err)
+		return c.JSON(500, response.CommonResponseStatusInternalServerError(err.Error()))
+	}
+	return c.JSON(200, response.CommonResponseStatusOK("updated"))
+}
+
+// RemoveDeleteRequest drops a tracked delete.
+//
+// Called when the delete succeeded, when the user retries (the new attempt replaces it), or
+// when the infra is no longer listed because it was removed some other way.
+func (h *DeleteRequestHandler) RemoveDeleteRequest(c echo.Context) error {
+	payload := new(UidPayload)
+	if err := c.Bind(payload); err != nil {
+		return c.JSON(400, response.CommonResponseStatusBadRequest(err.Error()))
+	}
+	if payload.Uid == "" {
+		return c.JSON(400, response.CommonResponseStatusBadRequest("uid is required"))
+	}
+	if err := h.repo.DeleteByUid(payload.Uid); err != nil {
+		log.Printf("Failed to remove delete request: %v", err)
+		return c.JSON(500, response.CommonResponseStatusInternalServerError(err.Error()))
+	}
+	return c.JSON(200, response.CommonResponseStatusOK("removed"))
+}

--- a/api/internal/model/db.go
+++ b/api/internal/model/db.go
@@ -30,7 +30,7 @@ func InitDB(cfg *config.Config) (*gorm.DB, error) {
 		}
 
 		// Auto-migrate the schema
-		if err = db.AutoMigrate(&Usersess{}); err != nil {
+		if err = db.AutoMigrate(&Usersess{}, &DeleteRequest{}); err != nil {
 			log.Printf("Failed to auto-migrate: %v", err)
 			return
 		}

--- a/api/internal/model/delete_request.go
+++ b/api/internal/model/delete_request.go
@@ -1,0 +1,77 @@
+package model
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+	"gorm.io/gorm"
+)
+
+// DeleteRequest tracks an in-flight or failed infra delete so the console can pick it up
+// again from any browser.
+//
+// Why this lives in the database rather than the browser: a delete takes minutes and can
+// fail. The request id is the only handle for asking cm-beetle what happened, and keeping
+// it in local storage means a different browser - or the same user after logging out -
+// has no way to learn that a delete failed, or why.
+//
+// Keyed by Uid, not by the infra name. In cb-tumblebug an infra's id *is* its name, so
+// deleting "infra101" and creating another "infra101" would make the old record look like
+// it belongs to the new infra. The uid stays unique across that.
+type DeleteRequest struct {
+	ID uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+
+	// Uid is cb-tumblebug's stable identifier for the infra - the key we match list rows on.
+	Uid string `gorm:"column:uid;type:text;uniqueIndex" json:"uid"`
+
+	// NsId and InfraId are what the APIs actually take. InfraId is the infra *name*, kept
+	// for calling cm-beetle and for showing the user which infra this was.
+	NsId    string `gorm:"column:ns_id;type:text" json:"ns_id"`
+	InfraId string `gorm:"column:infra_id;type:text" json:"infra_id"`
+
+	// ReqId is the X-Request-Id sent with the delete. Only the latest one is kept - asking
+	// about an earlier attempt tells us nothing once the user has retried.
+	ReqId string `gorm:"column:req_id;type:text" json:"req_id"`
+
+	// Option records whether this was a normal or forced delete, so the UI can say which
+	// one left CSP resources behind.
+	Option string `gorm:"column:option;type:text" json:"option"`
+
+	// Status is Handling, Error, or Unknown. Success is never stored - a successful delete
+	// removes the row, since the infra is gone from the list and there is nothing to show.
+	// Unknown means cm-beetle no longer knows the request id (it does not survive a restart)
+	// and the infra is still listed, so we cannot tell how it ended.
+	Status string `gorm:"column:status;type:text" json:"status"`
+
+	// ErrorReason is what cm-beetle reported. This is the part users cannot get anywhere
+	// else once the request record is gone.
+	ErrorReason string `gorm:"column:error_reason;type:text" json:"error_reason"`
+
+	RequestedBy string    `gorm:"column:requested_by;type:text" json:"requested_by"`
+	CreatedAt   time.Time `gorm:"column:created_at" json:"created_at"`
+	UpdatedAt   time.Time `gorm:"column:updated_at" json:"updated_at"`
+}
+
+// Delete request status values.
+const (
+	DeleteStatusHandling = "Handling"
+	DeleteStatusError    = "Error"
+	DeleteStatusUnknown  = "Unknown"
+)
+
+// TableName specifies the table name for GORM
+func (DeleteRequest) TableName() string {
+	return "delete_requests"
+}
+
+// BeforeCreate is a GORM hook to generate UUID before creating a record
+func (d *DeleteRequest) BeforeCreate(tx *gorm.DB) error {
+	if d.ID == uuid.Nil {
+		newUUID, err := uuid.NewV4()
+		if err != nil {
+			return err
+		}
+		d.ID = newUUID
+	}
+	return nil
+}

--- a/api/internal/repository/delete_request_repository.go
+++ b/api/internal/repository/delete_request_repository.go
@@ -1,0 +1,81 @@
+package repository
+
+import (
+	"api/internal/model"
+
+	"gorm.io/gorm"
+)
+
+// DeleteRequestRepository handles database operations for DeleteRequest
+type DeleteRequestRepository struct {
+	db *gorm.DB
+}
+
+// NewDeleteRequestRepository creates a new DeleteRequestRepository
+func NewDeleteRequestRepository(db *gorm.DB) *DeleteRequestRepository {
+	return &DeleteRequestRepository{db: db}
+}
+
+// FindAll returns every tracked delete request.
+//
+// The console asks for this on start-up and after logging in, so whichever browser is open
+// picks up whatever was left unfinished. Only in-flight and failed deletes are ever stored,
+// so this stays small.
+func (r *DeleteRequestRepository) FindAll() ([]model.DeleteRequest, error) {
+	var reqs []model.DeleteRequest
+	err := r.db.Order("created_at desc").Find(&reqs).Error
+	return reqs, err
+}
+
+// FindByUid finds a tracked delete request by infra uid
+func (r *DeleteRequestRepository) FindByUid(uid string) (*model.DeleteRequest, error) {
+	var req model.DeleteRequest
+	if err := r.db.Where("uid = ?", uid).First(&req).Error; err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+// Upsert stores a delete request, replacing any earlier one for the same infra.
+//
+// Re-deleting an infra makes the previous attempt irrelevant: its request id answers a
+// question nobody is asking any more. Keeping one row per infra also means the list only
+// ever has one state to show per row.
+func (r *DeleteRequestRepository) Upsert(req *model.DeleteRequest) error {
+	existing, err := r.FindByUid(req.Uid)
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return r.db.Create(req).Error
+		}
+		return err
+	}
+
+	existing.NsId = req.NsId
+	existing.InfraId = req.InfraId
+	existing.ReqId = req.ReqId
+	existing.Option = req.Option
+	existing.Status = req.Status
+	existing.ErrorReason = req.ErrorReason
+	if req.RequestedBy != "" {
+		existing.RequestedBy = req.RequestedBy
+	}
+	return r.db.Save(existing).Error
+}
+
+// UpdateStatus updates the status (and failure reason) of a tracked delete request
+func (r *DeleteRequestRepository) UpdateStatus(uid, status, errorReason string) error {
+	return r.db.Model(&model.DeleteRequest{}).
+		Where("uid = ?", uid).
+		Updates(map[string]any{
+			"status":       status,
+			"error_reason": errorReason,
+		}).Error
+}
+
+// DeleteByUid removes a tracked delete request.
+//
+// Called when the delete succeeded, or when the infra is no longer listed at all - someone
+// removed it another way, so there is nothing left to report.
+func (r *DeleteRequestRepository) DeleteByUid(uid string) error {
+	return r.db.Where("uid = ?", uid).Delete(&model.DeleteRequest{}).Error
+}

--- a/front/src/entities/mci/api/deleteRequest.ts
+++ b/front/src/entities/mci/api/deleteRequest.ts
@@ -1,0 +1,59 @@
+import { IAxiosResponse, useAxiosPost } from '@/shared/libs';
+
+/**
+ * 삭제 요청 추적 저장소 API (cm-butterfly 자체 도메인).
+ *
+ * 프록시(`cm-beetle/*`)가 아니라 우리 백엔드의 자체 엔드포인트다. 삭제 요청 id 를 서버에 두는
+ * 이유는 **어느 브라우저에서 접속하든 하던 처리를 이어받기 위해서**다. 브라우저에만 두면 다른
+ * 자리에서는 삭제가 실패한 사실도, 그 사유도 알 수 없다.
+ */
+
+export type DeleteRequestStatus = 'Handling' | 'Error' | 'Unknown';
+
+export interface DeleteRequestRecord {
+  uid: string;
+  ns_id: string;
+  infra_id: string;
+  req_id: string;
+  option: string;
+  status: DeleteRequestStatus;
+  error_reason: string;
+  requested_by?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/** 추적 중인 삭제 전체 조회 — 앱 시작·로그인 시 밀린 것을 이어받는다. */
+export function useListDeleteRequests() {
+  return useAxiosPost<IAxiosResponse<DeleteRequestRecord[]>, any>(
+    'listdeleterequests',
+    {},
+  );
+}
+
+/** 삭제 요청 기록(같은 인프라의 이전 기록은 새 요청으로 대체된다). */
+export function useSaveDeleteRequest(payload: Partial<DeleteRequestRecord>) {
+  return useAxiosPost<IAxiosResponse<DeleteRequestRecord>, any>(
+    'savedeleterequest',
+    payload,
+  );
+}
+
+/** 상태 갱신 — 실패(Error)·판단 불가(Unknown) 로만 옮긴다. 성공은 기록을 지운다. */
+export function useUpdateDeleteRequestStatus(
+  uid: string,
+  status: DeleteRequestStatus,
+  errorReason?: string,
+) {
+  return useAxiosPost<IAxiosResponse<string>, any>(
+    'updatedeleterequeststatus',
+    { uid, status, error_reason: errorReason ?? '' },
+  );
+}
+
+/** 기록 제거 — 삭제 성공, 또는 인프라가 목록에서 사라진 경우. */
+export function useRemoveDeleteRequest(uid: string) {
+  return useAxiosPost<IAxiosResponse<string>, any>('removedeleterequest', {
+    uid,
+  });
+}

--- a/front/src/entities/mci/lib/deleteTracker.ts
+++ b/front/src/entities/mci/lib/deleteTracker.ts
@@ -1,90 +1,243 @@
 import { reactive } from 'vue';
+import {
+  useListDeleteRequests,
+  useSaveDeleteRequest,
+  useUpdateDeleteRequestStatus,
+  useRemoveDeleteRequest,
+  type DeleteRequestRecord,
+  type DeleteRequestStatus,
+} from '@/entities/mci/api/deleteRequest';
+import { useGetBeetleRequest, useGetMciList } from '@/entities/mci/api';
 
-// 워크로드(인프라) 삭제 요청 추적 (BAR-1444)
-//
-// 삭제는 오래 걸리고(하류 수 분~수십 분) 비동기다. 사용자가 기다리다 다른 화면으로 가거나
-// 새로고침해도 "무엇이 삭제 중인지"를 알 수 있어야 하고, 같은 대상에 삭제 명령이 두 번 나가면
-// 안 된다. 그래서 삭제 요청을 infraId 별로 브라우저(localStorage)에 보관하고, 목록·상세가
-// 같은 기록을 본다. cm-beetle 의 요청 추적(reqId)과 짝을 이룬다.
+/**
+ * 워크로드(인프라) 삭제 추적 (BAR-1444 → BAR-1531)
+ *
+ * 삭제는 수 분 걸리고 실패할 수 있어서, 요청을 내고 끝이 아니라 *결과를 끝까지 따라가야* 한다.
+ * 이 모듈이 그 역할을 하며 두 가지가 핵심이다.
+ *
+ * **서버에 보관한다** — 요청 id 를 브라우저에만 두면 다른 PC 에서는 삭제가 실패한 사실도, 그 사유도
+ * 알 수 없다. 서버에 두면 어느 자리에서 로그인하든 하던 처리를 이어받는다.
+ *
+ * **화면과 무관하게 돈다** — 폴링이 목록 화면 안에 있으면 다른 화면으로 가는 순간 추적이 멈추고,
+ * 한참 뒤 목록에 돌아와서야 조회를 시작해 뒤늦게 반영된다. 그래서 컴포넌트가 아니라 이 모듈이
+ * 폴링을 소유한다. 앱이 떠 있는 동안 계속 돈다.
+ *
+ * 키는 인프라 이름이 아니라 **uid** 다. cb-tumblebug 에서 인프라 id 는 곧 이름이라, 지우고 같은
+ * 이름으로 다시 만들면 옛 기록이 새 인프라 것으로 보인다.
+ */
 
-export type DeleteStatus = 'Handling' | 'Success' | 'Error';
+export type DeleteStatus = DeleteRequestStatus;
 
 export interface DeleteRecord {
-  infraId: string;
+  uid: string;
   nsId: string;
+  infraId: string;
   reqId: string;
   option: string; // 'terminate' | 'force'
-  requestedAt: number;
   status: DeleteStatus;
-  errorReason?: string; // beetle/tumblebug 이 준 실패 사유 (있을 때만)
-  // 진행 단계(예: "deleting SG"). 현재 cb-tumblebug·cm-beetle 은 *삭제* 경로에서
-  // 단계별 진행을 내보내지 않으므로(생성 경로에만 있음) 채워지지 않는다. 업스트림이
-  // 삭제에도 progress 를 넣으면 그때 활용할 예약 필드다.
-  stage?: string;
+  errorReason?: string;
 }
 
-const STORAGE_KEY = 'cmig.mci.deleteRequests';
-
-function readStorage(): Record<string, DeleteRecord> {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as Record<string, DeleteRecord>) : {};
-  } catch {
-    return {};
-  }
-}
-
-// 모든 컴포넌트가 공유하는 반응형 상태. 최초 1회 localStorage 에서 채운다.
 const state = reactive<{ records: Record<string, DeleteRecord> }>({
-  records: readStorage(),
+  records: {},
 });
 
-function persist() {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state.records));
-  } catch {
-    /* 용량 초과 등은 무시 — 메모리 상태로는 계속 동작 */
-  }
+/** 서버 응답(snake_case)을 화면이 쓰는 형태로 옮긴다. */
+function fromRecord(r: DeleteRequestRecord): DeleteRecord {
+  return {
+    uid: r.uid,
+    nsId: r.ns_id,
+    infraId: r.infra_id,
+    reqId: r.req_id,
+    option: r.option,
+    status: r.status,
+    errorReason: r.error_reason || undefined,
+  };
 }
 
-/** 삭제 요청 기록을 저장(또는 갱신)한다. */
-export function putDeleteRecord(rec: DeleteRecord): void {
-  state.records[rec.infraId] = rec;
-  persist();
-}
-
-/** 해당 인프라의 삭제 기록을 반환(없으면 undefined). */
-export function getDeleteRecord(infraId: string): DeleteRecord | undefined {
-  return state.records[infraId];
-}
-
-/** 진행 중(Handling)인 삭제가 있으면 true — 중복 삭제 방어에 쓴다. */
-export function isDeleteInProgress(infraId: string): boolean {
-  return state.records[infraId]?.status === 'Handling';
-}
-
-/** 상태만 갱신한다(사유 포함). 기록이 없으면 무시. */
-export function updateDeleteStatus(
-  infraId: string,
-  status: DeleteStatus,
-  errorReason?: string,
-): void {
-  const rec = state.records[infraId];
-  if (!rec) return;
-  rec.status = status;
-  if (errorReason !== undefined) rec.errorReason = errorReason;
-  persist();
-}
-
-/** 기록을 지운다(삭제 완료로 목록에서 사라졌거나, 정리 시). */
-export function clearDeleteRecord(infraId: string): void {
-  if (state.records[infraId]) {
-    delete state.records[infraId];
-    persist();
-  }
-}
-
-/** 현재 보관된 삭제 기록 전체(목록 렌더링·폴링 대상 판단용). */
+/** 현재 추적 중인 기록 전체(목록 렌더용). */
 export function allDeleteRecords(): DeleteRecord[] {
   return Object.values(state.records);
+}
+
+/** uid 로 기록 조회. */
+export function getDeleteRecord(uid: string): DeleteRecord | undefined {
+  return state.records[uid];
+}
+
+/** 진행 중인 삭제가 있으면 true — 중복 요청 방어에 쓴다. */
+export function isDeleteInProgress(uid: string): boolean {
+  return state.records[uid]?.status === 'Handling';
+}
+
+/** 삭제 요청을 서버에 기록한다(같은 인프라의 이전 기록은 대체된다). */
+export async function putDeleteRecord(rec: DeleteRecord): Promise<void> {
+  state.records[rec.uid] = rec;
+  try {
+    await useSaveDeleteRequest({
+      uid: rec.uid,
+      ns_id: rec.nsId,
+      infra_id: rec.infraId,
+      req_id: rec.reqId,
+      option: rec.option,
+      status: rec.status,
+      error_reason: rec.errorReason ?? '',
+    }).execute();
+  } catch (e) {
+    // 서버 기록에 실패해도 이번 화면에서는 진행 상태를 보여준다. 다만 다른 자리에서는 보이지
+    // 않게 되므로 조용히 넘기지 않고 남긴다.
+    console.error('[deleteTracker] 삭제 요청 기록 실패', e);
+  }
+}
+
+/** 기록을 지운다 — 삭제가 성공했거나, 인프라가 목록에서 사라진 경우. */
+export async function clearDeleteRecord(uid: string): Promise<void> {
+  delete state.records[uid];
+  try {
+    await useRemoveDeleteRequest(uid).execute();
+  } catch (e) {
+    console.error('[deleteTracker] 삭제 기록 제거 실패', e);
+  }
+}
+
+/** 상태를 갱신한다. 성공은 여기로 오지 않는다 — 성공하면 기록 자체를 지운다. */
+async function markStatus(
+  uid: string,
+  status: DeleteStatus,
+  errorReason?: string,
+): Promise<void> {
+  const rec = state.records[uid];
+  if (rec) {
+    rec.status = status;
+    if (errorReason !== undefined) rec.errorReason = errorReason;
+  }
+  try {
+    await useUpdateDeleteRequestStatus(uid, status, errorReason).execute();
+  } catch (e) {
+    console.error('[deleteTracker] 삭제 상태 갱신 실패', e);
+  }
+}
+
+/** 삭제가 실패했음을 기록한다(사유 포함). 목록의 `삭제 상태` 가 이 값을 보여준다. */
+export async function markDeleteFailed(
+  uid: string,
+  errorReason?: string,
+): Promise<void> {
+  await markStatus(uid, 'Error', errorReason);
+}
+
+/** 서버에 남아 있는 추적 기록을 받아 온다(앱 시작·로그인 시). */
+export async function loadDeleteRecords(): Promise<void> {
+  try {
+    const res: any = await useListDeleteRequests().execute();
+    const list: DeleteRequestRecord[] =
+      res?.data?.responseData ?? res?.data?.data ?? res?.data ?? [];
+    const next: Record<string, DeleteRecord> = {};
+    for (const r of Array.isArray(list) ? list : []) {
+      next[r.uid] = fromRecord(r);
+    }
+    state.records = next;
+  } catch (e) {
+    console.error('[deleteTracker] 추적 기록 조회 실패', e);
+  }
+}
+
+// ── 폴링 ────────────────────────────────────────────────────────────────────
+
+/**
+ * 삭제는 오래 걸리므로 자주 물을 이유가 없다. 그리고 **이전 조회가 끝난 뒤 다음을 예약**한다 —
+ * setInterval 로 두면 응답이 주기보다 느릴 때 조회가 겹친다.
+ */
+const POLL_INTERVAL_MS = 10_000;
+
+let pollTimer: ReturnType<typeof setTimeout> | null = null;
+let running = false;
+
+/** 해당 인프라가 아직 목록에 있는지 확인한다(판단 불가 상황을 가르는 기준). */
+async function infraStillListed(rec: DeleteRecord): Promise<boolean> {
+  try {
+    const res: any = await useGetMciList(rec.nsId, '').execute();
+    const data =
+      res?.data?.responseData?.data ?? res?.data?.data ?? res?.data ?? {};
+    const list = data?.infra ?? data?.mci ?? [];
+    return (Array.isArray(list) ? list : []).some(
+      (m: any) => m?.uid === rec.uid,
+    );
+  } catch {
+    // 목록 조회 자체가 실패하면 판단하지 않는다(다음 주기에 다시 본다).
+    return true;
+  }
+}
+
+/** 진행 중인 삭제 하나의 결과를 확인한다. */
+async function checkOne(rec: DeleteRecord): Promise<void> {
+  try {
+    const res: any = await useGetBeetleRequest(rec.reqId).execute();
+    const details =
+      res?.data?.responseData?.data ??
+      res?.data?.data ??
+      res?.data?.responseData ??
+      res?.data ??
+      res;
+    const status = String(details?.status ?? '').toLowerCase();
+
+    if (status === 'success') {
+      // 성공은 남길 것이 없다 — 인프라가 목록에서 사라지므로 보여줄 대상도 없다.
+      await clearDeleteRecord(rec.uid);
+    } else if (status === 'error') {
+      await markStatus(rec.uid, 'Error', details?.errorResponse || undefined);
+    }
+    // Handling 이면 그대로 두고 다음 주기에 다시 본다.
+  } catch {
+    // 조회가 실패했다. cm-beetle 의 요청 기록은 재시작을 넘기지 못하므로, 정상적으로 처리된
+    // 요청인데도 여기로 올 수 있다. 그래서 실패로 단정하지 않고 *인프라가 아직 있는지*로 가른다.
+    const listed = await infraStillListed(rec);
+    if (!listed) {
+      // 인프라가 없다 = 어떤 경로로든 지워졌다. 남겨 둘 이유가 없다.
+      await clearDeleteRecord(rec.uid);
+    } else {
+      // 인프라는 있는데 요청 기록이 없다 → 성공인지 실패인지 알 수 없다.
+      await markStatus(rec.uid, 'Unknown');
+    }
+  }
+}
+
+/** 한 바퀴 — 진행 중인 것만 순서대로 확인한다. */
+async function pollOnce(): Promise<void> {
+  const handling = allDeleteRecords().filter(r => r.status === 'Handling');
+  for (const rec of handling) {
+    await checkOne(rec);
+  }
+}
+
+function scheduleNext(): void {
+  if (!running) return;
+  pollTimer = setTimeout(async () => {
+    await pollOnce();
+    scheduleNext();
+  }, POLL_INTERVAL_MS);
+}
+
+/**
+ * 추적을 시작한다 — 앱이 뜰 때와 로그인 직후에 부른다.
+ *
+ * 먼저 서버 기록을 받아 **즉시 한 번 확인**한다. 주기만 걸어 두면 첫 확인까지 그 시간만큼 낡은
+ * 상태를 보여주게 되는데, 서버에서는 이미 끝났을 수 있다.
+ */
+export async function startDeleteTracking(): Promise<void> {
+  if (running) return;
+  running = true;
+  await loadDeleteRecords();
+  await pollOnce();
+  scheduleNext();
+}
+
+/** 추적을 멈춘다(로그아웃 시). */
+export function stopDeleteTracking(): void {
+  running = false;
+  if (pollTimer) {
+    clearTimeout(pollTimer);
+    pollTimer = null;
+  }
+  state.records = {};
 }

--- a/front/src/entities/user/store/authenticationStore.ts
+++ b/front/src/entities/user/store/authenticationStore.ts
@@ -1,4 +1,8 @@
 import { defineStore } from 'pinia';
+import {
+  startDeleteTracking,
+  stopDeleteTracking,
+} from '@/entities/mci/lib/deleteTracker';
 
 export const useAuthenticationStore = defineStore('authentication', {
   state: () => ({
@@ -9,9 +13,14 @@ export const useAuthenticationStore = defineStore('authentication', {
   actions: {
     onLogin() {
       this.login = true;
+      // 로그인 시점이 삭제 추적의 트리거다. 서버에 남아 있는 요청이 있으면 어느 브라우저에서
+      // 접속했든 여기서 이어받아 확인한다 — 앞서 다른 자리에서 낸 삭제가 끝났는지 실패했는지를
+      // 워크로드 화면에 들어가기 *전에* 정리해 둔다.
+      void startDeleteTracking();
     },
     onLogout() {
       this.login = false;
+      stopDeleteTracking();
     },
   },
 });

--- a/front/src/entities/user/store/authenticationStore.ts
+++ b/front/src/entities/user/store/authenticationStore.ts
@@ -1,8 +1,4 @@
 import { defineStore } from 'pinia';
-import {
-  startDeleteTracking,
-  stopDeleteTracking,
-} from '@/entities/mci/lib/deleteTracker';
 
 export const useAuthenticationStore = defineStore('authentication', {
   state: () => ({
@@ -13,14 +9,9 @@ export const useAuthenticationStore = defineStore('authentication', {
   actions: {
     onLogin() {
       this.login = true;
-      // 로그인 시점이 삭제 추적의 트리거다. 서버에 남아 있는 요청이 있으면 어느 브라우저에서
-      // 접속했든 여기서 이어받아 확인한다 — 앞서 다른 자리에서 낸 삭제가 끝났는지 실패했는지를
-      // 워크로드 화면에 들어가기 *전에* 정리해 둔다.
-      void startDeleteTracking();
     },
     onLogout() {
       this.login = false;
-      stopDeleteTracking();
     },
   },
 });

--- a/front/src/shared/libs/store/auth/index.ts
+++ b/front/src/shared/libs/store/auth/index.ts
@@ -1,5 +1,9 @@
 import { defineStore } from 'pinia';
 import { IUserLoginResponse } from '@/entities';
+import {
+  startDeleteTracking,
+  stopDeleteTracking,
+} from '@/entities/mci/lib/deleteTracker';
 
 export type AuthorizationType = null | 'admin' | 'client';
 
@@ -19,9 +23,14 @@ export const useAuthStore = defineStore('auth', {
       this.id = loginData.id;
       this.role = loginData.role;
       this.isLogin = true;
+      // 로그인 시점이 삭제 추적의 트리거다. 서버에 남아 있는 요청이 있으면 어느 브라우저에서
+      // 접속했든 여기서 이어받아 확인한다 — 앞서 다른 자리에서 낸 삭제가 끝났는지 실패했는지를
+      // 워크로드 화면에 들어가기 *전에* 정리해 둔다.
+      void startDeleteTracking();
     },
     onLogout() {
       this.isLogin = false;
+      stopDeleteTracking();
     },
   },
 });

--- a/front/src/widgets/workload/mci/mciList/model/index.ts
+++ b/front/src/widgets/workload/mci/mciList/model/index.ts
@@ -59,6 +59,9 @@ export function useMciListModel(props: IProps) {
         name: mciRes.name,
         description: mciRes.description,
         id: mciRes.id,
+        // 삭제 추적의 키. id 는 곧 이름이라 지우고 같은 이름으로 다시 만들면 겹치므로,
+        // 행을 고유하게 가리키려면 uid 가 필요하다(BAR-1531).
+        uid: mciRes.uid,
         status: mciRes.status,
         provider: getCloudProvidersInVms(mciRes.vm),
         countTotal: statusCount.countTotal ?? '',
@@ -80,8 +83,7 @@ export function useMciListModel(props: IProps) {
           // tb-0.12.9 현행화: MCI 목록이 cm-beetle ListInfra 경유로 바뀌며 응답이 cm-beetle 표준
           // 래퍼(responseData.data.infra[])로 온다. 구 tumblebug 직접 응답(responseData.infra)도
           // fallback으로 허용해 양쪽을 안전하게 읽는다. (mci→infra 키 전환 + data 래퍼 반영)
-          const infraList =
-            res.data.responseData.data?.infra ?? [];
+          const infraList = res.data.responseData.data?.infra ?? [];
           mciStore.setMcis(infraList);
 
           const PromiseArr: any = [];

--- a/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
@@ -11,7 +11,8 @@ import { computed, reactive, ref, watch } from 'vue';
 import { useDeleteMci } from '@/entities/mci/api';
 import {
   putDeleteRecord,
-  updateDeleteStatus,
+  clearDeleteRecord,
+  markDeleteFailed,
   getDeleteRecord,
   isDeleteInProgress,
   type DeleteRecord,
@@ -92,46 +93,45 @@ function newReqId(): string {
 }
 
 // 지정한 인프라들에 삭제 요청을 낸다(옵션: terminate|force). 진행 기록을 남기고 추적한다.
-function fireDeletes(mciNames: string[], option: string): string[] {
-  const ids: string[] = [];
-  for (const infraId of mciNames) {
+function fireDeletes(mciList: any[], option: string): string[] {
+  const uids: string[] = [];
+  for (const mci of mciList) {
+    const uid = mci?.uid as string;
+    const infraId = mci?.name as string;
+    // uid 가 없으면 추적할 방법이 없다(이름은 재사용되므로 키가 될 수 없다).
+    if (!uid) continue;
+
     // 이미 진행 중이면 새 요청을 내지 않고(중복 방어) 그 기록을 그대로 추적한다.
-    if (isDeleteInProgress(infraId)) {
-      ids.push(infraId);
+    if (isDeleteInProgress(uid)) {
+      uids.push(uid);
       continue;
     }
     const reqId = newReqId();
     putDeleteRecord({
+      uid,
       infraId,
       nsId: props.nsId,
       reqId,
       option,
-      requestedAt: Date.now(),
       status: 'Handling',
     });
     useDeleteMci({ nsId: props.nsId, infraId, option }, reqId)
       .execute()
-      .then(() => updateDeleteStatus(infraId, 'Success'))
+      // 성공은 기록을 남기지 않는다 — 인프라가 목록에서 사라지므로 보여줄 대상이 없다.
+      .then(() => clearDeleteRecord(uid))
       .catch((error: any) =>
-        updateDeleteStatus(
-          infraId,
-          'Error',
-          extractErrorMessage(error) ?? undefined,
-        ),
+        markDeleteFailed(uid, extractErrorMessage(error) ?? undefined),
       );
-    ids.push(infraId);
+    uids.push(uid);
   }
-  return ids;
+  return uids;
 }
 
 // confirm 단계에서 삭제 실행 — 요청을 내고 progress 단계로 전환한다(즉시 닫지 않는다).
 function handleConfirm() {
   if (state.phase !== 'confirm') return;
   const option = state.deleteMethod === 'force' ? 'force' : 'terminate';
-  trackedIds.value = fireDeletes(
-    props.selectedMciList.map(m => m.name as string),
-    option,
-  );
+  trackedIds.value = fireDeletes(props.selectedMciList, option);
   state.phase = 'progress';
   emit('deleted'); // 목록이 즉시 `삭제 상태` 컬럼을 띄우도록 갱신
 }
@@ -140,8 +140,11 @@ function handleConfirm() {
 // force 는 CSP 자원을 남기고 텀블벅 내부 데이터만 지운다(배너로 이미 고지).
 // 기록이 Error 상태(진행 중 아님)이므로 fireDeletes 가 새 reqId 로 다시 발행한다.
 function handleForceDelete() {
-  const names = erroredRecords.value.map(r => r.infraId);
-  trackedIds.value = fireDeletes(names, 'force');
+  const targets = erroredRecords.value.map(r => ({
+    uid: r.uid,
+    name: r.infraId,
+  }));
+  trackedIds.value = fireDeletes(targets, 'force');
   state.phase = 'progress';
   emit('deleted');
 }
@@ -195,10 +198,12 @@ watch(
       resetState();
       return;
     }
-    const names = props.selectedMciList.map(m => m.name as string);
-    const inProgress = names.filter(name => isDeleteInProgress(name));
-    const errored = names.filter(
-      name => getDeleteRecord(name)?.status === 'Error',
+    const uids = props.selectedMciList
+      .map(m => m.uid as string)
+      .filter(Boolean);
+    const inProgress = uids.filter(uid => isDeleteInProgress(uid));
+    const errored = uids.filter(
+      uid => getDeleteRecord(uid)?.status === 'Error',
     );
     if (inProgress.length > 0) {
       trackedIds.value = inProgress;

--- a/front/src/widgets/workload/mci/mciList/ui/MciList.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciList.vue
@@ -20,12 +20,9 @@ import MciDeleteModal from './MciDeleteModal.vue';
 import TableLoadingSpinner from '@/shared/ui/LoadingSpinner/TableLoadingSpinner.vue';
 import { useDynamicTableHeight } from '@/shared/hooks/table/useDynamicTableHeight';
 import { useToolboxTableHeight } from '@/shared/hooks/table/useToolboxTableHeight';
-import { useGetBeetleRequest } from '@/entities/mci/api';
 import {
   allDeleteRecords,
   getDeleteRecord,
-  updateDeleteStatus,
-  clearDeleteRecord,
   type DeleteRecord,
 } from '@/entities/mci/lib/deleteTracker';
 
@@ -107,17 +104,17 @@ function handleSelectedIndex(index: number[]) {
 
 /** 현재 표시 중인 행 이름 집합에 걸린 삭제 기록만 추린다. */
 function activeRecords(): DeleteRecord[] {
-  const names = new Set(
-    mciTableModel.tableState.displayItems.map((it: any) => it?.name),
+  const uids = new Set(
+    mciTableModel.tableState.displayItems.map((it: any) => it?.uid),
   );
-  return allDeleteRecords().filter(r => names.has(r.infraId));
+  return allDeleteRecords().filter(r => uids.has(r.uid));
 }
 
 const hasActiveDeletes = computed(() => activeRecords().length > 0);
 
 /** 슬롯에서 행별 삭제 기록 조회. */
-function deleteStatusOf(name: string): DeleteRecord | undefined {
-  return getDeleteRecord(name);
+function deleteStatusOf(uid: string): DeleteRecord | undefined {
+  return getDeleteRecord(uid);
 }
 
 // 삭제 요청이 있을 때만 `삭제 상태` 컬럼을 넣고, 없으면 뺀다.
@@ -136,66 +133,8 @@ watch(hasActiveDeletes, active => {
   }
 });
 
-// Handling 상태의 요청을 폴링해 상태를 이어 받는다(화면 이동·새로고침 뒤 복구용).
-// 같은 페이지에서 방금 삭제한 건은 모달의 execute() 프라미스가 이미 상태를 갱신하지만,
-// 새로고침하면 그 프라미스가 사라지므로 reqId 로 다시 조회한다.
-let pollTimer: ReturnType<typeof setInterval> | null = null;
-
-async function pollDeleteStatuses() {
-  const handling = activeRecords().filter(r => r.status === 'Handling');
-  if (handling.length === 0) return;
-
-  for (const rec of handling) {
-    try {
-      const res: any = await useGetBeetleRequest(rec.reqId).execute();
-      // cm-beetle GET /request/{reqId} 는 RequestDetails 를 ApiResponse 로 감싸고,
-      // 그게 다시 우리 프록시(CommonResponse)로 감싸여 온다. 권위 있는 값은
-      // RequestDetails.status(Handling|Success|Error) 와 errorResponse(실패 사유)다.
-      // 단계(stage)별 진행 정보는 삭제 경로에 없다(cb-tumblebug·cm-beetle 최신 확인) —
-      // 그래서 status 만 읽는다.
-      const details =
-        res?.data?.responseData?.data ??
-        res?.data?.data ??
-        res?.data?.responseData ??
-        res?.data ??
-        res;
-      const status = String(details?.status ?? '').toLowerCase();
-      if (status === 'success') {
-        updateDeleteStatus(rec.infraId, 'Success');
-      } else if (status === 'error') {
-        updateDeleteStatus(
-          rec.infraId,
-          'Error',
-          details?.errorResponse || undefined,
-        );
-      }
-      // handling 이면 그대로 둔다.
-    } catch (e: any) {
-      // 조회 자체가 실패하면(예: reqId 만료) 진행 상태를 바꾸지 않고 다음 주기에 재시도.
-      // 단 그 인프라가 목록에서 사라졌으면 기록을 정리한다.
-      const stillListed = mciTableModel.tableState.displayItems.some(
-        (it: any) => it?.name === rec.infraId,
-      );
-      if (!stillListed) clearDeleteRecord(rec.infraId);
-    }
-  }
-}
-
-// Success 로 바뀐 기록이 있으면 목록을 새로 불러온다(행이 사라지고 기록도 정리).
-watch(
-  () =>
-    allDeleteRecords()
-      .map(r => `${r.infraId}:${r.status}`)
-      .join(','),
-  async () => {
-    const done = activeRecords().filter(r => r.status === 'Success');
-    if (done.length > 0) {
-      done.forEach(r => clearDeleteRecord(r.infraId));
-      await fetchMciList();
-      tableKey.value++;
-    }
-  },
-);
+// 상태 갱신(폴링)은 이 화면이 하지 않는다 — deleteTracker 가 앱 전역에서 돌기 때문에
+// 다른 화면에 있는 동안에도 결과가 반영된다. 여기서는 그 결과를 보여주기만 한다.
 
 onBeforeMount(() => {
   initToolBoxTableModel();
@@ -205,11 +144,6 @@ onMounted(async () => {
   await fetchMciList();
   // 초기 데이터 로드 후 컴포넌트 재렌더링
   tableKey.value++;
-  pollTimer = setInterval(pollDeleteStatuses, 5000);
-});
-
-onUnmounted(() => {
-  if (pollTimer) clearInterval(pollTimer);
 });
 </script>
 
@@ -278,23 +212,23 @@ onUnmounted(() => {
           </template>
           <template #col-deleteStatus-format="{ item }">
             <span
-              v-if="deleteStatusOf(item.name)?.status === 'Handling'"
+              v-if="deleteStatusOf(item.uid)?.status === 'Handling'"
               class="delete-status handling"
               data-testid="wl-row-delete-status"
             >
               <span class="spinner" /> 진행 중
             </span>
             <span
-              v-else-if="deleteStatusOf(item.name)?.status === 'Error'"
+              v-else-if="deleteStatusOf(item.uid)?.status === 'Error'"
               class="delete-status error-cell"
               data-testid="wl-row-delete-status"
             >
               에러
               <span
-                v-if="deleteStatusOf(item.name)?.errorReason"
+                v-if="deleteStatusOf(item.uid)?.errorReason"
                 class="error-popover"
                 data-testid="wl-delete-error-popover"
-                >{{ deleteStatusOf(item.name)?.errorReason }}</span
+                >{{ deleteStatusOf(item.uid)?.errorReason }}</span
               >
             </span>
           </template>


### PR DESCRIPTION
## 배경

인프라 삭제는 수 분 걸리고 실패할 수 있어서, 요청 ID 로 결과를 따라가야 합니다. 그런데 그 ID 를 **브라우저에만** 두고 폴링을 **워크로드 목록 화면 안에서** 돌리고 있었습니다.

그래서 다른 PC 나 다른 브라우저에서는 **삭제가 실패한 사실도, 그 사유도 알 수 없었고**, 목록을 벗어나면 추적이 멈춰 한참 뒤에 돌아와서야 뒤늦게 반영됐습니다.

## 변경 내용

**요청 ID 를 서버에 보관합니다.** 로그인이 트리거라, 어느 브라우저로 접속하든 남아 있는 요청을 이어받아 워크로드 화면에 들어가기 *전에* 정리합니다.

**키는 인프라 이름이 아니라 `uid` 입니다.** cb-tumblebug 에서 인프라의 id 는 곧 이름이라, 지우고 같은 이름으로 다시 만들면 옛 기록이 새 인프라 것으로 보입니다.

**성공한 삭제는 저장하지 않습니다.** 인프라가 목록에서 사라지므로 보여줄 것이 없습니다. 남는 것은 진행 중과 실패뿐이라 테이블도 작게 유지됩니다. 재시도하면 이전 시도를 대체합니다 — 그 요청 ID 는 아무도 묻지 않는 질문에 답하기 때문입니다.

**요청 기록을 못 찾아도 실패로 단정하지 않습니다.** cm-beetle 의 요청 기록은 재시작을 넘기지 못해서, 정상 처리된 요청도 그렇게 보일 수 있습니다. 인프라가 아직 목록에 있는지로 가르고, 알 수 없으면 `Unknown` 으로 둡니다.

**폴링 주기는 10초이고 이전 조회가 끝난 뒤 다음을 예약합니다.** 응답이 느려도 겹치지 않습니다. 시작 시 즉시 한 번 확인해, 이전처럼 첫 5초 동안 낡은 상태를 보여주지 않습니다.

테이블은 api 기동 시 자동 생성됩니다(기존 세션 테이블과 동일 방식). 별도 DDL 이 필요 없습니다.

## 검증

실제 클라우드 환경에서 확인했습니다. 로그인만 하고 **워크로드 목록에는 한 번도 들어가지 않은 채** 전 과정이 돌았습니다.

```
listdeleterequests → cm-beetle/GetRequest → removedeleterequest
   기록 이어받기        상태 확인            성공 → 정리
```

최종적으로 인프라와 추적 기록 모두 정리된 것을 확인했습니다. 대비로 브라우저를 닫은 채 관찰하면 갱신되지 않는데, 이는 서버 스케줄러를 두지 않기로 한 설계대로입니다.

검증 중 결함 두 건을 발견해 함께 고쳤습니다. 추적 시작을 **아무도 쓰지 않는 스토어**에 연결해 트리 셰이킹으로 사라져 있었고, 목록 행에 `uid` 를 담지 않아 삭제를 눌러도 아무것도 기록되지 않았습니다. 둘 다 빌드와 타입 체크를 통과한 상태였습니다.

**미검증** — 새 브라우저에서 상태를 이어받는 것은 대상이 이미 정리돼 재현하지 못했습니다. 같은 경로를 타므로 동작할 것으로 보나 실측하지는 않았습니다.

---

- [BAR-1531](https://mzdevs.atlassian.net/browse/BAR-1531) 워크로드 삭제 상태 추적 고도화
- 선행: [BAR-1444](https://mzdevs.atlassian.net/browse/BAR-1444) · 후속: [BAR-1536](https://mzdevs.atlassian.net/browse/BAR-1536) 알림 배지
- CI: https://github.com/MZC-CSC/onecloud-ci/actions/runs/29650981898