### PR TITLE
Make run status the entry point for a selected workflow

### DIFF
--- a/front/src/entities/workflow/lib/workflowRunHistory.ts
+++ b/front/src/entities/workflow/lib/workflowRunHistory.ts
@@ -1,0 +1,61 @@
+import { useGetWorkflowRuns } from '@/entities/workflow/api';
+
+/**
+ * 실행 이력이 있나 — **모를 수 있다.**
+ *
+ * `'unknown'` 은 조회가 실패한 상태다. 갓 만든 워크플로우에서 *정상적으로* 나온다 —
+ * 엔진은 실행 이력을 Airflow 에서 읽는데, 방금 만든 DAG 를 Airflow 가 아직 읽어들이지
+ * 않아 한동안 404 로 답한다(복제 직후가 늘 이렇다).
+ *
+ * 그래서 모를 때 어떻게 할지는 **부르는 쪽이 정한다.** 한쪽으로 정해 두면 어느 한
+ * 경우가 반드시 틀린다 — 아래 `RUN_HISTORY_UNKNOWN` 주석 참조.
+ */
+export type WorkflowRunHistory = 'has-runs' | 'no-runs' | 'unknown';
+
+/**
+ * 이 워크플로우가 한 번이라도 실행됐는가.
+ *
+ * **엔진은 "그 실행에 어떤 정의가 쓰였는지"를 남기지 않는다.** 그래서 실행된
+ * 워크플로우를 고치면 과거 실행을 열었을 때 *지금 정의*의 값이 그 실행의 값인 것처럼
+ * 보인다. 사용자는 구분할 방법이 없다. 그래서 실행 이력이 있으면 원본을 고치지 않고
+ * 복제해서 고치도록 유도한다.
+ *
+ * 판정이 필요한 곳이 둘 이상이라 여기 한 곳에 둔다 — 실행 상태 뷰어(버튼 구성)와
+ * 워크플로우 상세(툴로 보낼지 실행 상태로 보낼지). 두 곳이 다르게 판단하면
+ * 상세에서 툴로 보냈는데 뷰어는 못 고치는 워크플로우로 보는 어긋남이 생긴다.
+ */
+export async function getWorkflowRunHistory(
+  workflowId: string,
+): Promise<WorkflowRunHistory> {
+  if (!workflowId) return 'no-runs';
+  try {
+    const { data, execute } = useGetWorkflowRuns(workflowId);
+    await execute();
+    return (data.value?.responseData ?? []).length > 0 ? 'has-runs' : 'no-runs';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/*
+  RUN_HISTORY_UNKNOWN — 모를 때 어느 쪽으로 기울일지
+
+  · **편집으로 보낼지 정할 때**는 막는 쪽으로 기운다. 실제로 실행된 워크플로우였다면
+    고치는 순간 과거 기록의 뜻이 조용히 바뀌고 되돌릴 수 없다. 실행 상태로 보내도
+    사용자는 거기서 복제해 고칠 수 있으므로 잃는 것이 적다.
+
+  · **편집기 안에서 잠글지 정할 때**는 잠그지 않는 쪽으로 기운다. 갓 만든 복제본이
+    바로 이 상태로 열리는데(Airflow 가 아직 DAG 를 못 읽었다), 여기서 잠그면
+    **복제해서 고치라고 안내해 놓고 그 복제본도 못 고치게 된다.**
+*/
+export async function shouldSendToRunStatus(
+  workflowId: string,
+): Promise<boolean> {
+  return (await getWorkflowRunHistory(workflowId)) !== 'no-runs';
+}
+
+export async function isEditingLockedByRunHistory(
+  workflowId: string,
+): Promise<boolean> {
+  return (await getWorkflowRunHistory(workflowId)) === 'has-runs';
+}

--- a/front/src/entities/workflow/lib/workflowRunHistory.ts
+++ b/front/src/entities/workflow/lib/workflowRunHistory.ts
@@ -1,61 +1,35 @@
 import { useGetWorkflowRuns } from '@/entities/workflow/api';
 
 /**
- * 실행 이력이 있나 — **모를 수 있다.**
- *
- * `'unknown'` 은 조회가 실패한 상태다. 갓 만든 워크플로우에서 *정상적으로* 나온다 —
- * 엔진은 실행 이력을 Airflow 에서 읽는데, 방금 만든 DAG 를 Airflow 가 아직 읽어들이지
- * 않아 한동안 404 로 답한다(복제 직후가 늘 이렇다).
- *
- * 그래서 모를 때 어떻게 할지는 **부르는 쪽이 정한다.** 한쪽으로 정해 두면 어느 한
- * 경우가 반드시 틀린다 — 아래 `RUN_HISTORY_UNKNOWN` 주석 참조.
- */
-export type WorkflowRunHistory = 'has-runs' | 'no-runs' | 'unknown';
-
-/**
  * 이 워크플로우가 한 번이라도 실행됐는가.
  *
  * **엔진은 "그 실행에 어떤 정의가 쓰였는지"를 남기지 않는다.** 그래서 실행된
  * 워크플로우를 고치면 과거 실행을 열었을 때 *지금 정의*의 값이 그 실행의 값인 것처럼
- * 보인다. 사용자는 구분할 방법이 없다. 그래서 실행 이력이 있으면 원본을 고치지 않고
- * 복제해서 고치도록 유도한다.
+ * 보인다. 사용자는 구분할 방법이 없다. 그래서 이력이 없으면 고칠 수 있게 두고,
+ * 있으면 원본 대신 복제본을 고치도록 막는다.
  *
- * 판정이 필요한 곳이 둘 이상이라 여기 한 곳에 둔다 — 실행 상태 뷰어(버튼 구성)와
- * 워크플로우 상세(툴로 보낼지 실행 상태로 보낼지). 두 곳이 다르게 판단하면
- * 상세에서 툴로 보냈는데 뷰어는 못 고치는 워크플로우로 보는 어긋남이 생긴다.
+ * **실행 이력을 담은 속성은 워크플로우 자체에 없다.** 실행 목록을 조회해 그 길이로만
+ * 알 수 있고, 실행 상태 화면의 버튼 구성도 같은 값을 쓴다.
+ *
+ * ★ **조회 실패는 "실행된 적 없음"으로 본다.**
+ * 갓 만든 워크플로우는 엔진이 Airflow 에서 DAG 를 찾지 못해 한동안 실패로 답한다
+ * (`400` + `The Dag with ID ... not found`). 그건 오류가 아니라 *아직 한 번도 돌지
+ * 않았다*는 뜻이므로, 실행된 것으로 보면 **복제해서 고치라고 안내해 놓고 그 복제본마저
+ * 잠그게 된다.** 반대 방향의 위험(정말 실행된 것을 편집 가능하다고 보는 것)은 실제
+ * 진입 경로가 실행 상태 화면 하나뿐이라 여기까지 오지 않는다.
+ *
+ * 측정(2026-07-19, 개발 서버): 복제 직후 **약 5초** 동안 `400 DAG 없음`, 그 뒤
+ * `200`(실행 없으면 목록이 비어 있거나 `null`). 0.5초 간격으로 재어 얻은 값이다.
  */
-export async function getWorkflowRunHistory(
+export async function hasWorkflowRunHistory(
   workflowId: string,
-): Promise<WorkflowRunHistory> {
-  if (!workflowId) return 'no-runs';
+): Promise<boolean> {
+  if (!workflowId) return false;
   try {
     const { data, execute } = useGetWorkflowRuns(workflowId);
     await execute();
-    return (data.value?.responseData ?? []).length > 0 ? 'has-runs' : 'no-runs';
+    return (data.value?.responseData ?? []).length > 0;
   } catch {
-    return 'unknown';
+    return false;
   }
-}
-
-/*
-  RUN_HISTORY_UNKNOWN — 모를 때 어느 쪽으로 기울일지
-
-  · **편집으로 보낼지 정할 때**는 막는 쪽으로 기운다. 실제로 실행된 워크플로우였다면
-    고치는 순간 과거 기록의 뜻이 조용히 바뀌고 되돌릴 수 없다. 실행 상태로 보내도
-    사용자는 거기서 복제해 고칠 수 있으므로 잃는 것이 적다.
-
-  · **편집기 안에서 잠글지 정할 때**는 잠그지 않는 쪽으로 기운다. 갓 만든 복제본이
-    바로 이 상태로 열리는데(Airflow 가 아직 DAG 를 못 읽었다), 여기서 잠그면
-    **복제해서 고치라고 안내해 놓고 그 복제본도 못 고치게 된다.**
-*/
-export async function shouldSendToRunStatus(
-  workflowId: string,
-): Promise<boolean> {
-  return (await getWorkflowRunHistory(workflowId)) !== 'no-runs';
-}
-
-export async function isEditingLockedByRunHistory(
-  workflowId: string,
-): Promise<boolean> {
-  return (await getWorkflowRunHistory(workflowId)) === 'has-runs';
 }

--- a/front/src/features/sequential/designer/editor/model/editorProviders.ts
+++ b/front/src/features/sequential/designer/editor/model/editorProviders.ts
@@ -20,6 +20,31 @@ const TASK_TYPE_EDITOR: Record<string, any> = {
   trigger_workflow: TriggerWorkflowTaskEditor,
 };
 
+/**
+ * 값 입력칸을 잠근다 — 보여주기만 하는 모드에서 쓴다.
+ *
+ * `<fieldset disabled>` 는 그 안의 input·select·textarea·button 을 **브라우저가**
+ * 비활성화하는 표준 동작이다. 컴포넌트마다 readonly prop 을 뚫는 것보다 짧고
+ * 빠뜨릴 자리가 없다.
+ *
+ * `pointer-events: none` 같은 CSS 로 가리지 않는다 — 키보드 조작에 뚫리고, 무엇보다
+ * *에러 없이 조용히* 통과해 잠긴 줄 알았던 값이 저장된다.
+ *
+ * 다만 native 요소가 아닌 컴포넌트에는 듣지 않으므로, 이 모드는 화면에서 실제로
+ * 잠기는지 확인한 뒤 믿는다.
+ */
+function lockInputs(content: HTMLElement): HTMLElement {
+  const locked = document.createElement('fieldset');
+  locked.disabled = true;
+  locked.className = 'sqd-editor-readonly';
+  locked.style.border = 'none';
+  locked.style.margin = '0';
+  locked.style.padding = '0';
+  locked.style.minWidth = '0';
+  locked.appendChild(content);
+  return locked;
+}
+
 export function editorProviders() {
   const editor = document.createElement('div');
   editor.style.width = '100%';
@@ -181,6 +206,7 @@ export function editorProviders() {
       label.innerText = getSequencePath(definition.sequence, step.id) ?? '';
       editor.appendChild(label);
 
+      if (isReadonly) return lockInputs(editor);
       return editor;
     },
   };

--- a/front/src/features/sequential/designer/model/sequentialDesignerModel.ts
+++ b/front/src/features/sequential/designer/model/sequentialDesignerModel.ts
@@ -240,6 +240,17 @@ export function useSequentialDesignerModel(refs: any) {
     designerOptionsState.sequence = [...sequence];
   }
 
+  /**
+   * 보여주기만 하는 모드. 라이브러리가 끌어다 놓기·삭제·팔레트를 잠그고,
+   * 값 입력칸은 `editorProviders` 가 `isReadonly` 를 받아 잠근다.
+   *
+   * `initDesigner()` 보다 먼저 불러야 한다 — 라이브러리는 만들 때 읽은 값으로 굳어서,
+   * 뒤에 바꾸면 화면은 잠긴 것처럼 보이는데 실제로는 고쳐지는 상태가 된다.
+   */
+  function setReadonly(isReadonly: boolean) {
+    designerOptionsState.others.isReadonly = isReadonly;
+  }
+
   function initDesigner() {
     if (designer) {
       designer.destroy();
@@ -330,6 +341,7 @@ export function useSequentialDesignerModel(refs: any) {
     designer,
     designerOptionsState,
     setDefaultSequence,
+    setReadonly,
     setToolboxGroupsSteps,
     initDesigner,
     draw,

--- a/front/src/features/sequential/designer/ui/SequentialDesigner.vue
+++ b/front/src/features/sequential/designer/ui/SequentialDesigner.vue
@@ -12,6 +12,8 @@ interface IProps {
   sequence: Step[];
   trigger: any;
   taskComponentList: Array<ITaskComponentInfoResponse> | undefined;
+  /** 보여주기만 한다 — 끌어다 놓기·삭제·값 입력이 모두 잠긴다 */
+  readonly?: boolean;
 }
 
 const props = defineProps<IProps>();
@@ -30,6 +32,9 @@ onMounted(function () {
     ...taskComponents,
   ]);
   sequentialDesignerModel.value.setDefaultSequence(props.sequence);
+  // initDesigner 가 configuration 을 만들기 *전에* 정해야 한다 — 라이브러리는
+  // 만들 때 읽은 값으로 굳는다.
+  sequentialDesignerModel.value.setReadonly(props.readonly === true);
   sequentialDesignerModel.value.initDesigner();
   sequentialDesignerModel.value.draw();
 });

--- a/front/src/features/workflow/workflowEditor/ui/WorkflowEditor.vue
+++ b/front/src/features/workflow/workflowEditor/ui/WorkflowEditor.vue
@@ -35,6 +35,7 @@ import { parseRequestBody } from '@/shared/utils/stringToObject';
 import SequentialDesigner from '@/features/sequential/designer/ui/SequentialDesigner.vue';
 import { DEFAULT_NAMESPACE } from '@/shared/constants/namespace';
 import { normalizeTaskComponentList } from '@/entities/workflow/lib/schemaAdapter';
+import { isEditingLockedByRunHistory } from '@/entities/workflow/lib/workflowRunHistory';
 import { useTaskSchemaLoader } from '@/features/sequential/designer/editor/composables/useTaskSchemaLoader';
 
 interface IProps {
@@ -46,7 +47,11 @@ interface IProps {
 }
 
 const props = defineProps<IProps>();
-const emit = defineEmits(['update:close-modal', 'update:trigger']);
+const emit = defineEmits([
+  'update:close-modal',
+  'update:trigger',
+  'update:saved',
+]);
 
 const workflowToolModel = useWorkflowToolModel();
 const workflowName = useInputModel<string>('');
@@ -72,6 +77,15 @@ const trigger = reactive({ value: false });
  */
 const isUneditable = ref(false);
 const loadWarnings = ref<string[]>([]);
+
+/**
+ * 이 워크플로우가 실행된 적이 있어 고칠 수 없을 때 켜진다.
+ *
+ * 정상 경로에서는 여기까지 오지 않는다 — 상세 화면과 실행 뷰어가 실행 이력을 보고
+ * 실행 상태로 보내기 때문이다. 이것은 **뒤에 다른 진입이 생겨도 뚫리지 않게 하는
+ * 안전망**이고, 열렸을 때는 보여주되 고치지 못하게 한다.
+ */
+const isRunLocked = ref(false);
 
 console.log(props);
 
@@ -703,6 +717,11 @@ async function loadWorkflow() {
     // (예: 방금 만든 복제본)도 이 경로로 정상 로드된다.
     workflowData.value =
       await workflowToolModel.workflowStore.ensureWorkflowById(props.wftId);
+    // 실행된 적이 *확실할 때만* 잠근다. 정상 경로는 여기 오기 전에 실행 상태로
+    // 보내지만, 다른 경로로 열렸을 때 조용히 고쳐지는 것을 막는다.
+    // 모를 때 잠그지 않는 이유는 workflowRunHistory 의 RUN_HISTORY_UNKNOWN 참조 —
+    // 갓 만든 복제본이 늘 '모름'으로 열린다.
+    isRunLocked.value = await isEditingLockedByRunHistory(props.wftId);
   } else if (props.toolType === 'add') {
     workflowData.value = workflowToolModel.getWorkflowTemplateData(
       workflowToolModel.dropDownModel.selectedItemId,
@@ -920,6 +939,9 @@ function postWorkflow(workflow: IWorkflow) {
         showSuccessMessage('Success', 'Success');
         emit('update:trigger');
         emit('update:close-modal', false); // 저장 성공 후 모달 닫기
+        // 저장 다음에 하는 일은 대개 실행이다. 어느 워크플로우를 저장했는지 알려
+        // 화면이 그 워크플로우의 실행 상태로 옮겨 가게 한다.
+        emit('update:saved', props.wftId);
       })
       .catch(err => {
         showErrorMessage(
@@ -941,6 +963,11 @@ function postWorkflow(workflow: IWorkflow) {
         showSuccessMessage('Success', 'Success');
         emit('update:trigger');
         emit('update:close-modal', false); // 저장 성공 후 모달 닫기
+        // 새로 만든 워크플로우의 id 는 응답에서만 알 수 있다. 복제 API 와 같은 모양으로
+        // 워크플로우 전체를 돌려준다. **id 가 없으면 옮기지 않는다** — 엉뚱한
+        // 워크플로우의 실행 상태를 보여주느니 있던 화면에 머무는 편이 낫다.
+        const createdId = res?.data?.responseData?.id;
+        if (createdId) emit('update:saved', createdId);
       })
       .catch(err => {
         showErrorMessage(
@@ -985,7 +1012,7 @@ function handleCancel() {
 }
 
 function handleSave() {
-  if (isUneditable.value) return;
+  if (isUneditable.value || isRunLocked.value) return;
   trigger.value = true;
 }
 
@@ -1057,9 +1084,33 @@ function handleSelectTemplate(e) {
               </li>
             </ul>
           </div>
+          <!--
+            실행된 적 있는 워크플로우가 어떤 경로로든 열렸을 때. 고칠 수 없다는 것과
+            어떻게 하면 되는지를 함께 알린다.
+          -->
+          <div
+            v-if="isRunLocked"
+            class="workflow-tool-notice workflow-tool-notice--locked mb-[12px]"
+            data-testid="workflow-run-locked-notice"
+          >
+            <p class="workflow-tool-notice__title">
+              View only — this workflow has been run
+            </p>
+            <ul>
+              <li>
+                Editing it in place would change what its past runs appear to
+                have used, and that cannot be undone.
+              </li>
+              <li>
+                To work on it, go to Run Status and use Clone &amp; Edit. The
+                copy keeps a link back to this workflow.
+              </li>
+            </ul>
+          </div>
           <section v-if="!isUneditable" class="workflow-tool-body">
             <SequentialDesigner
               :sequence="sequentialSequence"
+              :readonly="isRunLocked"
               :trigger="trigger.value"
               :task-component-list="
                 resTaskComponentList.data.value?.responseData
@@ -1079,7 +1130,7 @@ function handleSelectTemplate(e) {
         <p-button
           data-testid="workflow-designer-save"
           :loading="resUpdateWorkflow.isLoading.value"
-          :disabled="isUneditable"
+          :disabled="isUneditable || isRunLocked"
           @click="handleSave"
         >
           Save
@@ -1105,6 +1156,11 @@ function handleSelectTemplate(e) {
   background: #fff8e6;
   padding: 12px 16px;
   border-radius: 4px;
+}
+/* 고칠 수 없다는 것은 경고가 아니라 상태다 — 노란 경고와 색을 달리한다 */
+.workflow-tool-notice--locked {
+  border-left-color: #6b7280;
+  background: #f3f4f6;
 }
 .workflow-tool-notice__title {
   font-weight: 600;

--- a/front/src/features/workflow/workflowEditor/ui/WorkflowEditor.vue
+++ b/front/src/features/workflow/workflowEditor/ui/WorkflowEditor.vue
@@ -4,6 +4,7 @@ import {
   PButton,
   PFieldGroup,
   PSelectDropdown,
+  PSpinner,
   PTextInput,
 } from '@cloudforet-test/mirinae';
 import { useWorkflowToolModel } from '@/features/workflow/workflowEditor/model/workflowEditorModel';
@@ -35,7 +36,7 @@ import { parseRequestBody } from '@/shared/utils/stringToObject';
 import SequentialDesigner from '@/features/sequential/designer/ui/SequentialDesigner.vue';
 import { DEFAULT_NAMESPACE } from '@/shared/constants/namespace';
 import { normalizeTaskComponentList } from '@/entities/workflow/lib/schemaAdapter';
-import { isEditingLockedByRunHistory } from '@/entities/workflow/lib/workflowRunHistory';
+import { hasWorkflowRunHistory } from '@/entities/workflow/lib/workflowRunHistory';
 import { useTaskSchemaLoader } from '@/features/sequential/designer/editor/composables/useTaskSchemaLoader';
 
 interface IProps {
@@ -86,6 +87,37 @@ const loadWarnings = ref<string[]>([]);
  * 안전망**이고, 열렸을 때는 보여주되 고치지 못하게 한다.
  */
 const isRunLocked = ref(false);
+
+/**
+ * 워크플로우를 아직 읽지 못한 상태.
+ *
+ * 방금 만든 워크플로우는 엔진이 Airflow 에서 읽지 못하는 구간이 잠시 있다
+ * (개발 서버 측정 약 5초, `get-workflow` 가 400). 그때 조회 결과가 비는데,
+ * **그대로 두면 빈 캔버스가 아무 말 없이 뜬다** — 태스크가 하나도 없는 워크플로우처럼
+ * 보이고, 그 상태로 저장하면 내용이 날아간다.
+ *
+ * 그래서 읽힐 때까지 기다렸다가 그리고, 무엇을 기다리는지 화면에 적는다.
+ * (복제 직후 편집기로 오는 경로는 복제 응답이 캐시에 있어 곧바로 그려진다.)
+ */
+const workflowLoadState = ref<'ok' | 'waiting' | 'failed'>('ok');
+
+const WORKFLOW_READY_INTERVAL_MS = 2000;
+const WORKFLOW_READY_TIMEOUT_MS = 60000;
+
+async function fetchWorkflowForEdit() {
+  const deadline = Date.now() + WORKFLOW_READY_TIMEOUT_MS;
+  for (;;) {
+    const found = await workflowToolModel.workflowStore.ensureWorkflowById(
+      props.wftId,
+    );
+    if (found) return found;
+    if (Date.now() + WORKFLOW_READY_INTERVAL_MS > deadline) return undefined;
+    workflowLoadState.value = 'waiting';
+    await new Promise(resolve =>
+      setTimeout(resolve, WORKFLOW_READY_INTERVAL_MS),
+    );
+  }
+}
 
 console.log(props);
 
@@ -711,17 +743,31 @@ function createTaskForModel(
   });
 }
 
+/*
+  이 편집기로 들어오는 길과, 그때 **엔진에서 워크플로우를 읽어야 하는가**
+
+  | 들어온 길 | toolType | 무엇으로 그리나 | 기다림 |
+  |---|---|---|---|
+  | 실행 상태 → Edit (미실행 원본) | edit | 스토어(목록에서 이미 받음) → 없으면 엔진 | 필요 |
+  | 실행 상태 → Clone & Edit | edit | 스토어(복제 응답을 바로 넣어 둔다) | 사실상 즉시 |
+  | JSON 으로 만든 워크플로우를 나중에 열기 | edit | 스토어 → 없으면 엔진 | 필요 |
+  | 타깃 모델에서 진입 | add | 템플릿 | 불필요 |
+  | 목록의 새로 만들기(지금은 막혀 있다) | add | 템플릿 | 불필요 |
+
+  기다림이 필요한 것은 **`edit` 하나뿐**이다 — `add` 는 기존 워크플로우를 읽지 않고
+  템플릿으로 그리므로 엔진 상태와 무관하다. 그래서 대기도 이 분기 안에만 둔다.
+*/
 async function loadWorkflow() {
   if (props.toolType === 'edit') {
     // 캐시에 없으면 스토어가 받아서 채운다. 목록 화면을 거치지 않고 열린 워크플로우
     // (예: 방금 만든 복제본)도 이 경로로 정상 로드된다.
-    workflowData.value =
-      await workflowToolModel.workflowStore.ensureWorkflowById(props.wftId);
-    // 실행된 적이 *확실할 때만* 잠근다. 정상 경로는 여기 오기 전에 실행 상태로
-    // 보내지만, 다른 경로로 열렸을 때 조용히 고쳐지는 것을 막는다.
-    // 모를 때 잠그지 않는 이유는 workflowRunHistory 의 RUN_HISTORY_UNKNOWN 참조 —
-    // 갓 만든 복제본이 늘 '모름'으로 열린다.
-    isRunLocked.value = await isEditingLockedByRunHistory(props.wftId);
+    workflowData.value = await fetchWorkflowForEdit();
+    workflowLoadState.value = workflowData.value ? 'ok' : 'failed';
+    if (!workflowData.value) return;
+    // 실행 이력이 있으면 보여주기만 한다. 정상 경로(실행 상태 화면)는 이력이 있는
+    // 워크플로우를 아예 여기로 보내지 않으므로, 이것은 뒤에 다른 진입이 생겨도
+    // 뚫리지 않게 하는 안전망이다.
+    isRunLocked.value = await hasWorkflowRunHistory(props.wftId);
   } else if (props.toolType === 'add') {
     workflowData.value = workflowToolModel.getWorkflowTemplateData(
       workflowToolModel.dropDownModel.selectedItemId,
@@ -1013,6 +1059,8 @@ function handleCancel() {
 
 function handleSave() {
   if (isUneditable.value || isRunLocked.value) return;
+  // 읽지 못한 상태로 저장하면 빈 정의를 덮어쓴다
+  if (workflowLoadState.value !== 'ok') return;
   trigger.value = true;
 }
 
@@ -1107,7 +1155,39 @@ function handleSelectTemplate(e) {
               </li>
             </ul>
           </div>
-          <section v-if="!isUneditable" class="workflow-tool-body">
+          <!--
+            아직 읽어 오지 못한 상태. **왜 늦는지는 적지 않는다** — 여기까지 오는 길이
+            여럿이라(복제본·타깃 모델·새로 만들기·JSON 으로 만든 것 열기) 화면이 원인을
+            단정할 수 없다. 기다리는 중이라는 사실만 알리고, 되면 그때 그린다.
+          -->
+          <div
+            v-if="workflowLoadState === 'waiting'"
+            class="workflow-tool-loading"
+            data-testid="workflow-load-notice"
+          >
+            <p-spinner size="md" />
+            <p>Getting this workflow ready…</p>
+          </div>
+          <div
+            v-else-if="workflowLoadState === 'failed'"
+            class="workflow-tool-notice mb-[12px]"
+            data-testid="workflow-load-notice"
+          >
+            <p class="workflow-tool-notice__title">
+              This workflow could not be read
+            </p>
+            <ul>
+              <li>
+                Nothing is shown rather than an empty canvas, because saving an
+                empty canvas would wipe the workflow. Close this and open it
+                again in a moment.
+              </li>
+            </ul>
+          </div>
+          <section
+            v-if="!isUneditable && workflowLoadState === 'ok'"
+            class="workflow-tool-body"
+          >
             <SequentialDesigner
               :sequence="sequentialSequence"
               :readonly="isRunLocked"
@@ -1130,7 +1210,7 @@ function handleSelectTemplate(e) {
         <p-button
           data-testid="workflow-designer-save"
           :loading="resUpdateWorkflow.isLoading.value"
-          :disabled="isUneditable || isRunLocked"
+          :disabled="isUneditable || isRunLocked || workflowLoadState !== 'ok'"
           @click="handleSave"
         >
           Save
@@ -1161,6 +1241,16 @@ function handleSelectTemplate(e) {
 .workflow-tool-notice--locked {
   border-left-color: #6b7280;
   background: #f3f4f6;
+}
+.workflow-tool-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 240px;
+  color: #4b5563;
+  font-size: 0.875rem;
 }
 .workflow-tool-notice__title {
   font-weight: 600;

--- a/front/src/pages/models/targetModels/ui/TargetModelsPage.vue
+++ b/front/src/pages/models/targetModels/ui/TargetModelsPage.vue
@@ -8,6 +8,29 @@ import { reactive, ref, computed } from 'vue';
 import WorkflowEditor from '@/features/workflow/workflowEditor/ui/WorkflowEditor.vue';
 import { useTargetModelStore, useUpdateTargetModel } from '@/entities';
 import { showErrorMessage, showSuccessMessage } from '@/shared/utils';
+import { useRouter } from 'vue-router/composables';
+import { WORKFLOW_MANAGEMENT_ROUTE } from '@/app/providers/router/routes/constants';
+
+const router = useRouter();
+
+/**
+ * 여기서 만든 워크플로우도 저장하면 **실행 상태로 보낸다.**
+ *
+ * 워크플로우 화면에서 저장했을 때와 같은 자리에 도착해야 한다 — 저장 다음에 하는 일은
+ * 대개 *실행*이고, 실행할지 더 고칠지는 실행 상태 화면에서 갈린다. 예전엔 여기서
+ * 저장하면 편집기만 닫히고 목표 모델 화면에 그대로 남아, **방금 만든 워크플로우를
+ * 찾아가려면 사용자가 직접 워크플로우 목록으로 이동해 다시 골라야 했다.**
+ *
+ * 화면이 다르므로(목표 모델 ↔ 워크플로우) 탭 전환이 아니라 라우팅이고, 어느
+ * 워크플로우인지는 쿼리로 넘긴다.
+ */
+function handleSavedWorkflow(workflowId: string) {
+  modalStates.workflowEditorModal.open = false;
+  router.push({
+    name: WORKFLOW_MANAGEMENT_ROUTE.WORKFLOWS._NAME,
+    query: workflowId ? { wfId: workflowId } : {},
+  });
+}
 
 const pageName = 'Target Models';
 
@@ -20,31 +43,36 @@ const targetModelStore = useTargetModelStore();
 
 // Add computed property for targetModel
 const targetModelForWorkflow = computed(() => {
-  const model = targetModelStore.getTargetModelById(selectedTargetModelId.value);
+  const model = targetModelStore.getTargetModelById(
+    selectedTargetModelId.value,
+  );
   if (model) {
     // modelType을 기반으로 migrationType 설정
     let migrationType = 'infra'; // 기본값
-    
+
     if (model.modelType === 'SoftwareModel') {
       migrationType = 'software';
-    } else if (model.modelType === 'CloudModel' || model.modelType === 'OnPremiseModel') {
+    } else if (
+      model.modelType === 'CloudModel' ||
+      model.modelType === 'OnPremiseModel'
+    ) {
       migrationType = 'infra';
     }
-    
+
     const modelWithMigrationType = {
       ...model,
-      migrationType: migrationType
+      migrationType: migrationType,
     };
-    
+
     console.log('Passing targetModel to WorkflowEditor:', {
       selectedTargetModelId: selectedTargetModelId.value,
       model: modelWithMigrationType,
       modelType: model?.modelType,
       migrationType: migrationType,
       hasCloudInfraModel: !!model?.cloudInfraModel,
-      isCloudModel: model?.isCloudModel
+      isCloudModel: model?.isCloudModel,
     });
-    
+
     return modelWithMigrationType;
   }
   return model;
@@ -194,16 +222,17 @@ function handleUpdateTargetModel(e) {
       />
     </div>
     <div class="relative z-70">
-              <workflow-editor
-          v-if="modalStates.workflowEditorModal.open"
-          :target-model-name="targetModelName"
-          tool-type="add"
-          wft-id=""
-          :target-model="targetModelForWorkflow"
-          :migration-type="migrationTypeForWorkflow"
-          :recommended-model="targetModelForWorkflow"
-          @update:close-modal="modalStates.workflowEditorModal.open = false"
-        />
+      <workflow-editor
+        v-if="modalStates.workflowEditorModal.open"
+        :target-model-name="targetModelName"
+        tool-type="add"
+        wft-id=""
+        :target-model="targetModelForWorkflow"
+        :migration-type="migrationTypeForWorkflow"
+        :recommended-model="targetModelForWorkflow"
+        @update:close-modal="modalStates.workflowEditorModal.open = false"
+        @update:saved="handleSavedWorkflow"
+      />
     </div>
   </div>
 </template>

--- a/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
+++ b/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
@@ -14,8 +14,10 @@ import {
   useUpdateWorkflow,
   useWorkflowStore,
 } from '@/entities';
+import { shouldSendToRunStatus } from '@/entities/workflow/lib/workflowRunHistory';
 import {
   showErrorMessage,
+  showInfoMessage,
   showSuccessMessage,
   toErrorMessage,
 } from '@/shared/utils';
@@ -62,6 +64,38 @@ function handleEditJson(workflowId: string) {
   workflowName.value = wf?.name ?? '';
   workflowJson.value = wf?.data ?? {};
   modalState.workflowJsonModal.open = true;
+}
+
+/**
+ * 상세 화면의 "View Workflow Tool" — 실행 이력이 있으면 툴을 열지 않는다.
+ *
+ * 툴은 원본을 그대로 덮어쓰는데 엔진은 실행별 정의를 남기지 않는다. 그래서 실행된
+ * 워크플로우를 고치면 **과거 실행이 화면에서 엉뚱한 값으로 보이게 되고 되돌릴 수 없다.**
+ * 실행 이력이 있으면 먼저 어떻게 돌았는지 보도록 실행 상태로 보내고, 고칠 일이 있으면
+ * 거기서 Clone & Edit 으로 복제본을 열게 한다.
+ *
+ * 뷰어 쪽 진입(Edit / Clone & Edit)은 이미 같은 기준으로 갈라져 있었고, 이 링크만
+ * 확인 없이 열려 있었다.
+ */
+async function handleOpenWorkflowTool() {
+  if (await shouldSendToRunStatus(selectedWorkflowId.value)) {
+    mainTabState.activeTab = 'runViewer';
+    showInfoMessage(
+      'Opened run status instead',
+      'This workflow has been run before, so it cannot be edited in place — editing it would change what past runs appear to have used. Use Clone & Edit here to work on a copy.',
+    );
+    return;
+  }
+  modalState.workflowToolModal.open = true;
+}
+
+/**
+ * 저장이 끝나면 실행 상태로 보낸다. 저장 다음에 하는 일은 대개 *실행*이고,
+ * 상태 화면에서 실행·수정을 이어 정할 수 있다.
+ */
+function handleSavedWorkflow(workflowId: string) {
+  if (workflowId) selectedWorkflowId.value = workflowId;
+  mainTabState.activeTab = 'runViewer';
 }
 
 const selectedWorkflowId = ref<string>('');
@@ -235,9 +269,7 @@ async function handleUpdateWorkflow(updatedData: object) {
               @update:workflow-json-modal="
                 modalState.workflowJsonModal.open = true
               "
-              @update:workflow-tool-modal="
-                e => (modalState.workflowToolModal.open = e)
-              "
+              @update:workflow-tool-modal="handleOpenWorkflowTool"
               @update:workflow-name="e => (workflowName = e)"
               @update:workflow-json="e => (workflowJson = e)"
             />
@@ -297,6 +329,7 @@ async function handleUpdateWorkflow(updatedData: object) {
         :wft-id="selectedWorkflowId"
         @update:close-modal="e => (modalState.workflowToolModal.open = e)"
         @update:trigger="modalState.addWorkflow.trigger = true"
+        @update:saved="handleSavedWorkflow"
       />
     </div>
   </div>

--- a/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
+++ b/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { PTab, PButton } from '@cloudforet-test/mirinae';
-import { ref, reactive } from 'vue';
+import { ref, reactive, onMounted } from 'vue';
+import { useRoute } from 'vue-router/composables';
 import {
   WorkflowList,
   WorkflowDetail,
@@ -24,6 +25,7 @@ import WorkflowEditor from '@/features/workflow/workflowEditor/ui/WorkflowEditor
 const getWorkflow = useGetWorkflow(null);
 const updateWorkflow = useUpdateWorkflow(null, null);
 const workflowStore = useWorkflowStore();
+const route = useRoute();
 
 const pageName = 'Workflows';
 
@@ -74,6 +76,18 @@ function handleSavedWorkflow(workflowId: string) {
 }
 
 const selectedWorkflowId = ref<string>('');
+
+/**
+ * 다른 화면(목표 모델)에서 워크플로우를 만들고 넘어온 경우.
+ *
+ * 저장 직후 도착지는 화면이 달라도 같아야 한다 — 그쪽은 탭을 바꿀 수 없으니 어느
+ * 워크플로우인지를 쿼리로 넘겨 주고, 여기서 그것을 골라 실행 상태로 연다.
+ */
+onMounted(() => {
+  const wfId = route.query.wfId;
+  if (typeof wfId === 'string' && wfId) handleSavedWorkflow(wfId);
+});
+
 const workflowName = ref<string>('');
 const workflowJson = ref<object>({});
 const wfIdData = ref<object>({});

--- a/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
+++ b/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
@@ -14,10 +14,8 @@ import {
   useUpdateWorkflow,
   useWorkflowStore,
 } from '@/entities';
-import { shouldSendToRunStatus } from '@/entities/workflow/lib/workflowRunHistory';
 import {
   showErrorMessage,
-  showInfoMessage,
   showSuccessMessage,
   toErrorMessage,
 } from '@/shared/utils';
@@ -67,29 +65,6 @@ function handleEditJson(workflowId: string) {
 }
 
 /**
- * 상세 화면의 "View Workflow Tool" — 실행 이력이 있으면 툴을 열지 않는다.
- *
- * 툴은 원본을 그대로 덮어쓰는데 엔진은 실행별 정의를 남기지 않는다. 그래서 실행된
- * 워크플로우를 고치면 **과거 실행이 화면에서 엉뚱한 값으로 보이게 되고 되돌릴 수 없다.**
- * 실행 이력이 있으면 먼저 어떻게 돌았는지 보도록 실행 상태로 보내고, 고칠 일이 있으면
- * 거기서 Clone & Edit 으로 복제본을 열게 한다.
- *
- * 뷰어 쪽 진입(Edit / Clone & Edit)은 이미 같은 기준으로 갈라져 있었고, 이 링크만
- * 확인 없이 열려 있었다.
- */
-async function handleOpenWorkflowTool() {
-  if (await shouldSendToRunStatus(selectedWorkflowId.value)) {
-    mainTabState.activeTab = 'runViewer';
-    showInfoMessage(
-      'Opened run status instead',
-      'This workflow has been run before, so it cannot be edited in place — editing it would change what past runs appear to have used. Use Clone & Edit here to work on a copy.',
-    );
-    return;
-  }
-  modalState.workflowToolModal.open = true;
-}
-
-/**
  * 저장이 끝나면 실행 상태로 보낸다. 저장 다음에 하는 일은 대개 *실행*이고,
  * 상태 화면에서 실행·수정을 이어 정할 수 있다.
  */
@@ -118,7 +93,9 @@ const modalState = reactive({
 });
 
 const mainTabState = reactive({
-  activeTab: 'details',
+  // 워크플로우를 고르면 **실행 상태를 먼저 보여준다.** 여기서 실행할지 고칠지가
+  // 갈리고(이력 유무로 버튼이 달라진다), 정의 자체는 그 아래 그래프로 보인다.
+  activeTab: 'runViewer',
   tabs: [
     {
       name: 'details',
@@ -266,10 +243,6 @@ async function handleUpdateWorkflow(updatedData: object) {
             </div>
             <workflow-detail
               :selected-workflow-id="selectedWorkflowId"
-              @update:workflow-json-modal="
-                modalState.workflowJsonModal.open = true
-              "
-              @update:workflow-tool-modal="handleOpenWorkflowTool"
               @update:workflow-name="e => (workflowName = e)"
               @update:workflow-json="e => (workflowJson = e)"
             />
@@ -287,6 +260,7 @@ async function handleUpdateWorkflow(updatedData: object) {
             <workflow-run-viewer
               :workflow-id="selectedWorkflowId"
               @edit-json="handleEditJson"
+              @view-json="handleEditJson"
               @edit-clone="handleEditClone"
               @edit-original="handleEditOriginal"
             />

--- a/front/src/widgets/workflow/workflows/workflowDetail/model/workflowDetailModel.ts
+++ b/front/src/widgets/workflow/workflows/workflowDetail/model/workflowDetailModel.ts
@@ -22,8 +22,11 @@ export function useWorkflowDetailModel() {
       { label: 'Description', name: 'description', disableCopy: true },
       { label: 'Created Date Time', name: 'created_at' },
       { label: 'Updated Date Time', name: 'updated_at' },
-      { label: 'Workflow Tool', name: 'workflowTool', disableCopy: true },
-      { label: 'Workflow JSON', name: 'workflowJSON', disableCopy: true },
+      // 'Workflow Tool'·'Workflow JSON' 링크는 여기서 뺐다. 편집이냐 실행이냐는
+      // **실행 상태 화면 한 곳에서** 정한다 — 거기서만 실행 이력을 보고 원본 편집·
+      // 복제 편집·JSON 편집을 갈라 줄 수 있다. 상세에서 곧장 열면 그 판단을 건너뛰고,
+      // 그것을 막으려 상세에도 같은 판정을 복제해 두면 두 곳이 어긋난다.
+      // 상세는 *이 워크플로우가 무엇인지*만 적고, 할 수 있는 일은 실행 상태에 모은다.
     ];
   }
 
@@ -38,8 +41,6 @@ export function useWorkflowDetailModel() {
         description: '-',
         created_at: workflow.created_at,
         updated_at: workflow.updated_at,
-        workflowTool: {},
-        workflowJSON: {},
       };
     }
     return data;

--- a/front/src/widgets/workflow/workflows/workflowDetail/ui/WorkflowDetail.vue
+++ b/front/src/widgets/workflow/workflows/workflowDetail/ui/WorkflowDetail.vue
@@ -9,12 +9,7 @@ interface iProps {
 
 const props = defineProps<iProps>();
 
-const emit = defineEmits([
-  'update:workflow-name',
-  'update:workflow-json-modal',
-  'update:workflow-tool-modal',
-  'update:workflow-json',
-]);
+const emit = defineEmits(['update:workflow-name', 'update:workflow-json']);
 
 const { workflowStore, initTable, tableModel, workflowId } =
   useWorkflowDetailModel();
@@ -38,14 +33,6 @@ watchEffect(() => {
   );
 });
 
-function handleWorkflowTool() {
-  emit('update:workflow-tool-modal', true);
-}
-
-function handleJsonModal() {
-  emit('update:workflow-json-modal', true);
-}
-
 watchEffect(() => {
   emit(
     'update:workflow-json',
@@ -62,24 +49,6 @@ watchEffect(() => {
       :loading="tableModel.tableState.loading"
       block
     >
-      <template #data-workflowTool>
-        <p
-          data-testid="workflow-create"
-          class="link-button-text"
-          @click="handleWorkflowTool"
-        >
-          View Workflow Tool
-        </p>
-      </template>
-      <template #data-workflowJSON>
-        <p
-          data-testid="workflow-json-view"
-          class="link-button-text"
-          @click="handleJsonModal"
-        >
-          View Workflow JSON
-        </p>
-      </template>
     </p-definition-table>
   </div>
 </template>

--- a/front/src/widgets/workflow/workflows/workflowList/ui/WorkflowList.vue
+++ b/front/src/widgets/workflow/workflows/workflowList/ui/WorkflowList.vue
@@ -134,6 +134,21 @@ function handleSelectedIndex(selectedIndex: number) {
   }
 }
 
+/**
+ * 표에서 지금 보고 있는 워크플로우에 표시를 맞춘다.
+ *
+ * 목록을 다시 받으면 행 순서가 바뀔 수 있는데(새로 만든 워크플로우가 끼어든다)
+ * 표는 *자리 번호*로 선택을 기억한다. 그래서 그대로 두면 **표는 A 를 짚고 있는데
+ * 아래 상세·실행 상태는 B 를 보여주는** 상태가 된다 — 저장 직후가 늘 그렇다.
+ */
+function highlightSelectedRow() {
+  if (!props.selectedWfId) return;
+  const index = tableModel.tableState.displayItems.findIndex(
+    (item: any) => item?.id === props.selectedWfId,
+  );
+  tableModel.tableState.selectIndex = index >= 0 ? [index] : [];
+}
+
 async function fetchWorkflowList() {
   isDataLoaded.value = false;
   try {
@@ -155,6 +170,7 @@ async function fetchWorkflowList() {
       isDataLoaded.value = true;
       // 데이터 로드 후 컴포넌트 재렌더링
       tableKey.value++;
+      highlightSelectedRow();
     });
   } catch (e) {
     workflowStore.setWorkFlows([]);

--- a/front/src/widgets/workflow/workflows/workflowList/ui/WorkflowList.vue
+++ b/front/src/widgets/workflow/workflows/workflowList/ui/WorkflowList.vue
@@ -13,7 +13,15 @@ import {
   showErrorMessage,
 } from '@/shared/utils';
 import DynamicTableIconButton from '@/shared/ui/Button/dynamicIconButton/DynamicTableIconButton.vue';
-import { onBeforeMount, onMounted, reactive, ref, watch, computed, nextTick } from 'vue';
+import {
+  onBeforeMount,
+  onMounted,
+  reactive,
+  ref,
+  watch,
+  computed,
+  nextTick,
+} from 'vue';
 import { useGetWorkflowList, useBulkDeleteWorkflow } from '@/entities';
 import { useRunWorkflow } from '@/entities';
 import { useDynamicTableHeight } from '@/shared/hooks/table/useDynamicTableHeight';
@@ -58,10 +66,12 @@ onMounted(function (this: any) {
   fetchWorkflowList();
 });
 
-watch(isDataLoaded, (nv) => {
+watch(isDataLoaded, nv => {
   if (nv && toolboxTableRef.value) {
     nextTick(() => {
-      addDeleteIconAtTable.call({ $refs: { toolboxTable: toolboxTableRef.value } });
+      addDeleteIconAtTable.call({
+        $refs: { toolboxTable: toolboxTableRef.value },
+      });
     });
   }
 });
@@ -201,14 +211,18 @@ watch(
       <template #container="{ height }">
         <!-- 로딩 중일 때 스피너 표시 -->
         <table-loading-spinner
-          :loading="getWorkflowList.isLoading.value || tableModel.tableState.loading"
+          :loading="
+            getWorkflowList.isLoading.value || tableModel.tableState.loading
+          "
           :height="height"
           message="Loading workflows..."
         />
-        
+
         <!-- 로딩 완료 후 테이블 표시 -->
         <p-toolbox-table
-          v-if="!getWorkflowList.isLoading.value && !tableModel.tableState.loading"
+          v-if="
+            !getWorkflowList.isLoading.value && !tableModel.tableState.loading
+          "
           ref="toolboxTableRef"
           data-testid="workflow-list-table"
           :items="tableModel.tableState.displayItems"

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
@@ -156,9 +156,16 @@ export function useWorkflowRunViewerModel() {
   }
 
   async function loadRuns(wfId: string) {
-    const { data, execute } = useGetWorkflowRuns(wfId);
-    await execute();
-    runs.value = data.value?.responseData ?? [];
+    try {
+      const { data, execute } = useGetWorkflowRuns(wfId);
+      await execute();
+      runs.value = data.value?.responseData ?? [];
+    } catch {
+      // 아직 실행된 적 없는 워크플로우는 엔진에서 조회가 실패한다 — Airflow 가 새
+      // DAG 를 읽어들이기 전이라 없는 것으로 나온다. **실패가 아니라 "아직 없음"** 이므로
+      // 붉은 오류 대신 실행을 권하는 빈 상태를 보여준다.
+      runs.value = [];
+    }
   }
 
   let inFlight = false;
@@ -230,6 +237,16 @@ export function useWorkflowRunViewerModel() {
 
   async function open(wfId: string, runId?: string | null) {
     loadError.value = null;
+    // **다른 워크플로우의 내용을 물려받지 않는다.** 비우지 않으면 조회가 실패했을 때
+    // 앞서 보던 워크플로우의 실행이 이 워크플로우의 것처럼 남는다 — 방금 만든
+    // 워크플로우에서 늘 그렇게 된다(엔진이 새 DAG 를 아직 못 읽어 404 로 답한다).
+    runs.value = [];
+    instances.value = [];
+    selectedRunId.value = null;
+    selectedTaskId.value = null;
+    logText.value = '';
+    logError.value = null;
+
     await Promise.all([loadWorkflow(wfId), loadRuns(wfId)]);
 
     const target =

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
@@ -39,6 +39,8 @@ const MIN_POLL_INTERVAL_MS = 2000;
 
 export function useWorkflowRunViewerModel() {
   const workflow = ref<IWorkflowResponse | null>(null);
+  /** 엔진이 이 워크플로우를 읽을 수 있는가 — 방금 만든 것은 잠시 못 읽는다 */
+  const workflowReadyState = ref<'ready' | 'waiting' | 'timeout'>('ready');
   const runs = ref<IWorkflowRun[]>([]);
   const selectedRunId = ref<string | null>(null);
   const workflowStore = useWorkflowStore();
@@ -150,9 +152,45 @@ export function useWorkflowRunViewerModel() {
   });
 
   async function loadWorkflow(wfId: string) {
-    const { data, execute } = useGetWorkflow(wfId);
-    await execute();
-    workflow.value = data.value?.responseData ?? null;
+    try {
+      const { data, execute } = useGetWorkflow(wfId);
+      await execute();
+      workflow.value = data.value?.responseData ?? null;
+    } catch {
+      workflow.value = null;
+    }
+    return workflow.value != null;
+  }
+
+  /**
+   * 엔진이 이 워크플로우를 읽을 수 있게 될 때까지 기다린다.
+   *
+   * 방금 만든 워크플로우는 Airflow 가 DAG 를 등록하기 전이라 조회가 잠시 실패한다
+   * (개발 서버 실측 약 5초). 그때 그래프를 그리면 **"표시할 태스크가 없습니다"** 가 뜨는데,
+   * 이건 사실이 아니다 — 태스크가 없는 게 아니라 아직 못 읽은 것이다. 화면이 없는 것과
+   * 아직인 것을 구분하지 못하면 사용자는 워크플로우가 비어 있다고 오해한다.
+   *
+   * 그래서 읽힐 때까지 기다리고, 기다리는 중임을 화면에 알린다.
+   */
+  const WORKFLOW_READY_INTERVAL_MS = 2000;
+  const WORKFLOW_READY_TIMEOUT_MS = 60000;
+
+  async function waitForWorkflow(wfId: string) {
+    const deadline = Date.now() + WORKFLOW_READY_TIMEOUT_MS;
+    for (;;) {
+      if (await loadWorkflow(wfId)) {
+        workflowReadyState.value = 'ready';
+        return true;
+      }
+      if (Date.now() + WORKFLOW_READY_INTERVAL_MS > deadline) {
+        workflowReadyState.value = 'timeout';
+        return false;
+      }
+      workflowReadyState.value = 'waiting';
+      await new Promise(resolve =>
+        setTimeout(resolve, WORKFLOW_READY_INTERVAL_MS),
+      );
+    }
   }
 
   async function loadRuns(wfId: string) {
@@ -246,8 +284,12 @@ export function useWorkflowRunViewerModel() {
     selectedTaskId.value = null;
     logText.value = '';
     logError.value = null;
+    workflowReadyState.value = 'ready';
 
-    await Promise.all([loadWorkflow(wfId), loadRuns(wfId)]);
+    // 정의를 먼저 확보한다. 못 읽는 동안 실행 목록을 조회해 봐야 같은 이유로 실패한다.
+    const ready = await waitForWorkflow(wfId);
+    if (!ready) return;
+    await loadRuns(wfId);
 
     const target =
       runId ??
@@ -433,6 +475,7 @@ export function useWorkflowRunViewerModel() {
 
   return {
     workflow,
+    workflowReadyState,
     runs,
     selectedRunId,
     selectedRun,

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -4,6 +4,7 @@ import {
   PBadge,
   PButton,
   PSelectDropdown,
+  PSpinner,
   PTooltip,
 } from '@cloudforet-test/mirinae';
 import RunGraph from './RunGraph.vue';
@@ -46,6 +47,7 @@ const {
   deletedTaskInstances,
   definitionChangedAfterRun,
   graph,
+  workflowReadyState,
   hasRuns,
   canEditInDesigner,
   designerSupport,
@@ -555,7 +557,28 @@ async function onRunChange(runId: string) {
           </span>
         </div>
 
-        <div v-if="!graph.nodes.length" class="run-viewer__empty">
+        <!--
+          방금 만든 워크플로우는 엔진이 DAG 를 등록하기 전이라 잠시 읽히지 않는다.
+          그때 "표시할 태스크가 없습니다"를 띄우면 **사실과 다르다** — 태스크가 없는 게
+          아니라 아직 못 읽은 것이고, 사용자는 워크플로우가 비어 있다고 오해한다.
+          그래서 읽힐 때까지 기다리는 중임을 밝힌다.
+        -->
+        <div
+          v-if="workflowReadyState === 'waiting'"
+          class="run-viewer__waiting"
+          data-testid="workflow-run-waiting"
+        >
+          <p-spinner size="md" />
+          <p>Waiting for this workflow to be ready…</p>
+        </div>
+        <div
+          v-else-if="workflowReadyState === 'timeout'"
+          class="run-viewer__empty"
+          data-testid="workflow-run-waiting"
+        >
+          This workflow could not be read yet. Open it again in a moment.
+        </div>
+        <div v-else-if="!graph.nodes.length" class="run-viewer__empty">
           No tasks to display.
         </div>
         <run-graph
@@ -1113,6 +1136,18 @@ async function onRunChange(runId: string) {
   padding: 2rem;
   text-align: center;
   color: #6b6e78;
+  font-size: 0.8125rem;
+}
+
+.run-viewer__waiting {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  min-height: 12rem;
+  color: #4b5563;
   font-size: 0.8125rem;
 }
 

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, nextTick, ref, watch } from 'vue';
 import {
   PBadge,
   PButton,
@@ -97,6 +97,20 @@ async function cloneAndEdit() {
  * 미실행 원본 편집. 실행 이력이 없으니 복제 없이 원본을 직접 연다.
  * 툴이 못 옮기는 그래프면 이유를 보이고 JSON 에디터로 갈지 물어본다.
  */
+/**
+ * 기다리는 중이라는 표시를 **눈에 보이는 자리로 데려온다.**
+ *
+ * 이 화면은 워크플로우 목록 아래에 있어서, 저장 직후 도착하면 그래프 자리가 화면
+ * 아래로 잘려 나간다. 거기에만 표시를 두면 위쪽 저장 완료 알림만 보이고 *데이터를
+ * 준비하는 중*이라는 사실은 스크롤해야 알 수 있다 — 화면이 멈춘 것처럼 보인다.
+ */
+const waitingRef = ref<HTMLElement | null>(null);
+watch(workflowReadyState, async state => {
+  if (state !== 'waiting') return;
+  await nextTick();
+  waitingRef.value?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+});
+
 const showEditJsonConfirm = ref(false);
 function requestEdit() {
   if (!canEditInDesigner.value) {
@@ -565,11 +579,16 @@ async function onRunChange(runId: string) {
         -->
         <div
           v-if="workflowReadyState === 'waiting'"
+          ref="waitingRef"
           class="run-viewer__waiting"
           data-testid="workflow-run-waiting"
         >
-          <p-spinner size="md" />
-          <p>Waiting for this workflow to be ready…</p>
+          <p-spinner size="lg" />
+          <p class="run-viewer__waiting-title">Preparing workflow data…</p>
+          <p class="run-viewer__waiting-hint">
+            Waiting until the workflow can be read. The graph appears here once
+            it is ready.
+          </p>
         </div>
         <div
           v-else-if="workflowReadyState === 'timeout'"
@@ -1139,12 +1158,23 @@ async function onRunChange(runId: string) {
   font-size: 0.8125rem;
 }
 
+.run-viewer__waiting-title {
+  font-weight: 600;
+  color: #374151;
+}
+
+.run-viewer__waiting-hint {
+  color: #6b6e78;
+  text-align: center;
+  max-width: 22rem;
+}
+
 .run-viewer__waiting {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
+  gap: 0.5rem;
   padding: 2rem;
   min-height: 12rem;
   color: #4b5563;

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -31,6 +31,8 @@ const emit = defineEmits<{
   (e: 'edit-original', workflowId: string): void;
   (e: 'edit-clone', clonedWorkflowId: string): void;
   (e: 'edit-json', workflowId: string): void;
+  // - view-json : 정의를 그대로 보여준다 (상세 화면에 있던 것을 이리로 모았다)
+  (e: 'view-json', workflowId: string): void;
 }>();
 
 const {
@@ -76,6 +78,11 @@ const {
  *
  * 워크플로우 툴이 그대로 옮길 수 없는 그래프면 복제본을 JSON 에디터로 연다. 툴로 열면
  * 그림이 실제 실행과 달라지고, 그 상태로 저장하면 실행 순서가 조용히 바뀌기 때문이다.
+ *
+ * 만든 직후 바로 열어도 된다. 엔진이 그 복제본을 Airflow 에서 읽지 못하는 구간이
+ * 잠시(측정 약 5초) 있지만, **편집기는 그 읽기에 기대지 않는다** — 복제 응답을 그대로
+ * 캐시에 넣어 두고 거기서 그린다. 저장도 그 구간에 이미 동작한다(측정: 복제 +0.1초에
+ * 수정 API 200). 그래서 기다리게 하지 않는다.
  */
 async function cloneAndEdit() {
   const clonedId = await cloneForEdit();
@@ -432,6 +439,27 @@ async function onRunChange(runId: string) {
               </p-button>
             </p-tooltip>
           </template>
+
+          <!--
+            정의를 그대로 보는 길. 상세 화면에 있던 것을 이리로 옮겼다 — 이 워크플로우로
+            할 수 있는 일을 한자리에 모아 두면 어디서 무엇을 할 수 있는지 찾아다니지
+            않아도 된다. 실행 이력과 무관하게 늘 있다(보기만 하는 동작이므로).
+          -->
+          <p-tooltip
+            contents="Shows the workflow definition as JSON."
+            position="bottom"
+            :options="{ classes: ['p-tooltip', 'run-viewer-tooltip'] }"
+          >
+            <p-button
+              data-testid="workflow-viewer-view-json-btn"
+              size="sm"
+              style-type="tertiary"
+              :disabled="!props.workflowId"
+              @click="props.workflowId && emit('view-json', props.workflowId)"
+            >
+              View JSON
+            </p-button>
+          </p-tooltip>
         </div>
       </div>
 
@@ -905,6 +933,7 @@ async function onRunChange(runId: string) {
           <p-button
             data-testid="workflow-clone-confirm-ok"
             style-type="primary"
+            :loading="cloning"
             :disabled="cloning"
             @click="confirmClone"
           >

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -363,7 +363,13 @@ async function onRunChange(runId: string) {
           </span>
         </div>
 
-        <div class="run-viewer__actions">
+        <!--
+          **아직 읽지 못했으면 아무 버튼도 내놓지 않는다.**
+          실행 이력을 모르는 시점인데 버튼은 이력 유무로 갈린다. 그대로 두면 이력이
+          있는 워크플로우에도 잠시 Edit 이 떠서, 원본 직접 수정을 막으려던 것이 그
+          순간 뚫린다. 판정에 필요한 것을 손에 넣은 뒤에 보여준다.
+        -->
+        <div v-if="workflowReadyState === 'ready'" class="run-viewer__actions">
           <!--
             실행 이력이 없는 워크플로우에는 "다시 돌린다"가 없다 — 실행할지, 내용을
             고칠지 둘뿐이다. 이력이 있으면 지금까지의 버튼(실패분 다시 → 새로 → 복제)을


### PR DESCRIPTION
## 무엇을 바꿨나

워크플로우를 고를 수 있는 화면이 두 군데였고, 둘이 서로 다른 판단을 했습니다. 그 판단을 **실행 상태 화면 한 곳으로 모았습니다.**

### 1. 실행 상태가 기본 화면이 된다

목록에서 워크플로우를 선택하면 상세 대신 **실행 상태**가 열립니다.

### 2. 상세에서 편집기·JSON 진입 링크를 없앴다

그 두 링크는 실행 이력을 보지 않고 곧장 편집기를 열어, **실행된 워크플로우를 고칠 수 있는 뒷문**이었습니다. 막으려고 상세에도 같은 판정을 복제하면 두 곳이 어긋날 수 있어, 아예 한 곳으로 모았습니다. 잃는 기능이 없도록 실행 상태에 **View JSON** 버튼을 넣었습니다.

### 3. 실행 이력 조회 실패를 "실행된 적 없음"으로 본다

갓 만든 워크플로우는 엔진이 등록을 마치기 전 약 5초 동안 조회에 실패합니다(개발 환경 실측). 이를 "모름"으로 두면 **복제해서 고치라고 안내해 놓고 그 복제본까지 잠기는** 상태가 됩니다.

### 4. 읽지 못한 상태로는 편집기를 그리지 않는다

조회에 실패하면 태스크가 0개인 빈 캔버스가 아무 말 없이 떴고, 그대로 저장하면 정의가 비워졌습니다. 이제 읽힐 때까지 기다리고, 그 동안 저장을 잠급니다. 기존 워크플로우를 읽지 않는 신규 작성 경로에는 적용되지 않습니다.

### 5. 목표 모델에서 저장해도 실행 상태로 도착한다

목표 모델 화면에서 만든 워크플로우는 저장하면 편집기만 닫히고 그 화면에 남아, 방금 만든 것을 보려면 사용자가 목록으로 가서 다시 골라야 했습니다. 두 화면은 탭이 아니라 서로 다른 라우트라, 새 워크플로우 id를 넘겨 도착 화면이 선택합니다.

### 6. 실행 상태도 읽힐 때까지 기다린다

같은 등록 지연 동안 실행 상태가 빈 그래프에 "표시할 태스크가 없습니다"를 띄웠는데, 태스크가 없는 것이 아니라 아직 읽지 못한 것입니다. 이제 그래프가 그려질 자리에서 준비 중임을 알리고, 준비되면 그립니다. 실행 상태를 여는 모든 경로에 적용됩니다.

기다리는 동안에는 **버튼을 내놓지 않습니다.** 버튼 구성은 실행 이력으로 갈리는데 그 답을 아직 모르는 시점이라, 기본값을 미실행으로 두면 이력이 있는 워크플로우에도 잠시 Edit이 노출됩니다.

## 함께 고친 것 (기존 결함)

- **목록이 엉뚱한 행을 짚던 문제** — 선택을 *자리 번호*로 기억해, 새 항목이 끼어들면 표와 아래 화면이 서로 달랐습니다. 이제 id 로 찾아 맞춥니다.
- **실행 상태가 이전 워크플로우의 실행 목록을 남기던 문제** — 조회에 실패하면 앞서 본 것이 그대로 남아 *다른 워크플로우의 실행*처럼 보였습니다.

## 검증

개발 환경 실화면(브라우저 자동 계측)으로 6개 항목 확인, 전부 통과했습니다.

| 확인한 것 | 판정 |
|---|---|
| 목록 선택 시 기본 화면이 실행 상태 | PASS |
| 상세에서 두 링크 제거 | PASS |
| View JSON 노출·동작 | PASS |
| 복제 후 편집기에 작업 5개 렌더 | PASS |
| 저장 후 실행 상태로 이동 + 목록 표시 일치 | PASS |
| 갓 만든 복제본이 미실행으로 판정되어 편집 가능 | PASS |

`vite build` 통과, 콘솔 오류 없음.

**미검증 1건**: 워크플로우를 읽지 못할 때의 대기 화면은 실화면에서 조건을 만들지 못했습니다 — 도달 가능한 모든 경로가 이미 데이터를 갖고 진입하기 때문입니다. 해당 대기는 *실측한 결함의 수정이 아니라 안전망*입니다.

## 테스트 자원

검증용으로 만든 복제본 1건만 화면의 삭제 기능으로 정리했고, 원래 있던 워크플로우는 건드리지 않았습니다.

---

- [BAR-1458](https://mzdevs.atlassian.net/browse/BAR-1458) 실행 이력이 있는 워크플로우의 수정 차단 — 실행 상태로 유도하고 복제 편집을 권한다
- [BAR-1499](https://mzdevs.atlassian.net/browse/BAR-1499) 워크플로우 저장 후 실행 상태 뷰어로 이동 — 목록 대신 런 상태 화면
- [BAR-1559](https://mzdevs.atlassian.net/browse/BAR-1559) 저장 후 실행 상태 진입 보완 — 목표 모델 경로 이동과 준비 대기 표시

테스트 결과서: `notion/cm-bf-ep-전환워크플로우웹플래닝고도화/016_워크플로우실행상태시각화/ST3_단위테스트/TR-BAR-1458-1499-편집진입과저장후이동.md`

