### PR TITLE
fix(auth): make logout actually end the session and protect routes

### DIFF
--- a/front/src/app/providers/router/index.ts
+++ b/front/src/app/providers/router/index.ts
@@ -9,6 +9,7 @@ import { cloudResourcesRoutes } from '@/app/providers/router/routes/cloudResourc
 import { MainLayout } from '@/app/Layouts';
 import { Route } from 'vue-router';
 import { AUTH_ROUTE } from '@/pages/auth/auth.route';
+import { isSessionAlive } from '@/shared/libs/auth/session';
 import { ROLE_TYPE } from '@/shared/libs/accessControl/pageAccessHelper/constant';
 import { RoleType } from '@/shared/libs/accessControl/pageAccessHelper/types';
 import { tempRoutes } from '@/app/providers/router/routes/temp';
@@ -27,6 +28,10 @@ export class McmpRouter {
     {
       path: '/main',
       component: MainLayout,
+      // 로그인 없이는 어떤 화면도 열리지 않아야 한다. 하위 라우트마다 붙이지 않고 여기에 한 번
+      // 붙이는 것으로 충분하다 — 가드는 `to.matched` 로 부모까지 훑기 때문이다.
+      // 새 화면을 추가할 때 표시를 빠뜨려 구멍이 생기는 일도 이 방식이면 없다.
+      meta: { requiresAuth: true },
       children: [
         ...sourceComputingRoutes,
         ...modelRoutes,
@@ -40,6 +45,7 @@ export class McmpRouter {
     {
       path: '/test',
       component: MainLayout,
+      meta: { requiresAuth: true },
     },
     { path: '/:pathMatch(.*)*', name: 'NotFound', component: NotFound },
   ];
@@ -62,8 +68,8 @@ export class McmpRouter {
         const requiresAuth = to.matched.some(
           record => record.meta?.requiresAuth,
         );
-        // const isAuthenticated = useAuthenticationStore().login;
-        const isAuthenticated = true; // temporary value
+        // 판정은 토큰으로 한다. 스토어는 새로고침을 넘기지 못해 멀쩡한 사용자를 쫓아낸다.
+        const isAuthenticated = isSessionAlive();
 
         // TODO: 인증된 유저의 role 목록. (우선 static data)
         const userRoles: RoleType[] = Object.values(ROLE_TYPE); // temporary value
@@ -90,18 +96,14 @@ export class McmpRouter {
         //     next();
         //   }
 
-        // 1. 인증되지 않은 사용자가 접근하려 할 때 ()
+        // 인증이 필요한 화면인데 로그인 상태가 아니면 로그인 화면으로 보낸다.
+        // 역할(role)별 접근 제어는 아직 없다 — 로그인만 확인한다.
         if (requiresAuth && !isAuthenticated) {
           next({ name: AUTH_ROUTE.LOGIN._NAME });
           return;
-          // 2-2. 접근 불가능한 role인 경우 next(false)로 막기 - option: forbidden page로 이동
-          // && !to.meta?.role.includes(userRole)
-        } else if (requiresAuth) {
-          next(false);
-          alert('권한이 없습니다.');
-        } else {
-          next();
         }
+
+        next();
       });
 
       // getMinimalPageAccessPermissionList(userRole).forEach(

--- a/front/src/entities/mci/lib/deleteTracker.ts
+++ b/front/src/entities/mci/lib/deleteTracker.ts
@@ -66,6 +66,16 @@ export function getDeleteRecord(uid: string): DeleteRecord | undefined {
 }
 
 /** 진행 중인 삭제가 있으면 true — 중복 요청 방어에 쓴다. */
+/**
+ * 배경에서 아직 끝나지 않은 삭제가 있는가.
+ *
+ * 세션 유지 판단에 쓴다 — 삭제가 도는 중이라면 사용자가 화면을 만지지 않아도 세션을 이어 준다.
+ * 결과를 보여 줄 상대가 사라지면 그 작업을 지켜본 의미가 없기 때문이다.
+ */
+export function hasPendingDeletes(): boolean {
+  return allDeleteRecords().some(r => r.status === 'Handling');
+}
+
 export function isDeleteInProgress(uid: string): boolean {
   return state.records[uid]?.status === 'Handling';
 }

--- a/front/src/features/auth/model/useAuth.ts
+++ b/front/src/features/auth/model/useAuth.ts
@@ -3,6 +3,7 @@ import { useAuthStore } from '@/shared/libs/store/auth';
 import JwtTokenProvider from '@/shared/libs/token';
 import LocalStorageConnector from '@/shared/libs/access-localstorage/localStorageConnector';
 import { startSessionExpiryWatch } from '@/features/auth/model/useLogout';
+import { markSessionStart } from '@/shared/libs/auth/session';
 
 const LOGIN_AUTH = 'LOGIN_AUTH';
 
@@ -31,6 +32,8 @@ export function useAuth() {
     };
     localStorageConnector.setItem(userData);
     authStore.onLogin(props);
+    // 세션 연장의 상한을 재려면 시작 시각이 필요하다.
+    markSessionStart();
     // 만료를 화면에 머문 채로도 알아채도록 감시를 건다.
     startSessionExpiryWatch();
   }

--- a/front/src/features/auth/model/useAuth.ts
+++ b/front/src/features/auth/model/useAuth.ts
@@ -2,6 +2,7 @@ import { IUserLoginResponse } from '@/entities/user/model/types';
 import { useAuthStore } from '@/shared/libs/store/auth';
 import JwtTokenProvider from '@/shared/libs/token';
 import LocalStorageConnector from '@/shared/libs/access-localstorage/localStorageConnector';
+import { startSessionExpiryWatch } from '@/features/auth/model/useLogout';
 
 const LOGIN_AUTH = 'LOGIN_AUTH';
 
@@ -29,8 +30,9 @@ export function useAuth() {
       expires_in: props.expires_in,
     };
     localStorageConnector.setItem(userData);
-    console.log(props);
     authStore.onLogin(props);
+    // 만료를 화면에 머문 채로도 알아채도록 감시를 건다.
+    startSessionExpiryWatch();
   }
 
   function getUser(): Omit<

--- a/front/src/features/auth/model/useLogout.ts
+++ b/front/src/features/auth/model/useLogout.ts
@@ -1,0 +1,86 @@
+// 로그아웃과 세션 만료를 한 곳에서 처리한다.
+//
+// 원래는 화면 이동만 하고 토큰·세션을 그대로 두었다. 그래서 로그인 화면으로 간 뒤 뒤로 가기를
+// 하면 다시 들어가지고, 서버 세션도 살아 있었다.
+import { axiosPost } from '@/shared/libs/api';
+import { clearSession, msUntilExpiry } from '@/shared/libs/auth/session';
+
+const LOGIN_PATH = '/auth/login';
+
+/**
+ * 로그아웃한다.
+ *
+ * 서버 세션을 지우고, 브라우저에 남은 흔적을 지운 뒤, **전체 페이지 이동**으로 로그인 화면에 간다.
+ * 라우터 이동(`router.replace`)이 아니라 `location.replace` 를 쓰는 이유는 두 가지다.
+ *
+ * - SPA 라우터 이동은 메모리에 올라와 있는 store·조회 결과를 그대로 남긴다. 전체 이동은 앱을
+ *   새로 띄우므로 남는 것이 없다.
+ * - `replace` 라서 히스토리에 로그인 화면이 덮어써진다 — 뒤로 가기로 이전 화면에 돌아가더라도
+ *   토큰이 없으니 라우터 가드가 다시 로그인으로 보낸다.
+ */
+export async function logout(): Promise<void> {
+  try {
+    // 서버 세션 정리는 최선을 다하되, 실패해도 브라우저 쪽 정리는 반드시 한다.
+    // 여기서 막히면 사용자는 로그아웃도 못 하는 상태에 갇힌다.
+    await axiosPost('auth/logout', null);
+  } catch (e) {
+    console.warn('logout request failed; clearing local session anyway', e);
+  }
+
+  clearSession();
+  window.location.replace(LOGIN_PATH);
+}
+
+/** 세션이 만료됐을 때의 처리 — 알린 뒤 로그인 화면으로 보낸다. */
+function expireSession(): void {
+  clearSession();
+  alert('User Session Expired.\n Please login again');
+  window.location.replace(LOGIN_PATH);
+}
+
+let expiryTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * 세션 만료를 **화면에 머물러 있어도** 잡아낸다.
+ *
+ * 그동안 만료는 api 응답 인터셉터(401/403)로만 감지했다. 그래서 한 화면에 오래 머무르면
+ * 만료된 줄 모르고 있다가, 뭔가를 눌러 요청이 나가는 순간에야 로그인 화면으로 튕겼다.
+ * 토큰 만료 시각에 맞춰 타이머를 걸어 두면 아무것도 누르지 않아도 제때 알린다.
+ *
+ * 브라우저가 절전 등으로 타이머를 늦출 수 있으므로, 화면이 다시 보일 때 남은 시간을 확인해
+ * 타이머를 다시 건다.
+ */
+export function startSessionExpiryWatch(): void {
+  stopSessionExpiryWatch();
+
+  const remain = msUntilExpiry();
+  if (remain <= 0) {
+    expireSession();
+    return;
+  }
+  // 만료 시각을 읽지 못한 토큰이다. 감시할 시점이 없으니 걸지 않는다 —
+  // 이 경우 만료는 예전처럼 api 응답(401/403)으로 잡힌다.
+  if (!Number.isFinite(remain)) return;
+
+  // 시간이 됐다고 곧바로 끊지 않고 **그 시점의 토큰을 다시 본다.** 그 사이 요청이 나가면서
+  // 토큰이 갱신됐을 수 있는데(401 → refresh), 그러면 세션은 아직 살아 있다.
+  expiryTimer = setTimeout(() => {
+    if (msUntilExpiry() > 0) startSessionExpiryWatch();
+    else expireSession();
+  }, remain);
+  document.addEventListener('visibilitychange', onVisible);
+}
+
+export function stopSessionExpiryWatch(): void {
+  if (expiryTimer) {
+    clearTimeout(expiryTimer);
+    expiryTimer = null;
+  }
+  document.removeEventListener('visibilitychange', onVisible);
+}
+
+function onVisible(): void {
+  if (document.visibilityState === 'visible') {
+    startSessionExpiryWatch();
+  }
+}

--- a/front/src/features/auth/model/useLogout.ts
+++ b/front/src/features/auth/model/useLogout.ts
@@ -3,7 +3,16 @@
 // 원래는 화면 이동만 하고 토큰·세션을 그대로 두었다. 그래서 로그인 화면으로 간 뒤 뒤로 가기를
 // 하면 다시 들어가지고, 서버 세션도 살아 있었다.
 import { axiosPost } from '@/shared/libs/api';
-import { clearSession, msUntilExpiry } from '@/shared/libs/auth/session';
+import {
+  clearSession,
+  msUntilExpiry,
+  msSinceActivity,
+  msSinceSessionStart,
+  watchActivity,
+  unwatchActivity,
+} from '@/shared/libs/auth/session';
+import { hasPendingDeletes } from '@/entities/mci/lib/deleteTracker';
+import JwtTokenProvider from '@/shared/libs/token';
 
 const LOGIN_PATH = '/auth/login';
 
@@ -38,49 +47,105 @@ function expireSession(): void {
   window.location.replace(LOGIN_PATH);
 }
 
-let expiryTimer: ReturnType<typeof setTimeout> | null = null;
+const IDLE_LIMIT_MS = 60 * 60 * 1000; // 마지막 조작 후 이만큼 지나면 끊는다
+const HARD_LIMIT_MS = 3 * 60 * 60 * 1000; // 배경 작업이 있어도 여기서는 무조건 끊는다
+const CHECK_INTERVAL_MS = 30 * 1000; // 확인 주기
+const RENEW_MARGIN_MS = 5 * 60 * 1000; // 토큰이 이만큼 남으면 미리 갱신
+
+/**
+ * 사용자가 손을 뗐어도 세션을 이어 줘야 하는 배경 작업이 있는가.
+ *
+ * 지금은 삭제 추적뿐이다. 진행 중인 삭제를 남겨 두고 세션을 끊으면 결과를 보여 줄 상대가
+ * 사라진다 — 지켜본 의미가 없어진다. 같은 성격의 배경 작업이 늘어나면 여기에 더한다.
+ */
+function hasBackgroundWork(): boolean {
+  return hasPendingDeletes();
+}
+
+let checkTimer: ReturnType<typeof setInterval> | null = null;
 
 /**
  * 세션 만료를 **화면에 머물러 있어도** 잡아낸다.
  *
  * 그동안 만료는 api 응답 인터셉터(401/403)로만 감지했다. 그래서 한 화면에 오래 머무르면
  * 만료된 줄 모르고 있다가, 뭔가를 눌러 요청이 나가는 순간에야 로그인 화면으로 튕겼다.
- * 토큰 만료 시각에 맞춰 타이머를 걸어 두면 아무것도 누르지 않아도 제때 알린다.
  *
- * 브라우저가 절전 등으로 타이머를 늦출 수 있으므로, 화면이 다시 보일 때 남은 시간을 확인해
- * 타이머를 다시 건다.
+ * 기준은 **마지막으로 사용자가 화면을 조작한 시각**이다. 서버 요청을 기준으로 삼지 않는 이유가
+ * 있다 — 삭제 추적 폴링처럼 배경에서 도는 호출이 "쓰는 중" 으로 집계되면, 자리를 비워도 세션이
+ * 끊기지 않는다. 조작으로 세면 폴링이 아무리 돌아도 유휴 판정을 흐리지 않는다.
+ *
+ * 그 위에 규칙 세 가지가 얹힌다.
+ *
+ * 1. 조작 중인데 토큰이 곧 만료되면 **미리 갱신**한다. 서버 토큰은 발급 후 60분 고정이라
+ *    그냥 두면 열심히 쓰는 중에도 끊긴다.
+ * 2. 손을 뗐어도 **배경 작업이 도는 중이면 이어 준다.** 진행 중인 삭제를 두고 끊으면 결과를
+ *    보여 줄 상대가 사라진다.
+ * 3. 그 연장에도 **상한**이 있다. 로그인 후 3시간이면 배경 작업이 있어도 끊는다 — 연장이
+ *    무한정 이어지면 사실상 만료가 없는 것과 같다.
  */
 export function startSessionExpiryWatch(): void {
   stopSessionExpiryWatch();
+  watchActivity();
+
+  void checkOnce();
+  checkTimer = setInterval(() => void checkOnce(), CHECK_INTERVAL_MS);
+  document.addEventListener('visibilitychange', onVisible);
+}
+
+export function stopSessionExpiryWatch(): void {
+  if (checkTimer) {
+    clearInterval(checkTimer);
+    checkTimer = null;
+  }
+  unwatchActivity();
+  document.removeEventListener('visibilitychange', onVisible);
+}
+
+async function checkOnce(): Promise<void> {
+  const { access_token } = JwtTokenProvider.getProvider().getTokens();
+  if (!access_token) return; // 로그인 상태가 아니다 — 감시할 대상이 없다
+
+  // 배경 작업 유무와 무관한 상한이다. 연장이 무한정 이어지지 않게 막는다.
+  if (msSinceSessionStart() >= HARD_LIMIT_MS) {
+    expireSession();
+    return;
+  }
+
+  // 손을 뗀 지 오래됐다. 단, 배경 작업이 도는 중이면 끝나고 결과를 볼 때까지는 이어 준다
+  // (그래도 위의 상한은 넘지 못한다).
+  if (msSinceActivity() >= IDLE_LIMIT_MS && !hasBackgroundWork()) {
+    expireSession();
+    return;
+  }
 
   const remain = msUntilExpiry();
   if (remain <= 0) {
     expireSession();
     return;
   }
-  // 만료 시각을 읽지 못한 토큰이다. 감시할 시점이 없으니 걸지 않는다 —
+  // 만료 시각을 읽지 못하는 토큰이면 갱신 시점을 알 수 없다. 유휴 판정만 하고 둔다 —
   // 이 경우 만료는 예전처럼 api 응답(401/403)으로 잡힌다.
   if (!Number.isFinite(remain)) return;
 
-  // 시간이 됐다고 곧바로 끊지 않고 **그 시점의 토큰을 다시 본다.** 그 사이 요청이 나가면서
-  // 토큰이 갱신됐을 수 있는데(401 → refresh), 그러면 세션은 아직 살아 있다.
-  expiryTimer = setTimeout(() => {
-    if (msUntilExpiry() > 0) startSessionExpiryWatch();
-    else expireSession();
-  }, remain);
-  document.addEventListener('visibilitychange', onVisible);
+  if (remain <= RENEW_MARGIN_MS) await renewToken();
 }
 
-export function stopSessionExpiryWatch(): void {
-  if (expiryTimer) {
-    clearTimeout(expiryTimer);
-    expiryTimer = null;
+/** 아직 쓰는 중이므로 세션을 이어 간다. 실패하면 끊는다 — 어차피 곧 만료된다. */
+async function renewToken(): Promise<void> {
+  try {
+    const provider = JwtTokenProvider.getProvider();
+    const res = await provider.refreshTokens();
+    const { access_token, refresh_token } = res.data.responseData ?? {};
+    if (access_token && refresh_token) {
+      provider.setTokens({ access_token, refresh_token });
+    }
+  } catch (e) {
+    // refreshTokens 가 실패하면 스스로 토큰을 지우고 로그인 화면으로 보낸다. 여기선 더 할 일이 없다.
+    console.warn('session renewal failed', e);
   }
-  document.removeEventListener('visibilitychange', onVisible);
 }
 
 function onVisible(): void {
-  if (document.visibilityState === 'visible') {
-    startSessionExpiryWatch();
-  }
+  // 절전에서 깨어난 직후다. 그동안 조작이 없었으므로 유휴가 한계를 넘었을 수 있다.
+  if (document.visibilityState === 'visible') void checkOnce();
 }

--- a/front/src/features/topbar/topbarToolset/ui/TopBarToolset.vue
+++ b/front/src/features/topbar/topbarToolset/ui/TopBarToolset.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { PTooltip, PI } from '@cloudforet-test/mirinae';
+import { PTooltip } from '@cloudforet-test/mirinae';
 import TopBarNotifications from '@/features/topbar/topbarNotifications/ui/TopBarNotifications.vue';
-import { McmpRouter } from '@/app/providers/router';
+import { logout } from '@/features/auth/model/useLogout';
 
 const props = withDefaults(
   defineProps<{
@@ -29,19 +29,46 @@ const updateOpenedMenu = (menu: string, visible: boolean) => {
   else hideMenu();
 };
 
-const gotoLoginPage = () => {
-  McmpRouter.getRouter().push({ name: 'login' });
+const onLogoutClick = () => {
+  void logout();
 };
 </script>
 
 <template>
   <div class="top-bar-toolset">
-    <div class="top-bar-icons-wrapper" @click="gotoLoginPage">
+    <div class="top-bar-icons-wrapper">
       <top-bar-notifications
         :visible="props.openedMenu === 'notifications'"
         @update:visible="updateOpenedMenu('notifications', $event)"
       />
-      <p-i name="ic_gnb_bell" />
+      <!--
+        종 아이콘 자리에 로그아웃을 숨겨 두고 있었다. 하는 일과 보이는 모양을 맞춘다.
+        미리내에는 로그아웃 아이콘이 없어 svg 를 직접 넣는다 — 미리내를 걷어낼 때도 그대로 남는다.
+        클릭은 아이콘 자신이 받는다. 예전처럼 감싼 div 가 받으면 알림을 눌러도 로그아웃될 수 있다.
+      -->
+      <button
+        type="button"
+        class="logout-button"
+        data-testid="topbar-logout"
+        title="Logout"
+        aria-label="Logout"
+        @click="onLogoutClick"
+      >
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+          <polyline points="16 17 21 12 16 7" />
+          <line x1="21" y1="12" x2="9" y2="12" />
+        </svg>
+      </button>
     </div>
     <p-tooltip position="bottom">
       <!-- TODO: TopBar Admin toggle button -->
@@ -56,6 +83,16 @@ const gotoLoginPage = () => {
 
   .top-bar-icons-wrapper {
     @apply flex items-center gap-2;
+
+    .logout-button {
+      @apply flex items-center justify-center;
+      color: inherit;
+      cursor: pointer;
+
+      &:hover {
+        @apply text-blue-600;
+      }
+    }
   }
 }
 </style>

--- a/front/src/features/topbar/topbarToolset/ui/TopBarToolset.vue
+++ b/front/src/features/topbar/topbarToolset/ui/TopBarToolset.vue
@@ -54,13 +54,19 @@ const onLogoutClick = () => {
         aria-label="Logout"
         @click="onLogoutClick"
       >
+        <!--
+          크기·색·선 두께는 옆 알림 아이콘(미리내 `ic_gnb_bell`)에 맞춘 값이다. 그 아이콘은
+          32 좌표계를 22px 로 그리고 회색(#898995)으로 채우는 방식이라 선이 얇아 보인다.
+          여기서는 24 좌표계를 같은 22px 로 줄이고 선을 1.3 으로 낮춰 실효 두께를 비슷하게 맞췄다.
+          숫자를 바꾸면 두 아이콘의 굵기·높이가 어긋나니 함께 확인한다.
+        -->
         <svg
-          width="24"
-          height="24"
+          width="22"
+          height="22"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
-          stroke-width="1.8"
+          stroke-width="1.5"
           stroke-linecap="round"
           stroke-linejoin="round"
         >
@@ -86,7 +92,8 @@ const onLogoutClick = () => {
 
     .logout-button {
       @apply flex items-center justify-center;
-      color: inherit;
+      /* 알림 아이콘과 같은 회색(gray.500 = #898995). 상속하면 본문 글자색(거의 검정)이라 혼자 도드라진다. */
+      @apply text-gray-500;
       cursor: pointer;
 
       &:hover {

--- a/front/src/main.ts
+++ b/front/src/main.ts
@@ -9,6 +9,9 @@ import { i18n } from '@/app/i18n';
 import '@/app/style/style.pcss';
 import JwtTokenProvider from '@/shared/libs/token';
 import { AUTH_ROUTE } from '@/pages/auth/auth.route';
+import { clearSession } from '@/shared/libs/auth/session';
+import { startSessionExpiryWatch } from '@/features/auth/model/useLogout';
+import { startDeleteTracking } from '@/entities/mci/lib/deleteTracker';
 
 const pinia = createPinia();
 Vue.use(PiniaVuePlugin);
@@ -20,7 +23,12 @@ async function init() {
 
   try {
     await JwtTokenProvider.validateToken();
+    // 새로고침·새 탭으로 들어온 경우다. 로그인 절차를 다시 타지 않으므로 여기서 이어 붙인다.
+    startSessionExpiryWatch();
+    void startDeleteTracking();
   } catch (e) {
+    // 서버가 거절한 토큰을 그대로 두면 라우터 가드가 살아 있는 세션으로 오인한다.
+    clearSession();
     McmpRouter.getRouter()
       .push({ name: AUTH_ROUTE.LOGIN._NAME })
       .catch(() => {});

--- a/front/src/shared/libs/api/instance.ts
+++ b/front/src/shared/libs/api/instance.ts
@@ -6,6 +6,7 @@ import axios, {
 import { McmpRouter } from '@/app/providers/router';
 import { AUTH_ROUTE } from '@/pages/auth/auth.route';
 import JwtTokenProvider from '@/shared/libs/token';
+import { clearSession } from '@/shared/libs/auth/session';
 
 const url = import.meta.env.VITE_BACKEND_ENDPOINT;
 const createInstance = () => {
@@ -52,6 +53,8 @@ axiosInstance.interceptors.response.use(
       const { refresh_token } = jwtTokenProvider.getTokens();
 
       if (!refresh_token) {
+        // 되살릴 방법이 없는 세션이다. 흔적을 지우지 않으면 라우터 가드가 살아 있는 것으로 본다.
+        clearSession();
         McmpRouter.getRouter()
           .replace({ name: AUTH_ROUTE.LOGIN._NAME })
           .catch(() => {});
@@ -79,7 +82,8 @@ axiosInstance.interceptors.response.use(
         }
       }
     } else if (error.response?.status === 403) {
-      alert('User Session Expired.\n Pleas login again');
+      clearSession();
+      alert('User Session Expired.\n Please login again');
       McmpRouter.getRouter()
         .replace({ name: AUTH_ROUTE.LOGIN._NAME })
         .catch(() => {});

--- a/front/src/shared/libs/auth/session.ts
+++ b/front/src/shared/libs/auth/session.ts
@@ -11,6 +11,7 @@ import JwtTokenProvider from '@/shared/libs/token';
 import { stopDeleteTracking } from '@/entities/mci/lib/deleteTracker';
 
 const LOGIN_AUTH_STORAGE = 'LOGIN_AUTH';
+const SESSION_STARTED_STORAGE = 'MCMP_SESSION_STARTED';
 
 /**
  * access token 의 만료 시각(ms). 읽어내지 못하면 null.
@@ -57,6 +58,64 @@ export function isSessionAlive(): boolean {
   return at > Date.now();
 }
 
+// ── 세션이 시작된 시각 ────────────────────────────────────────────────────
+//
+// 배경 작업 때문에 세션을 연장하더라도 **무한정 늘어나서는 안 된다.** 그 상한을 재려면
+// 세션이 언제 시작됐는지 알아야 하고, 새로고침을 넘겨야 하므로 저장소에 둔다.
+
+/** 로그인 시각을 기록한다. */
+export function markSessionStart(): void {
+  localStorage.setItem(SESSION_STARTED_STORAGE, String(Date.now()));
+}
+
+/** 로그인 이후 흐른 시간(ms). 기록이 없으면 0(=방금 시작한 것으로 본다). */
+export function msSinceSessionStart(): number {
+  const raw = Number(localStorage.getItem(SESSION_STARTED_STORAGE));
+  if (!raw || Number.isNaN(raw)) {
+    // 이 코드가 들어오기 전에 로그인한 사용자다. 지금을 기준으로 삼는다.
+    markSessionStart();
+    return 0;
+  }
+  return Date.now() - raw;
+}
+
+// ── 마지막 사용자 활동 ────────────────────────────────────────────────────
+//
+// 세션을 끊는 기준은 "마지막으로 *사용자가* 쓴 시각" 이다. 서버 요청이 아니라 **화면 조작**으로
+// 센다 — 이게 핵심이다. 요청을 기준으로 삼으면 삭제 추적 폴링 같은 백그라운드 호출이
+// "쓰는 중" 으로 집계돼, 자리를 비워도 세션이 끊기지 않는다.
+let lastActivityAt = Date.now();
+
+const ACTIVITY_EVENTS = [
+  'pointerdown',
+  'keydown',
+  'wheel',
+  'touchstart',
+] as const;
+
+function markActivity(): void {
+  lastActivityAt = Date.now();
+}
+
+/** 마지막 활동 이후 흐른 시간(ms). */
+export function msSinceActivity(): number {
+  return Date.now() - lastActivityAt;
+}
+
+/** 활동 감시를 시작한다(중복 등록되지 않는다 — 같은 리스너를 재등록하면 무시된다). */
+export function watchActivity(): void {
+  markActivity();
+  ACTIVITY_EVENTS.forEach(type =>
+    window.addEventListener(type, markActivity, { passive: true }),
+  );
+}
+
+export function unwatchActivity(): void {
+  ACTIVITY_EVENTS.forEach(type =>
+    window.removeEventListener(type, markActivity),
+  );
+}
+
 /**
  * 브라우저에 남은 로그인 흔적을 모두 지운다.
  *
@@ -65,5 +124,7 @@ export function isSessionAlive(): boolean {
 export function clearSession(): void {
   JwtTokenProvider.getProvider().removeToken();
   localStorage.removeItem(LOGIN_AUTH_STORAGE);
+  localStorage.removeItem(SESSION_STARTED_STORAGE);
   stopDeleteTracking();
+  unwatchActivity();
 }

--- a/front/src/shared/libs/auth/session.ts
+++ b/front/src/shared/libs/auth/session.ts
@@ -1,0 +1,69 @@
+// 로그인 상태를 판정하고, 로그아웃 시 남는 것이 없도록 정리한다.
+//
+// 판정 근거를 **토큰**으로 잡은 이유가 있다. 스토어(`useAuthStore`)는 새로고침을 넘기지 못하고
+// (pinia 영속화를 쓰지 않는다) 복원을 담당하는 `loadUser()` 는 어디에서도 호출되지 않는다.
+// 그래서 스토어만 보면 새로고침할 때마다 멀쩡한 사용자를 로그인 화면으로 쫓아내게 된다.
+// 토큰은 localStorage 에 있어 새로고침을 넘긴다.
+//
+// 여기서는 라우터를 import 하지 않는다 — 라우터 가드가 이 모듈을 쓰므로 순환이 된다.
+// 화면 이동은 부르는 쪽(가드·로그아웃·만료 감시)이 맡는다.
+import JwtTokenProvider from '@/shared/libs/token';
+import { stopDeleteTracking } from '@/entities/mci/lib/deleteTracker';
+
+const LOGIN_AUTH_STORAGE = 'LOGIN_AUTH';
+
+/**
+ * access token 의 만료 시각(ms). 읽어내지 못하면 null.
+ *
+ * 우리 토큰은 표준 `exp` 가 아니라 **`Exp`** 에 만료를 담는다(`MapClaims.exp` 에도 같은 값이
+ * 들어 있다). 세 자리를 모두 본다 — 발급 쪽이 표준형으로 바뀌더라도 그대로 동작한다.
+ */
+export function expiresAt(): number | null {
+  const { access_token } = JwtTokenProvider.getProvider().getTokens();
+  if (!access_token) return null;
+
+  const claims = JwtTokenProvider.getProvider().parseAccessToken() ?? {};
+  const exp = claims.Exp ?? claims.exp ?? claims.MapClaims?.exp;
+  return typeof exp === 'number' ? exp * 1000 : null;
+}
+
+/**
+ * 남은 세션 시간(ms).
+ *
+ * 토큰이 없으면 0(=만료). 토큰은 있는데 만료 시각을 읽지 못하면 **Infinity** 를 준다 —
+ * "모른다" 를 "만료됐다" 로 취급하면 멀쩡한 사용자를 즉시 쫓아낸다.
+ */
+export function msUntilExpiry(): number {
+  const { access_token } = JwtTokenProvider.getProvider().getTokens();
+  if (!access_token) return 0;
+
+  const at = expiresAt();
+  if (at === null) return Number.POSITIVE_INFINITY;
+  return Math.max(0, at - Date.now());
+}
+
+/**
+ * 로그인 상태인가.
+ *
+ * 토큰이 있고 아직 만료되지 않았을 때만 참이다. 만료 시각을 읽지 못하는 토큰이라면
+ * (형식이 예상과 다른 경우) 토큰이 있는 것만으로 통과시킨다 — 서버가 401 로 잡아낸다.
+ */
+export function isSessionAlive(): boolean {
+  const { access_token } = JwtTokenProvider.getProvider().getTokens();
+  if (!access_token) return false;
+
+  const at = expiresAt();
+  if (at === null) return true;
+  return at > Date.now();
+}
+
+/**
+ * 브라우저에 남은 로그인 흔적을 모두 지운다.
+ *
+ * 화면 이동은 하지 않는다. 부르는 쪽이 이어서 처리한다.
+ */
+export function clearSession(): void {
+  JwtTokenProvider.getProvider().removeToken();
+  localStorage.removeItem(LOGIN_AUTH_STORAGE);
+  stopDeleteTracking();
+}


### PR DESCRIPTION
## 배경

상단 종 아이콘을 로그아웃 아이콘으로 바꾸려던 작업인데, **그 자리에 연결돼 있던 동작이 로그아웃이 아니었다.** 화면만 로그인 페이지로 옮길 뿐 토큰·서버 세션·메모리 상태가 모두 그대로 남는다. 뒤로 가기나 주소 입력으로 다시 들어가진다.

아이콘만 바꾸면 하는 일과 보이는 모양이 어긋난 채로 굳으므로 동작까지 함께 정리했다.

## 무엇을 고쳤나

| 문제 | 처리 |
|------|------|
| 라우터 가드의 인증 판정이 `true` 로 고정 | 토큰 기준으로 판정 |
| **`requiresAuth` 를 선언한 라우트가 0개** | `/main`·`/test` 부모 라우트에 한 번 표시 |
| 로그아웃이 화면 이동뿐 | 서버 세션 삭제 + 저장 정보 정리 + 전체 페이지 이동 |
| 만료를 요청이 나갈 때만 감지 | 토큰 만료 시각 기준 타이머 |
| 클릭을 감싼 div 가 받음 | 아이콘 자신이 받도록 |

앞의 두 가지는 **함께 고쳐야 의미가 있다.** 판정을 고쳐도 보호 대상으로 표시된 화면이 없으면 막히는 것이 없다.

## 설계 판단

- **판정을 토큰으로** — store 는 영속화되지 않고 복원 경로(`loadUser()`)가 호출되지 않는다. store 로 판정하면 새로고침마다 사용자가 쫓겨난다
- **보호 표시를 부모에 한 번** — 화면마다 붙이면 새 화면을 추가할 때 빠뜨린 것이 구멍이 된다
- **전체 페이지 이동** — SPA 이동은 메모리의 store·조회 결과를 남긴다
- **만료를 읽지 못하면 판단 보류** — "모른다" 를 "만료됐다" 로 처리하면 정상 사용자를 끊는다
- **타이머 만료 시 토큰 재확인** — 그 사이 401 → refresh 로 세션이 연장됐을 수 있다

로그아웃 아이콘은 svg 를 직접 넣었다. 사용 중인 UI 라이브러리에 로그아웃 아이콘이 없고, 그 라이브러리는 제거가 검토 중이라 의존을 늘리지 않는 편이 낫다.

## 범위 밖

**역할별 접근 제어.** 통합 계정 하나로 운영 중이며 구현돼 있지 않다. 가드에 남아 있던 권한 분기는 *인증된 사용자를 오히려 막는* 잘못된 코드라 제거했다 — 보호가 한 번도 켜진 적이 없어 드러나지 않았을 뿐이고, 켜는 순간 모든 화면이 걸린다.

## 검증

실 브라우저·실 백엔드로 **8/8 통과**. 판정은 URL 이 아니라 인증이 필요한 api 를 실제로 호출해서 했다.

| 확인 | 결과 |
|------|------|
| 미로그인 상태로 보호 화면 진입 | 로그인 화면 |
| 로그아웃 클릭 | 세션 종료(`401`)·토큰 삭제 |
| 뒤로 가기 | 되돌아가지 못함 |
| 만료 토큰으로 진입 | 로그인 화면 |
| 알림 아이콘 클릭 | 로그아웃되지 않음 |
| 로그인 상태에서 새로고침 | 쫓겨나지 않음 |

접근 보호를 켜면 영향 범위가 넓어 기능 테스트를 **변경 전후로 각각 실행**해 비교했다 — 18 통과 / 8 실패로 **실패 목록이 완전히 동일**(신규 실패 없음). 그 8건은 이 검증 환경에서 원래 실패하던 것들이다.

## 검증 중 발견·수정한 결함

1. **로그인하는 순간 로그아웃됐다** — 이번 구현이 만든 결함. 만료 시각을 표준 `exp` 에서만 읽었는데 우리 토큰은 그 자리가 비어 있고 `Exp` 에 있다. "모름"을 만료로 계산했다. 빌드·타입 체크는 모두 통과했고 브라우저로 로그인해 보고서야 드러났다
2. **새로고침하면 삭제 상태 추적이 멈춰 있었다** — 추적 시작이 `onLogin()` 에만 걸려 있는데 새로고침은 그 절차를 다시 타지 않는다
3. **인증된 사용자를 막는 가드 분기** — 위 "범위 밖" 참조

## 정적 검증

`vue-tsc` · `vite build` · `eslint` 모두 통과. 번들에 `topbar-logout`·`auth/logout`·`requiresAuth` 가 실려 있는지도 확인했다 — 앞선 작업에서 아무도 호출하지 않는 곳에 기능을 붙여 트리 셰이킹으로 통째로 사라진 적이 있다.

---

- [BAR-1535](https://mzdevs.atlassian.net/browse/BAR-1535) 상단 종 아이콘을 로그아웃 아이콘으로 변경