### PR TITLE
Make job notifications actually reach the badge

### DIFF
--- a/api/cmd/app/main.go
+++ b/api/cmd/app/main.go
@@ -113,6 +113,11 @@ func main() {
 	api.POST("/readnotification", notificationHandler.ReadNotification)
 	api.POST("/readallnotifications", notificationHandler.ReadAllNotifications)
 
+	trackedJobHandler := handler.NewTrackedJobHandler(db)
+	api.POST("/listtrackedjobs", trackedJobHandler.ListTrackedJobs)
+	api.POST("/savetrackedjob", trackedJobHandler.SaveTrackedJob)
+	api.POST("/removetrackedjob", trackedJobHandler.RemoveTrackedJob)
+
 	api.POST("/test", handler.ApiTestController)
 
 	// API list endpoint (no auth required)

--- a/api/internal/handler/tracked_job.go
+++ b/api/internal/handler/tracked_job.go
@@ -1,0 +1,96 @@
+package handler
+
+import (
+	"log"
+	"time"
+
+	"api/internal/middleware"
+	"api/internal/model"
+	"api/internal/repository"
+	"api/internal/util/response"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// TrackedJobHandler exposes the long jobs the console is still watching.
+//
+// Shared rather than per-user, like the tracked deletes: a load test or workflow run is
+// something happening to a resource, and whoever opens the console next benefits from
+// seeing it through. The resulting notification is the part that belongs to a person.
+type TrackedJobHandler struct {
+	repo *repository.TrackedJobRepository
+}
+
+// NewTrackedJobHandler creates a new TrackedJobHandler
+func NewTrackedJobHandler(db *gorm.DB) *TrackedJobHandler {
+	return &TrackedJobHandler{repo: repository.NewTrackedJobRepository(db)}
+}
+
+// TrackedJobPayload is what the console sends when a long job starts.
+type TrackedJobPayload struct {
+	Kind       string `json:"kind"`
+	NaturalKey string `json:"natural_key"`
+	Label      string `json:"label"`
+	Action     string `json:"action"`
+	StartedAt  string `json:"started_at"`
+}
+
+// ListTrackedJobs returns every job still being tracked.
+func (h *TrackedJobHandler) ListTrackedJobs(c echo.Context) error {
+	jobs, err := h.repo.FindAll()
+	if err != nil {
+		log.Printf("Failed to list tracked jobs: %v", err)
+		return c.JSON(500, response.CommonResponseStatusInternalServerError(err.Error()))
+	}
+	return c.JSON(200, response.CommonResponseStatusOK(jobs))
+}
+
+// SaveTrackedJob records a job that just started, replacing an earlier one on the same target.
+func (h *TrackedJobHandler) SaveTrackedJob(c echo.Context) error {
+	payload := new(TrackedJobPayload)
+	if err := c.Bind(payload); err != nil {
+		return c.JSON(400, response.CommonResponseStatusBadRequest(err.Error()))
+	}
+	if payload.Kind == "" || payload.NaturalKey == "" {
+		return c.JSON(400, response.CommonResponseStatusBadRequest("kind and natural_key are required"))
+	}
+
+	startedAt := time.Now()
+	if payload.StartedAt != "" {
+		if parsed, err := time.Parse(time.RFC3339, payload.StartedAt); err == nil {
+			startedAt = parsed
+		}
+	}
+
+	requestedBy, _ := c.Get(middleware.ContextKeyUserID).(string)
+	job := &model.TrackedJob{
+		Kind:        payload.Kind,
+		NaturalKey:  payload.NaturalKey,
+		Label:       payload.Label,
+		Action:      payload.Action,
+		StartedAt:   startedAt,
+		RequestedBy: requestedBy,
+	}
+	if err := h.repo.Upsert(job); err != nil {
+		log.Printf("Failed to save tracked job: %v", err)
+		return c.JSON(500, response.CommonResponseStatusInternalServerError(err.Error()))
+	}
+	return c.JSON(200, response.CommonResponseStatusOK(job))
+}
+
+// RemoveTrackedJob drops a tracked job once it has ended and the user has been told.
+func (h *TrackedJobHandler) RemoveTrackedJob(c echo.Context) error {
+	payload := new(TrackedJobPayload)
+	if err := c.Bind(payload); err != nil {
+		return c.JSON(400, response.CommonResponseStatusBadRequest(err.Error()))
+	}
+	if payload.Kind == "" || payload.NaturalKey == "" {
+		return c.JSON(400, response.CommonResponseStatusBadRequest("kind and natural_key are required"))
+	}
+	if err := h.repo.Delete(payload.Kind, payload.NaturalKey); err != nil {
+		log.Printf("Failed to remove tracked job: %v", err)
+		return c.JSON(500, response.CommonResponseStatusInternalServerError(err.Error()))
+	}
+	return c.JSON(200, response.CommonResponseStatusOK("removed"))
+}

--- a/api/internal/model/db.go
+++ b/api/internal/model/db.go
@@ -30,7 +30,7 @@ func InitDB(cfg *config.Config) (*gorm.DB, error) {
 		}
 
 		// Auto-migrate the schema
-		if err = db.AutoMigrate(&Usersess{}, &DeleteRequest{}, &Notification{}); err != nil {
+		if err = db.AutoMigrate(&Usersess{}, &DeleteRequest{}, &Notification{}, &TrackedJob{}); err != nil {
 			log.Printf("Failed to auto-migrate: %v", err)
 			return
 		}

--- a/api/internal/model/tracked_job.go
+++ b/api/internal/model/tracked_job.go
@@ -1,0 +1,85 @@
+package model
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+	"gorm.io/gorm"
+)
+
+// TrackedJob is a long job someone started that nobody is watching any more.
+//
+// The console tracks these so it can tell the user how they ended (see Notification).
+// Tracking has to survive leaving the screen, a reload, and moving to another browser,
+// which is why it lives here rather than in the tab that started the job.
+//
+// Why a row is needed at all: **neither load tests nor workflow runs hand back an id when
+// you start them.** A load test returns nothing the console reads, and a workflow run has
+// to be found afterwards by listing runs and taking the newest. So the only thing available
+// at start time is a natural key - which node, or which workflow - and that is what gets
+// stored. The checker uses it later to ask "what happened to the last one of these?".
+//
+// Deliberately generic. Infra deletes predate this and keep their own table (DeleteRequest)
+// because that one carries delete-specific fields; everything since shares this one.
+type TrackedJob struct {
+	ID uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+
+	// Kind says which checker owns the row: "perf" or "workflow".
+	Kind string `gorm:"column:kind;type:text;index" json:"kind"`
+
+	// NaturalKey identifies the job by what we knew when it started - not by its own id,
+	// which we do not get. Uniqueness is per kind: starting another load test on the same
+	// node replaces the previous row, since the earlier attempt answers a question nobody
+	// is asking any more.
+	//
+	// perf     : "{nsId}/{infraId}/{nodeId}"
+	// workflow : "{wfId}/{runId}" (run id is resolved shortly after the run starts)
+	NaturalKey string `gorm:"column:natural_key;type:text" json:"natural_key"`
+
+	// Label is what the user should see - a VM name, a workflow name. Captured at start
+	// because it cannot be recovered later: by the time the job ends there is only an id.
+	Label string `gorm:"column:label;type:text" json:"label"`
+
+	// Action distinguishes runs of the same thing: "run", "rerun", "rerun-failed".
+	// Without it a finished workflow can only be described as "finished", which is not
+	// what the user asked for.
+	Action string `gorm:"column:action;type:text" json:"action"`
+
+	// StartedAt is part of the notification's dedup key. Reruns reuse the same workflow run
+	// id, so the id alone cannot tell two attempts apart.
+	StartedAt time.Time `gorm:"column:started_at" json:"started_at"`
+
+	RequestedBy string    `gorm:"column:requested_by;type:text" json:"requested_by"`
+	CreatedAt   time.Time `gorm:"column:created_at" json:"created_at"`
+	UpdatedAt   time.Time `gorm:"column:updated_at" json:"updated_at"`
+}
+
+// Tracked job kinds.
+const (
+	TrackedJobKindPerf     = "perf"
+	TrackedJobKindWorkflow = "workflow"
+)
+
+// Tracked job actions.
+const (
+	TrackedJobActionRun         = "run"
+	TrackedJobActionRerun       = "rerun"
+	TrackedJobActionRerunFailed = "rerun-failed"
+)
+
+// TableName specifies the table name for GORM
+func (TrackedJob) TableName() string {
+	return "tracked_jobs"
+}
+
+// BeforeCreate is a GORM hook to generate UUID before creating a record
+func (t *TrackedJob) BeforeCreate(tx *gorm.DB) error {
+	if t.ID == uuid.Nil {
+		newUUID, err := uuid.NewV4()
+		if err != nil {
+			return err
+		}
+		t.ID = newUUID
+	}
+	return nil
+}

--- a/api/internal/repository/tracked_job_repository.go
+++ b/api/internal/repository/tracked_job_repository.go
@@ -1,0 +1,57 @@
+package repository
+
+import (
+	"api/internal/model"
+
+	"gorm.io/gorm"
+)
+
+// TrackedJobRepository handles database operations for TrackedJob
+type TrackedJobRepository struct {
+	db *gorm.DB
+}
+
+// NewTrackedJobRepository creates a new TrackedJobRepository
+func NewTrackedJobRepository(db *gorm.DB) *TrackedJobRepository {
+	return &TrackedJobRepository{db: db}
+}
+
+// FindAll returns every job still being tracked, newest first.
+//
+// The console asks for this after logging in so that whichever browser is open picks up
+// jobs started somewhere else. Rows are removed once a job ends, so this stays small.
+func (r *TrackedJobRepository) FindAll() ([]model.TrackedJob, error) {
+	var jobs []model.TrackedJob
+	err := r.db.Order("started_at desc").Find(&jobs).Error
+	return jobs, err
+}
+
+// Upsert stores a tracked job, replacing an earlier one with the same kind and natural key.
+//
+// Starting another load test on the same node - or another run of the same workflow -
+// makes the previous attempt irrelevant. Keeping one row per target also stops the table
+// growing with attempts nobody will ask about.
+func (r *TrackedJobRepository) Upsert(job *model.TrackedJob) error {
+	var existing model.TrackedJob
+	err := r.db.Where("kind = ? AND natural_key = ?", job.Kind, job.NaturalKey).First(&existing).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return r.db.Create(job).Error
+		}
+		return err
+	}
+
+	existing.Label = job.Label
+	existing.Action = job.Action
+	existing.StartedAt = job.StartedAt
+	if job.RequestedBy != "" {
+		existing.RequestedBy = job.RequestedBy
+	}
+	return r.db.Save(&existing).Error
+}
+
+// Delete removes a tracked job once it has ended and been reported.
+func (r *TrackedJobRepository) Delete(kind, naturalKey string) error {
+	return r.db.Where("kind = ? AND natural_key = ?", kind, naturalKey).
+		Delete(&model.TrackedJob{}).Error
+}

--- a/front/src/entities/mci/lib/deleteTracker.ts
+++ b/front/src/entities/mci/lib/deleteTracker.ts
@@ -12,20 +12,21 @@ import { notify } from '@/entities/notification/lib/notificationStore';
 import { registerTracker } from '@/shared/libs/tracking/runner';
 
 /**
- * 워크로드(인프라) 삭제 추적 (BAR-1444 → BAR-1531)
+ * Tracking for workload (infra) deletes.
  *
- * 삭제는 수 분 걸리고 실패할 수 있어서, 요청을 내고 끝이 아니라 *결과를 끝까지 따라가야* 한다.
- * 이 모듈이 그 역할을 하며 두 가지가 핵심이다.
+ * A delete takes minutes and can fail, so issuing the request is not the end of it — the
+ * outcome has to be followed. Two things matter here.
  *
- * **서버에 보관한다** — 요청 id 를 브라우저에만 두면 다른 PC 에서는 삭제가 실패한 사실도, 그 사유도
- * 알 수 없다. 서버에 두면 어느 자리에서 로그인하든 하던 처리를 이어받는다.
+ * **It is kept on the server.** With the request id held in the browser alone, neither the
+ * failure nor its reason is visible from another machine. On the server, signing in
+ * anywhere picks up where the work left off.
  *
- * **화면과 무관하게 돈다** — 폴링이 목록 화면 안에 있으면 다른 화면으로 가는 순간 추적이 멈추고,
- * 한참 뒤 목록에 돌아와서야 조회를 시작해 뒤늦게 반영된다. 그래서 컴포넌트가 아니라 이 모듈이
- * 폴링을 소유한다. 앱이 떠 있는 동안 계속 돈다.
+ * **It runs independently of the screen.** Polling that lives in the list screen stops the
+ * moment another screen is opened, and only resumes — late — on returning. So this module
+ * owns the polling rather than a component, and it keeps running while the app is open.
  *
- * 키는 인프라 이름이 아니라 **uid** 다. cb-tumblebug 에서 인프라 id 는 곧 이름이라, 지우고 같은
- * 이름으로 다시 만들면 옛 기록이 새 인프라 것으로 보인다.
+ * The key is the **uid**, not the infra name. In cb-tumblebug an infra id is its name, so
+ * deleting and recreating under the same name makes an old record look like the new infra.
  */
 
 export type DeleteStatus = DeleteRequestStatus;
@@ -44,7 +45,7 @@ const state = reactive<{ records: Record<string, DeleteRecord> }>({
   records: {},
 });
 
-/** 서버 응답(snake_case)을 화면이 쓰는 형태로 옮긴다. */
+/** Converts the server response (snake_case) into the shape the screen uses. */
 function fromRecord(r: DeleteRequestRecord): DeleteRecord {
   return {
     uid: r.uid,
@@ -57,22 +58,23 @@ function fromRecord(r: DeleteRequestRecord): DeleteRecord {
   };
 }
 
-/** 현재 추적 중인 기록 전체(목록 렌더용). */
+/** Every record currently tracked, for rendering the list. */
 export function allDeleteRecords(): DeleteRecord[] {
   return Object.values(state.records);
 }
 
-/** uid 로 기록 조회. */
+/** Looks up a record by uid. */
 export function getDeleteRecord(uid: string): DeleteRecord | undefined {
   return state.records[uid];
 }
 
-/** 진행 중인 삭제가 있으면 true — 중복 요청 방어에 쓴다. */
+/** True while a delete is in flight — guards against issuing a duplicate request. */
 /**
- * 배경에서 아직 끝나지 않은 삭제가 있는가.
+ * Whether a delete is still running in the background.
  *
- * 세션 유지 판단에 쓴다 — 삭제가 도는 중이라면 사용자가 화면을 만지지 않아도 세션을 이어 준다.
- * 결과를 보여 줄 상대가 사라지면 그 작업을 지켜본 의미가 없기 때문이다.
+ * Used to decide on keeping the session alive: while one is running the session continues
+ * even without interaction, because watching a job through is pointless if the person it
+ * would be reported to has been signed out.
  */
 export function hasPendingDeletes(): boolean {
   return allDeleteRecords().some(r => r.status === 'Handling');
@@ -82,7 +84,7 @@ export function isDeleteInProgress(uid: string): boolean {
   return state.records[uid]?.status === 'Handling';
 }
 
-/** 삭제 요청을 서버에 기록한다(같은 인프라의 이전 기록은 대체된다). */
+/** Records a delete request on the server; an earlier record for the same infra is replaced. */
 export async function putDeleteRecord(rec: DeleteRecord): Promise<void> {
   state.records[rec.uid] = rec;
   try {
@@ -96,23 +98,23 @@ export async function putDeleteRecord(rec: DeleteRecord): Promise<void> {
       error_reason: rec.errorReason ?? '',
     }).execute();
   } catch (e) {
-    // 서버 기록에 실패해도 이번 화면에서는 진행 상태를 보여준다. 다만 다른 자리에서는 보이지
-    // 않게 되므로 조용히 넘기지 않고 남긴다.
-    console.error('[deleteTracker] 삭제 요청 기록 실패', e);
+    // Show progress on this screen even if the server write failed. It will not be visible
+    // from anywhere else, though, so do not let it pass silently.
+    console.error('[deleteTracker] failed to record the delete request', e);
   }
 }
 
-/** 기록을 지운다 — 삭제가 성공했거나, 인프라가 목록에서 사라진 경우. */
+/** Drops the record — the delete succeeded, or the infra is gone from the list. */
 export async function clearDeleteRecord(uid: string): Promise<void> {
   delete state.records[uid];
   try {
     await useRemoveDeleteRequest(uid).execute();
   } catch (e) {
-    console.error('[deleteTracker] 삭제 기록 제거 실패', e);
+    console.error('[deleteTracker] failed to remove the delete record', e);
   }
 }
 
-/** 상태를 갱신한다. 성공은 여기로 오지 않는다 — 성공하면 기록 자체를 지운다. */
+/** Updates the status. Success never comes through here — a success drops the record. */
 async function markStatus(
   uid: string,
   status: DeleteStatus,
@@ -126,19 +128,28 @@ async function markStatus(
   try {
     await useUpdateDeleteRequestStatus(uid, status, errorReason).execute();
   } catch (e) {
-    console.error('[deleteTracker] 삭제 상태 갱신 실패', e);
+    console.error('[deleteTracker] failed to update the delete status', e);
   }
 }
 
-/** 삭제가 실패했음을 기록한다(사유 포함). 목록의 `삭제 상태` 가 이 값을 보여준다. */
+/**
+ * Records that a delete failed, with the reason. The list shows this in `Delete Status`.
+ *
+ * **The notification is raised here too.** The tracker only inspects records still in
+ * `Handling`, and a request that fails as it is sent is written straight to `Error`, so it
+ * never comes up for inspection. Without this the failure exists only as a status value in
+ * the list, and anyone who had left the screen never learns of it.
+ */
 export async function markDeleteFailed(
   uid: string,
   errorReason?: string,
 ): Promise<void> {
   await markStatus(uid, 'Error', errorReason);
+  const rec = state.records[uid];
+  if (rec) await notifyFailed(rec, errorReason);
 }
 
-/** 서버에 남아 있는 추적 기록을 받아 온다(앱 시작·로그인 시). */
+/** Loads the tracking records kept on the server (on app start and on login). */
 export async function loadDeleteRecords(): Promise<void> {
   try {
     const res: any = await useListDeleteRequests().execute();
@@ -150,17 +161,18 @@ export async function loadDeleteRecords(): Promise<void> {
     }
     state.records = next;
   } catch (e) {
-    console.error('[deleteTracker] 추적 기록 조회 실패', e);
+    console.error('[deleteTracker] failed to load tracking records', e);
   }
 }
 
-// ── 러너 등록 ───────────────────────────────────────────────────────────────
+// ── Runner registration ─────────────────────────────────────────────────────
 //
-// 주기·중첩 방지·로그인/로그아웃 생명주기는 러너가 맡는다([runner](@/shared/libs/tracking/runner)).
-// 여기는 *무엇을 물어볼지* 만 안다 — 삭제는 cm-beetle 의 요청 조회로 끝을 판정하는데, 부하 테스트도
-// 워크플로우도 각자 다른 것을 본다. 한곳에 모으면 공통이 아니라 종류별 분기 덩어리가 된다.
+// The runner owns the interval, the overlap guard and the login/logout lifecycle
+// ([runner](@/shared/libs/tracking/runner)). This side knows only *what to ask*: a delete is
+// judged finished by querying cm-beetle, while a load test and a workflow each look at
+// something different. Folding those together would grow a switch, not a shared mechanism.
 
-/** 해당 인프라가 아직 목록에 있는지 확인한다(판단 불가 상황을 가르는 기준). */
+/** Whether the infra is still listed — the tie-breaker when the outcome is unclear. */
 async function infraStillListed(rec: DeleteRecord): Promise<boolean> {
   try {
     const res: any = await useGetMciList(rec.nsId, '').execute();
@@ -171,13 +183,14 @@ async function infraStillListed(rec: DeleteRecord): Promise<boolean> {
       (m: any) => m?.uid === rec.uid,
     );
   } catch {
-    // 목록 조회 자체가 실패하면 판단하지 않는다(다음 주기에 다시 본다).
+    // If listing itself failed, decide nothing and look again on the next pass.
     return true;
   }
 }
 
 async function notifyDone(rec: DeleteRecord): Promise<void> {
-  // 강제 삭제는 텀블벅 기록만 지우고 CSP 자원은 남긴다 — 성공이지만 손이 더 간다.
+  // A force delete removes only the internal record and leaves the CSP resources — a
+  // success, but one that still needs attention.
   const forced = rec.option === 'force';
   await notify({
     category: 'Workload',
@@ -193,11 +206,16 @@ async function notifyDone(rec: DeleteRecord): Promise<void> {
 }
 
 async function notifyFailed(rec: DeleteRecord, reason?: string): Promise<void> {
+  // Carry the reason in the notification. The status cell is narrow and shows only the
+  // start of it, and this notification is often where the failure is first noticed. When no
+  // reason came back, say where one can be obtained instead.
   await notify({
     category: 'Workload',
     level: 'Error',
     message: `Failed to delete infra "${rec.infraId}".`,
-    detail: reason ?? '',
+    detail: reason
+      ? `${reason}\n\nDeleting it again shows the same reason before it starts.`
+      : 'No reason was returned. Deleting it again shows the reason before it starts.',
     dedupKey: `delete:${rec.reqId}:error`,
   });
 }
@@ -213,7 +231,7 @@ async function notifyUnknown(rec: DeleteRecord): Promise<void> {
   });
 }
 
-/** 진행 중인 삭제 하나의 결과를 확인한다. */
+/** Checks the outcome of one in-flight delete. */
 async function checkOne(rec: DeleteRecord): Promise<void> {
   try {
     const res: any = await useGetBeetleRequest(rec.reqId).execute();
@@ -227,24 +245,26 @@ async function checkOne(rec: DeleteRecord): Promise<void> {
 
     if (status === 'success') {
       await notifyDone(rec);
-      // 성공은 남길 것이 없다 — 인프라가 목록에서 사라지므로 보여줄 대상도 없다.
+      // A success leaves nothing to keep — the infra is gone from the list, so there is
+      // nothing left to show it against.
       await clearDeleteRecord(rec.uid);
     } else if (status === 'error') {
       const reason = details?.errorResponse || undefined;
       await markStatus(rec.uid, 'Error', reason);
       await notifyFailed(rec, reason);
     }
-    // Handling 이면 그대로 두고 다음 주기에 다시 본다.
+    // Still Handling: leave it and look again on the next pass.
   } catch {
-    // 조회가 실패했다. cm-beetle 의 요청 기록은 재시작을 넘기지 못하므로, 정상적으로 처리된
-    // 요청인데도 여기로 올 수 있다. 그래서 실패로 단정하지 않고 *인프라가 아직 있는지*로 가른다.
+    // The lookup failed. cm-beetle's request records do not survive its restart, so a
+    // request that completed normally can land here. Rather than calling it failed, decide
+    // by whether the infra is still there.
     const listed = await infraStillListed(rec);
     if (!listed) {
-      // 인프라가 없다 = 어떤 경로로든 지워졌다. 남겨 둘 이유가 없다.
+      // No infra means it is gone by some route. Nothing to keep.
       await notifyDone(rec);
       await clearDeleteRecord(rec.uid);
     } else {
-      // 인프라는 있는데 요청 기록이 없다 → 성공인지 실패인지 알 수 없다.
+      // The infra is there but the request record is not — the outcome is unknown.
       await markStatus(rec.uid, 'Unknown');
       await notifyUnknown(rec);
     }

--- a/front/src/entities/mci/lib/deleteTracker.ts
+++ b/front/src/entities/mci/lib/deleteTracker.ts
@@ -147,6 +147,22 @@ async function markStatus(
 }
 
 /**
+ * Notes that the delete *request* errored, without calling the delete itself failed.
+ *
+ * The request runs for minutes and a proxy will time it out (504) while the server keeps
+ * going, so an error here says nothing certain about the outcome. The record stays in
+ * `Handling` — which is what the tracker inspects — and the reason is kept in case the
+ * tracker does conclude failure and needs something to show.
+ */
+export async function noteDeleteRequestError(
+  uid: string,
+  errorReason?: string,
+): Promise<void> {
+  const rec = state.records[uid];
+  if (rec && errorReason !== undefined) rec.errorReason = errorReason;
+}
+
+/**
  * Records that a delete failed, with the reason. The list shows this in `Delete Status`.
  *
  * **The notification is raised here too.** The tracker only inspects records still in

--- a/front/src/entities/mci/lib/deleteTracker.ts
+++ b/front/src/entities/mci/lib/deleteTracker.ts
@@ -104,6 +104,20 @@ export async function putDeleteRecord(rec: DeleteRecord): Promise<void> {
   }
 }
 
+/**
+ * Announces a delete that finished successfully, then drops its record.
+ *
+ * The caller that issued the request has to do this, because a request that returns success
+ * clears its own record immediately and the tracker only ever inspects records still in
+ * `Handling`. Clearing without announcing leaves the success unreported — which is the one
+ * thing this feature exists to prevent.
+ */
+export async function markDeleteSucceeded(uid: string): Promise<void> {
+  const rec = state.records[uid];
+  if (rec) await notifyDone(rec);
+  await clearDeleteRecord(uid);
+}
+
 /** Drops the record — the delete succeeded, or the infra is gone from the list. */
 export async function clearDeleteRecord(uid: string): Promise<void> {
   delete state.records[uid];

--- a/front/src/entities/mci/lib/deleteTracker.ts
+++ b/front/src/entities/mci/lib/deleteTracker.ts
@@ -176,6 +176,43 @@ async function infraStillListed(rec: DeleteRecord): Promise<boolean> {
   }
 }
 
+async function notifyDone(rec: DeleteRecord): Promise<void> {
+  // 강제 삭제는 텀블벅 기록만 지우고 CSP 자원은 남긴다 — 성공이지만 손이 더 간다.
+  const forced = rec.option === 'force';
+  await notify({
+    category: 'Workload',
+    level: forced ? 'Error' : 'Info',
+    message: forced
+      ? `Infra "${rec.infraId}" was force-deleted. CSP resources may remain.`
+      : `Infra "${rec.infraId}" has been deleted.`,
+    detail: forced
+      ? 'Force delete removes the record only. Any surviving CSP resources keep billing and must be removed by hand.'
+      : '',
+    dedupKey: `delete:${rec.reqId}:done`,
+  });
+}
+
+async function notifyFailed(rec: DeleteRecord, reason?: string): Promise<void> {
+  await notify({
+    category: 'Workload',
+    level: 'Error',
+    message: `Failed to delete infra "${rec.infraId}".`,
+    detail: reason ?? '',
+    dedupKey: `delete:${rec.reqId}:error`,
+  });
+}
+
+async function notifyUnknown(rec: DeleteRecord): Promise<void> {
+  await notify({
+    category: 'Workload',
+    level: 'Error',
+    message: `Could not confirm the deletion of infra "${rec.infraId}".`,
+    detail:
+      'The request record is gone but the infra is still listed, so the outcome is unknown. Check the workload list.',
+    dedupKey: `delete:${rec.reqId}:unknown`,
+  });
+}
+
 /** 진행 중인 삭제 하나의 결과를 확인한다. */
 async function checkOne(rec: DeleteRecord): Promise<void> {
   try {

--- a/front/src/entities/mci/model/stores.ts
+++ b/front/src/entities/mci/model/stores.ts
@@ -54,10 +54,16 @@ export const useMCIStore = defineStore(NAMESPACE, () => {
     }
   }
 
+  /**
+   * 노드의 마지막 부하 테스트 상태를 담는다.
+   *
+   * `undefined` 를 넣으면 *보여줄 결과가 없다*는 뜻이다 — 조회된 실행이 다른 VM 것이라
+   * 화면에 내보내면 안 되는 경우에 쓴다(BAR-1547).
+   */
   function assignLastLoadTestStateToVm(
     mciID: string,
     vmID: string,
-    response: ILastloadtestStateResponse,
+    response: ILastloadtestStateResponse | undefined,
   ) {
     const mci = getMciById(mciID);
     if (mci) {

--- a/front/src/entities/mci/model/stores.ts
+++ b/front/src/entities/mci/model/stores.ts
@@ -55,10 +55,10 @@ export const useMCIStore = defineStore(NAMESPACE, () => {
   }
 
   /**
-   * 노드의 마지막 부하 테스트 상태를 담는다.
+   * Holds the node's most recent load test state.
    *
-   * `undefined` 를 넣으면 *보여줄 결과가 없다*는 뜻이다 — 조회된 실행이 다른 VM 것이라
-   * 화면에 내보내면 안 되는 경우에 쓴다(BAR-1547).
+   * `undefined` means *there is nothing to show* — used when the run that came back belongs
+   * to a different VM and must not reach the screen.
    */
   function assignLastLoadTestStateToVm(
     mciID: string,

--- a/front/src/entities/mci/model/types.ts
+++ b/front/src/entities/mci/model/types.ts
@@ -212,8 +212,9 @@ export interface ILoadTestExecutionStep {
 
 export interface ILastloadtestStateResponse {
   compileDuration: string;
-  // cm-ant 가 기록해 둔 *대상 노드의 uid* (BAR-1546 이후). 노드 id 는 이름이라 재사용되므로
-  // 이 값이 없으면 조회 결과가 지금 보고 있는 VM 것인지 알 수 없다. 그 이전 기록에는 없다.
+  // The *uid of the target node* as recorded by cm-ant. A node id is a name and names are
+  // reused, so without this there is no way to tell whether a result belongs to the VM on
+  // screen. Records written before this was added do not carry it.
   nodeUid?: string;
   createdAt: string;
   executionDuration: string;

--- a/front/src/entities/mci/model/types.ts
+++ b/front/src/entities/mci/model/types.ts
@@ -212,6 +212,9 @@ export interface ILoadTestExecutionStep {
 
 export interface ILastloadtestStateResponse {
   compileDuration: string;
+  // cm-ant 가 기록해 둔 *대상 노드의 uid* (BAR-1546 이후). 노드 id 는 이름이라 재사용되므로
+  // 이 값이 없으면 조회 결과가 지금 보고 있는 VM 것인지 알 수 없다. 그 이전 기록에는 없다.
+  nodeUid?: string;
   createdAt: string;
   executionDuration: string;
   executionStatus: string;

--- a/front/src/entities/tracking/api/index.ts
+++ b/front/src/entities/tracking/api/index.ts
@@ -1,13 +1,14 @@
 import { IAxiosResponse, useAxiosPost } from '@/shared/libs';
 
 /**
- * 장시간 작업 추적 저장소 API (cm-butterfly 자체 도메인).
+ * Storage API for tracking long-running jobs (cm-butterfly's own domain).
  *
- * 부하 테스트도 워크플로우 실행도 **시작할 때 자기 id 를 돌려주지 않는다.** 그래서 시작 시점에
- * 알 수 있는 것(어느 노드인지·어느 워크플로우인지)을 자연키로 남겨 두고, 나중에 그 키로
- * "마지막 실행이 어떻게 됐나" 를 묻는다.
+ * Neither a load test nor a workflow run **hands back its own id when it starts.** What is
+ * knowable at that point — which node, which workflow — is kept as a natural key, and that
+ * key is what later asks how the last run turned out.
  *
- * 서버에 두는 이유는 삭제 추적과 같다 — 브라우저에만 두면 다른 자리에서는 결과를 알 수 없다.
+ * It lives on the server for the same reason delete tracking does: kept in the browser
+ * alone, the outcome would be invisible from anywhere else.
  */
 
 export type TrackedJobKind = 'perf' | 'workflow';
@@ -23,7 +24,7 @@ export interface TrackedJobRecord {
   requested_by?: string;
 }
 
-/** 추적 중인 작업 전체 — 로그인·앱 시작 시 이어받는다. */
+/** Every tracked job — picked up on login and on app start. */
 export function useListTrackedJobs() {
   return useAxiosPost<IAxiosResponse<TrackedJobRecord[]>, any>(
     'listtrackedjobs',
@@ -31,7 +32,7 @@ export function useListTrackedJobs() {
   );
 }
 
-/** 작업 시작 기록(같은 대상의 이전 기록은 대체된다). */
+/** Records a job start; an earlier record for the same target is replaced. */
 export function useSaveTrackedJob(payload: {
   kind: TrackedJobKind;
   natural_key: string;
@@ -45,7 +46,7 @@ export function useSaveTrackedJob(payload: {
   );
 }
 
-/** 끝나서 알린 작업을 목록에서 지운다. */
+/** Drops a job that has finished and been announced. */
 export function useRemoveTrackedJob(kind: TrackedJobKind, naturalKey: string) {
   return useAxiosPost<IAxiosResponse<string>, any>('removetrackedjob', {
     kind,

--- a/front/src/entities/tracking/api/index.ts
+++ b/front/src/entities/tracking/api/index.ts
@@ -1,0 +1,54 @@
+import { IAxiosResponse, useAxiosPost } from '@/shared/libs';
+
+/**
+ * 장시간 작업 추적 저장소 API (cm-butterfly 자체 도메인).
+ *
+ * 부하 테스트도 워크플로우 실행도 **시작할 때 자기 id 를 돌려주지 않는다.** 그래서 시작 시점에
+ * 알 수 있는 것(어느 노드인지·어느 워크플로우인지)을 자연키로 남겨 두고, 나중에 그 키로
+ * "마지막 실행이 어떻게 됐나" 를 묻는다.
+ *
+ * 서버에 두는 이유는 삭제 추적과 같다 — 브라우저에만 두면 다른 자리에서는 결과를 알 수 없다.
+ */
+
+export type TrackedJobKind = 'perf' | 'workflow';
+export type TrackedJobAction = 'run' | 'rerun' | 'rerun-failed';
+
+export interface TrackedJobRecord {
+  id: string;
+  kind: TrackedJobKind | string;
+  natural_key: string;
+  label: string;
+  action: string;
+  started_at: string;
+  requested_by?: string;
+}
+
+/** 추적 중인 작업 전체 — 로그인·앱 시작 시 이어받는다. */
+export function useListTrackedJobs() {
+  return useAxiosPost<IAxiosResponse<TrackedJobRecord[]>, any>(
+    'listtrackedjobs',
+    {},
+  );
+}
+
+/** 작업 시작 기록(같은 대상의 이전 기록은 대체된다). */
+export function useSaveTrackedJob(payload: {
+  kind: TrackedJobKind;
+  natural_key: string;
+  label: string;
+  action: TrackedJobAction;
+  started_at: string;
+}) {
+  return useAxiosPost<IAxiosResponse<TrackedJobRecord>, any>(
+    'savetrackedjob',
+    payload,
+  );
+}
+
+/** 끝나서 알린 작업을 목록에서 지운다. */
+export function useRemoveTrackedJob(kind: TrackedJobKind, naturalKey: string) {
+  return useAxiosPost<IAxiosResponse<string>, any>('removetrackedjob', {
+    kind,
+    natural_key: naturalKey,
+  });
+}

--- a/front/src/entities/tracking/lib/trackedJobs.ts
+++ b/front/src/entities/tracking/lib/trackedJobs.ts
@@ -1,0 +1,111 @@
+import { reactive } from 'vue';
+import {
+  useListTrackedJobs,
+  useSaveTrackedJob,
+  useRemoveTrackedJob,
+  type TrackedJobRecord,
+  type TrackedJobKind,
+  type TrackedJobAction,
+} from '@/entities/tracking/api';
+
+/**
+ * 추적 중인 장시간 작업 목록 (BAR-1544 / BAR-1545 공용)
+ *
+ * 체커들이 공유하는 창고다. 각 체커는 자기 `kind` 의 것만 꺼내 확인한다.
+ *
+ * **왜 기록이 필요한가** — 부하 테스트도 워크플로우 실행도 시작할 때 자기 id 를 주지 않는다.
+ * 시작 시점에 손에 있는 것은 *어느 노드/어느 워크플로우인가* 뿐이고, 그것을 남겨 둬야 나중에
+ * "그 대상의 마지막 실행이 어떻게 됐나" 를 물을 수 있다.
+ *
+ * **왜 이름과 동작까지 남기는가** — 끝난 뒤에는 id 밖에 없어서 문장을 만들 수 없다.
+ * "'주문서비스' 워크플로우 **재실행**이 끝났습니다" 를 쓰려면 이름과 동작을 시작할 때 잡아야 한다.
+ */
+
+export interface TrackedJob {
+  kind: TrackedJobKind;
+  naturalKey: string;
+  label: string;
+  action: TrackedJobAction;
+  startedAt: string;
+}
+
+const state = reactive<{ jobs: Record<string, TrackedJob> }>({ jobs: {} });
+
+const keyOf = (kind: string, naturalKey: string) => `${kind}::${naturalKey}`;
+
+function fromRecord(r: TrackedJobRecord): TrackedJob {
+  return {
+    kind: r.kind as TrackedJobKind,
+    naturalKey: r.natural_key,
+    label: r.label,
+    action: (r.action || 'run') as TrackedJobAction,
+    startedAt: r.started_at,
+  };
+}
+
+/** 특정 종류의 추적 중인 작업들. */
+export function trackedJobsOf(kind: TrackedJobKind): TrackedJob[] {
+  return Object.values(state.jobs).filter(j => j.kind === kind);
+}
+
+/** 추적 중인 것이 하나라도 있는가(세션 유지 판단에 쓰인다). */
+export function hasTrackedJobs(kind: TrackedJobKind): boolean {
+  return trackedJobsOf(kind).length > 0;
+}
+
+/** 작업 시작을 기록한다. */
+export async function putTrackedJob(job: TrackedJob): Promise<void> {
+  state.jobs[keyOf(job.kind, job.naturalKey)] = job;
+  try {
+    await useSaveTrackedJob({
+      kind: job.kind,
+      natural_key: job.naturalKey,
+      label: job.label,
+      action: job.action,
+      started_at: job.startedAt,
+    }).execute();
+  } catch (e) {
+    // 서버 기록에 실패해도 이번 브라우저에서는 추적한다. 다만 다른 자리에서는 이어받지
+    // 못하게 되므로 조용히 넘기지 않는다.
+    console.error('[trackedJobs] 작업 기록 실패', e);
+  }
+}
+
+/** 자연키를 바꿔 다시 기록한다 — 시작 후에야 실제 id 를 알게 되는 경우에 쓴다. */
+export async function retagTrackedJob(
+  job: TrackedJob,
+  nextNaturalKey: string,
+): Promise<TrackedJob> {
+  await clearTrackedJob(job.kind, job.naturalKey);
+  const next = { ...job, naturalKey: nextNaturalKey };
+  await putTrackedJob(next);
+  return next;
+}
+
+/** 끝난 작업을 목록에서 지운다. */
+export async function clearTrackedJob(
+  kind: TrackedJobKind,
+  naturalKey: string,
+): Promise<void> {
+  delete state.jobs[keyOf(kind, naturalKey)];
+  try {
+    await useRemoveTrackedJob(kind, naturalKey).execute();
+  } catch (e) {
+    console.error('[trackedJobs] 작업 기록 제거 실패', e);
+  }
+}
+
+/** 서버에 남아 있는 추적 기록을 받아 온다(로그인·앱 시작 시). */
+export async function loadTrackedJobs(): Promise<void> {
+  try {
+    const res: any = await useListTrackedJobs().execute();
+    const list: TrackedJobRecord[] = res?.data?.responseData ?? [];
+    const next: Record<string, TrackedJob> = {};
+    for (const r of Array.isArray(list) ? list : []) {
+      next[keyOf(r.kind, r.natural_key)] = fromRecord(r);
+    }
+    state.jobs = next;
+  } catch (e) {
+    console.error('[trackedJobs] 추적 기록 조회 실패', e);
+  }
+}

--- a/front/src/entities/tracking/lib/trackedJobs.ts
+++ b/front/src/entities/tracking/lib/trackedJobs.ts
@@ -9,16 +9,17 @@ import {
 } from '@/entities/tracking/api';
 
 /**
- * 추적 중인 장시간 작업 목록 (BAR-1544 / BAR-1545 공용)
+ * The list of long-running jobs being tracked, shared by every checker.
  *
- * 체커들이 공유하는 창고다. 각 체커는 자기 `kind` 의 것만 꺼내 확인한다.
+ * Each checker takes out only the entries of its own `kind`.
  *
- * **왜 기록이 필요한가** — 부하 테스트도 워크플로우 실행도 시작할 때 자기 id 를 주지 않는다.
- * 시작 시점에 손에 있는 것은 *어느 노드/어느 워크플로우인가* 뿐이고, 그것을 남겨 둬야 나중에
- * "그 대상의 마지막 실행이 어떻게 됐나" 를 물을 수 있다.
+ * **Why a record is needed** — neither a load test nor a workflow run hands back its own id
+ * when it starts. All that is in hand at that moment is *which node* or *which workflow*,
+ * and that has to be kept to later ask how the last run on it turned out.
  *
- * **왜 이름과 동작까지 남기는가** — 끝난 뒤에는 id 밖에 없어서 문장을 만들 수 없다.
- * "'주문서비스' 워크플로우 **재실행**이 끝났습니다" 를 쓰려면 이름과 동작을 시작할 때 잡아야 한다.
+ * **Why the name and the action are kept too** — once it ends there is only an id, which
+ * cannot be turned into a sentence. Writing "the **re-run** of workflow X has finished"
+ * means capturing the name and the action at the start.
  */
 
 export interface TrackedJob {
@@ -43,17 +44,17 @@ function fromRecord(r: TrackedJobRecord): TrackedJob {
   };
 }
 
-/** 특정 종류의 추적 중인 작업들. */
+/** Tracked jobs of one kind. */
 export function trackedJobsOf(kind: TrackedJobKind): TrackedJob[] {
   return Object.values(state.jobs).filter(j => j.kind === kind);
 }
 
-/** 추적 중인 것이 하나라도 있는가(세션 유지 판단에 쓰인다). */
+/** Whether anything is being tracked (used to decide on keeping the session alive). */
 export function hasTrackedJobs(kind: TrackedJobKind): boolean {
   return trackedJobsOf(kind).length > 0;
 }
 
-/** 작업 시작을 기록한다. */
+/** Records that a job has started. */
 export async function putTrackedJob(job: TrackedJob): Promise<void> {
   state.jobs[keyOf(job.kind, job.naturalKey)] = job;
   try {
@@ -65,13 +66,13 @@ export async function putTrackedJob(job: TrackedJob): Promise<void> {
       started_at: job.startedAt,
     }).execute();
   } catch (e) {
-    // 서버 기록에 실패해도 이번 브라우저에서는 추적한다. 다만 다른 자리에서는 이어받지
-    // 못하게 되므로 조용히 넘기지 않는다.
-    console.error('[trackedJobs] 작업 기록 실패', e);
+    // Keep tracking in this browser even if the server write failed. It will not carry to
+    // another seat, though, so do not let it pass silently.
+    console.error('[trackedJobs] failed to record the job', e);
   }
 }
 
-/** 자연키를 바꿔 다시 기록한다 — 시작 후에야 실제 id 를 알게 되는 경우에 쓴다. */
+/** Re-records under a different natural key, for when the real id is only known after the start. */
 export async function retagTrackedJob(
   job: TrackedJob,
   nextNaturalKey: string,
@@ -82,7 +83,7 @@ export async function retagTrackedJob(
   return next;
 }
 
-/** 끝난 작업을 목록에서 지운다. */
+/** Drops a finished job from the list. */
 export async function clearTrackedJob(
   kind: TrackedJobKind,
   naturalKey: string,
@@ -91,11 +92,11 @@ export async function clearTrackedJob(
   try {
     await useRemoveTrackedJob(kind, naturalKey).execute();
   } catch (e) {
-    console.error('[trackedJobs] 작업 기록 제거 실패', e);
+    console.error('[trackedJobs] failed to remove the job record', e);
   }
 }
 
-/** 서버에 남아 있는 추적 기록을 받아 온다(로그인·앱 시작 시). */
+/** Loads the tracking records kept on the server (on login and on app start). */
 export async function loadTrackedJobs(): Promise<void> {
   try {
     const res: any = await useListTrackedJobs().execute();
@@ -106,6 +107,6 @@ export async function loadTrackedJobs(): Promise<void> {
     }
     state.jobs = next;
   } catch (e) {
-    console.error('[trackedJobs] 추적 기록 조회 실패', e);
+    console.error('[trackedJobs] failed to load tracking records', e);
   }
 }

--- a/front/src/entities/vm/api/api.ts
+++ b/front/src/entities/vm/api/api.ts
@@ -24,15 +24,21 @@ const RUN_LOAD_TEST = 'cm-ant/Runloadtest';
 const STOP_LOAD_TEST = 'cm-ant/StopLoadTest';
 const GET_LOAD_TEST_INFO = 'cm-ant/GetLoadTestExecutionInfo';
 const GET_LAST_LOAD_TEST_CONFIG = 'cm-ant/Getlastloadtestexecutionstate';
+// 실행 키로 딱 그 실행만 조회한다. 이름 기반 "마지막 실행" 과 달리 대상이 바뀌지 않는다.
+const GET_LOAD_TEST_STATE_BY_KEY = 'cm-ant/GetLoadTestExecutionState';
 const GET_LOAD_TEST_EVALUATION_DATA = 'cm-ant/Getlastloadtestresult';
 const GET_LOAD_TEST_RESOURCE_METRIC = 'cm-ant/Getlastloadtestmetrics';
 
 // Load Test Scenario Catalog API endpoints
-const GET_ALL_LOAD_TEST_SCENARIO_CATALOGS = 'cm-ant/GetAllLoadTestScenarioCatalogs';
+const GET_ALL_LOAD_TEST_SCENARIO_CATALOGS =
+  'cm-ant/GetAllLoadTestScenarioCatalogs';
 const GET_LOAD_TEST_SCENARIO_CATALOG = 'cm-ant/GetLoadTestScenarioCatalog';
-const CREATE_LOAD_TEST_SCENARIO_CATALOG = 'cm-ant/CreateLoadTestScenarioCatalog';
-const UPDATE_LOAD_TEST_SCENARIO_CATALOG = 'cm-ant/UpdateLoadTestScenarioCatalog';
-const DELETE_LOAD_TEST_SCENARIO_CATALOG = 'cm-ant/DeleteLoadTestScenarioCatalog';
+const CREATE_LOAD_TEST_SCENARIO_CATALOG =
+  'cm-ant/CreateLoadTestScenarioCatalog';
+const UPDATE_LOAD_TEST_SCENARIO_CATALOG =
+  'cm-ant/UpdateLoadTestScenarioCatalog';
+const DELETE_LOAD_TEST_SCENARIO_CATALOG =
+  'cm-ant/DeleteLoadTestScenarioCatalog';
 
 export function useRunLoadTest(requestPayload: IRunLoadTestRequest | null) {
   const requestBodyWrapper: Required<
@@ -57,7 +63,9 @@ export function useStopLoadTest(loadTestKey: string | null) {
 
   return useAxiosPost<
     IAxiosResponse<unknown>,
-    Required<Pick<RequestBodyWrapper<{ loadTestKey: string } | null>, 'request'>>
+    Required<
+      Pick<RequestBodyWrapper<{ loadTestKey: string } | null>, 'request'>
+    >
   >(STOP_LOAD_TEST, requestBodyWrapper);
 }
 
@@ -124,6 +132,19 @@ export function useGetLastLoadTestState(
       >
     >
   >(GET_LAST_LOAD_TEST_CONFIG, requestBodyWrapper);
+}
+
+/**
+ * 실행 키로 부하 테스트 상태를 조회한다.
+ *
+ * 이름(ns/infra/node)으로 "마지막 실행" 을 묻는 것과 결정적으로 다르다 — 이름은 재사용되므로
+ * 그 질문의 답은 도중에 다른 VM 의 실행으로 바뀔 수 있다. 실행 키는 그 실행 하나를 가리킨다.
+ */
+export function useGetLoadTestStateByKey(loadTestKey: string) {
+  return useAxiosPost<IAxiosResponse<ILastloadtestStateResponseWrapper>, any>(
+    GET_LOAD_TEST_STATE_BY_KEY,
+    { pathParams: { loadTestKey } },
+  );
 }
 
 interface IMetricParams extends IMciRequestParams {

--- a/front/src/entities/vm/api/api.ts
+++ b/front/src/entities/vm/api/api.ts
@@ -24,7 +24,8 @@ const RUN_LOAD_TEST = 'cm-ant/Runloadtest';
 const STOP_LOAD_TEST = 'cm-ant/StopLoadTest';
 const GET_LOAD_TEST_INFO = 'cm-ant/GetLoadTestExecutionInfo';
 const GET_LAST_LOAD_TEST_CONFIG = 'cm-ant/Getlastloadtestexecutionstate';
-// 실행 키로 딱 그 실행만 조회한다. 이름 기반 "마지막 실행" 과 달리 대상이 바뀌지 않는다.
+// Looks up exactly that run by its execution key. Unlike a name-based "last run", the
+// target cannot change underneath.
 const GET_LOAD_TEST_STATE_BY_KEY = 'cm-ant/GetLoadTestExecutionState';
 const GET_LOAD_TEST_EVALUATION_DATA = 'cm-ant/Getlastloadtestresult';
 const GET_LOAD_TEST_RESOURCE_METRIC = 'cm-ant/Getlastloadtestmetrics';
@@ -135,10 +136,11 @@ export function useGetLastLoadTestState(
 }
 
 /**
- * 실행 키로 부하 테스트 상태를 조회한다.
+ * Reads load test state by execution key.
  *
- * 이름(ns/infra/node)으로 "마지막 실행" 을 묻는 것과 결정적으로 다르다 — 이름은 재사용되므로
- * 그 질문의 답은 도중에 다른 VM 의 실행으로 바뀔 수 있다. 실행 키는 그 실행 하나를 가리킨다.
+ * This differs from asking for "the last run" by name (ns/infra/node) in the way that
+ * matters: names are reused, so that question can start answering with another VM's run.
+ * An execution key names one run and nothing else.
  */
 export function useGetLoadTestStateByKey(loadTestKey: string) {
   return useAxiosPost<IAxiosResponse<ILastloadtestStateResponseWrapper>, any>(

--- a/front/src/entities/vm/lib/loadTestTracker.ts
+++ b/front/src/entities/vm/lib/loadTestTracker.ts
@@ -1,0 +1,115 @@
+import { useGetLoadTestStateByKey } from '@/entities/vm/api/api';
+import { notify } from '@/entities/notification/lib/notificationStore';
+import { registerTracker } from '@/shared/libs/tracking/runner';
+import {
+  putTrackedJob,
+  clearTrackedJob,
+  trackedJobsOf,
+  hasTrackedJobs,
+  loadTrackedJobs,
+  type TrackedJob,
+} from '@/entities/tracking/lib/trackedJobs';
+
+/**
+ * 부하 테스트 추적 (BAR-1544)
+ *
+ * 부하 테스트는 몇 분씩 걸리고 그동안 사용자는 VM 목록을 떠난다. 지금까지 폴링은 그 화면이
+ * 소유해서 **화면을 벗어나면 추적이 끊겼다.** 여기로 옮겨 앱이 떠 있는 동안 계속 돌게 한다.
+ *
+ * ★ **추적 키는 실행 키(loadTestKey)다.**
+ *
+ * 처음에는 `{nsId}/{infraId}/{nodeId}` 를 키로 삼고 "그 노드의 마지막 실행" 을 물으려 했는데,
+ * 그러면 **알림이 엉뚱한 실행을 가리킬 수 있다.** 그 셋은 이름이고 이름은 재사용된다 —
+ * VM 을 지우고 같은 이름으로 다시 만들면 삭제된 VM 의 실행이 답으로 돌아온다(BAR-1546 에서 실측).
+ * 같은 노드에서 부하 테스트를 두 번 돌린 경우에도 첫 번째 완료를 두 번째 것으로 착각한다.
+ *
+ * 실행 키는 그 실행 하나만 가리키므로 두 문제가 모두 사라진다. 키는 **실행 응답에서 받는다** —
+ * cm-ant 가 돌려주고 있었는데 화면이 버리고 있었다.
+ */
+
+const KIND = 'perf' as const;
+
+/** cm-ant 가 끝났다고 보는 값. 그 외(on_processing·on_fetching)는 진행 중이다. */
+const TERMINAL_SUCCESS = 'successed';
+const TERMINAL_FAILED = 'test_failed';
+
+/**
+ * 부하 테스트 시작을 기록한다.
+ *
+ * `label` 에는 **사용자가 알아볼 이름**을 넣는다. 완료 시점에 남는 것은 실행 키뿐이라
+ * "어느 VM 이었는지" 를 문장으로 만들 수 없다.
+ */
+export async function trackLoadTest(params: {
+  loadTestKey: string;
+  label: string;
+}): Promise<void> {
+  if (!params.loadTestKey) {
+    // 키가 없으면 추적할 방법이 없다. 이름으로 대신 추적하면 다른 실행을 알리게 되므로
+    // 아예 걸지 않는다 — 알림이 없는 편이 틀린 알림보다 낫다.
+    console.warn('[loadTestTracker] 실행 키가 없어 추적하지 않는다');
+    return;
+  }
+
+  await putTrackedJob({
+    kind: KIND,
+    naturalKey: params.loadTestKey,
+    label: params.label,
+    action: 'run',
+    startedAt: new Date().toISOString(),
+  });
+}
+
+/** 진행 중인 부하 테스트가 있는가(세션 유지 판단). */
+export function hasPendingLoadTests(): boolean {
+  return hasTrackedJobs(KIND);
+}
+
+/** 하나의 결과를 확인한다. */
+async function checkOne(job: TrackedJob): Promise<void> {
+  let result: any;
+  try {
+    const res: any = await useGetLoadTestStateByKey(job.naturalKey).execute();
+    result = res?.data?.responseData?.result;
+  } catch {
+    // 조회가 실패했다. 실패로 단정하지 않고 다음 주기에 다시 본다 — 테스트 자체는 돌고 있을 수 있다.
+    return;
+  }
+
+  if (!result) return;
+
+  const status = String(result.executionStatus ?? '').toLowerCase();
+  if (status !== TERMINAL_SUCCESS && status !== TERMINAL_FAILED) return;
+
+  if (status === TERMINAL_SUCCESS) {
+    await notify({
+      category: 'Perf',
+      level: 'Info',
+      message: `Load test on "${job.label}" completed.`,
+      dedupKey: `perf:${job.naturalKey}:done`,
+    });
+  } else {
+    await notify({
+      category: 'Perf',
+      level: 'Error',
+      message: `Load test on "${job.label}" failed.`,
+      detail: result.failureMessage || '',
+      dedupKey: `perf:${job.naturalKey}:error`,
+    });
+  }
+
+  await clearTrackedJob(KIND, job.naturalKey);
+}
+
+registerTracker({
+  id: 'load-test',
+  check: async () => {
+    for (const job of trackedJobsOf(KIND)) {
+      await checkOne(job);
+    }
+  },
+  hasWork: hasPendingLoadTests,
+  resume: loadTrackedJobs,
+  reset: () => {
+    /* 목록은 trackedJobs 가 소유한다 — 로그아웃 정리는 그쪽에서 한 번만 한다 */
+  },
+});

--- a/front/src/entities/vm/lib/loadTestTracker.ts
+++ b/front/src/entities/vm/lib/loadTestTracker.ts
@@ -11,42 +11,45 @@ import {
 } from '@/entities/tracking/lib/trackedJobs';
 
 /**
- * 부하 테스트 추적 (BAR-1544)
+ * Load test tracking.
  *
- * 부하 테스트는 몇 분씩 걸리고 그동안 사용자는 VM 목록을 떠난다. 지금까지 폴링은 그 화면이
- * 소유해서 **화면을 벗어나면 추적이 끊겼다.** 여기로 옮겨 앱이 떠 있는 동안 계속 돌게 한다.
+ * A load test runs for minutes and the VM list is usually left behind while it does. Polling
+ * belonged to that screen, so **leaving it ended the tracking.** Moving it here keeps it
+ * running for as long as the app is open.
  *
- * ★ **추적 키는 실행 키(loadTestKey)다.**
+ * ★ **The tracking key is the execution key (`loadTestKey`).**
  *
- * 처음에는 `{nsId}/{infraId}/{nodeId}` 를 키로 삼고 "그 노드의 마지막 실행" 을 물으려 했는데,
- * 그러면 **알림이 엉뚱한 실행을 가리킬 수 있다.** 그 셋은 이름이고 이름은 재사용된다 —
- * VM 을 지우고 같은 이름으로 다시 만들면 삭제된 VM 의 실행이 답으로 돌아온다(BAR-1546 에서 실측).
- * 같은 노드에서 부하 테스트를 두 번 돌린 경우에도 첫 번째 완료를 두 번째 것으로 착각한다.
+ * Keying on `{nsId}/{infraId}/{nodeId}` and asking for "the last run on that node" was the
+ * first attempt, and it lets **a notification point at the wrong run.** Those three are
+ * names, and names get reused — delete a VM, recreate it under the same name, and the
+ * deleted VM's run comes back as the answer (measured while fixing the node uid handling).
+ * Two runs on the same node have the same problem: the first completion reads as the second.
  *
- * 실행 키는 그 실행 하나만 가리키므로 두 문제가 모두 사라진다. 키는 **실행 응답에서 받는다** —
- * cm-ant 가 돌려주고 있었는데 화면이 버리고 있었다.
+ * An execution key names one run and nothing else, which removes both cases. The key comes
+ * back **in the run response** — cm-ant was already returning it and the screen was
+ * discarding it.
  */
 
 const KIND = 'perf' as const;
 
-/** cm-ant 가 끝났다고 보는 값. 그 외(on_processing·on_fetching)는 진행 중이다. */
+/** What cm-ant treats as finished. Anything else (on_processing, on_fetching) is still running. */
 const TERMINAL_SUCCESS = 'successed';
 const TERMINAL_FAILED = 'test_failed';
 
 /**
- * 부하 테스트 시작을 기록한다.
+ * Records that a load test has started.
  *
- * `label` 에는 **사용자가 알아볼 이름**을 넣는다. 완료 시점에 남는 것은 실행 키뿐이라
- * "어느 VM 이었는지" 를 문장으로 만들 수 없다.
+ * `label` carries **a name the user will recognise**. At completion only the execution key
+ * is left, which cannot be turned into a sentence saying which VM this was.
  */
 export async function trackLoadTest(params: {
   loadTestKey: string;
   label: string;
 }): Promise<void> {
   if (!params.loadTestKey) {
-    // 키가 없으면 추적할 방법이 없다. 이름으로 대신 추적하면 다른 실행을 알리게 되므로
-    // 아예 걸지 않는다 — 알림이 없는 편이 틀린 알림보다 낫다.
-    console.warn('[loadTestTracker] 실행 키가 없어 추적하지 않는다');
+    // Without the key there is nothing to track. Falling back to names would announce a
+    // different run, so track nothing instead — no notification beats a wrong one.
+    console.warn('[loadTestTracker] no execution key; not tracking');
     return;
   }
 
@@ -59,19 +62,20 @@ export async function trackLoadTest(params: {
   });
 }
 
-/** 진행 중인 부하 테스트가 있는가(세션 유지 판단). */
+/** Whether any load test is still running (used to decide on keeping the session alive). */
 export function hasPendingLoadTests(): boolean {
   return hasTrackedJobs(KIND);
 }
 
-/** 하나의 결과를 확인한다. */
+/** Checks the outcome of one tracked run. */
 async function checkOne(job: TrackedJob): Promise<void> {
   let result: any;
   try {
     const res: any = await useGetLoadTestStateByKey(job.naturalKey).execute();
     result = res?.data?.responseData?.result;
   } catch {
-    // 조회가 실패했다. 실패로 단정하지 않고 다음 주기에 다시 본다 — 테스트 자체는 돌고 있을 수 있다.
+    // The lookup failed. Do not call the run failed on that alone — it may still be running.
+    // Look again on the next pass.
     return;
   }
 
@@ -110,6 +114,6 @@ registerTracker({
   hasWork: hasPendingLoadTests,
   resume: loadTrackedJobs,
   reset: () => {
-    /* 목록은 trackedJobs 가 소유한다 — 로그아웃 정리는 그쪽에서 한 번만 한다 */
+    /* trackedJobs owns the list — it clears once on logout, so nothing to do here */
   },
 });

--- a/front/src/features/topbar/topbarNotifications/ui/TopBarNotifications.vue
+++ b/front/src/features/topbar/topbarNotifications/ui/TopBarNotifications.vue
@@ -160,16 +160,17 @@ const handleNotiButtonClick = () => {
     }
   }
 
+  /*
+    자리만 잡는 껍데기다 — **외형은 안쪽 패널이 그린다.**
+    예전엔 여기에도 배경·테두리·그림자와 27.5rem 너비가 있었는데, 안쪽 패널은 25rem 이라
+    바깥이 40px 더 넓었다. 안쪽이 왼쪽에 붙으면서 바깥의 오른쪽 끝이 그만큼 삐져나와
+    **패널이 조금 엇갈려 두 개로 보였다.** 껍데기가 외형을 함께 들면 둘의 너비를 늘
+    맞춰야 하므로, 아예 위치 잡기만 남긴다.
+  */
   .notification-content {
-    @apply absolute bg-white rounded-xs border border-gray-200;
-    display: flex;
-    flex-direction: column;
-    width: 27.5rem;
-    min-height: auto;
+    @apply absolute;
     top: 100%;
     right: 0;
-    box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.08);
-    margin-right: -0.5rem;
     z-index: 1000;
   }
 }

--- a/front/src/features/topbar/topbarNotifications/ui/TopBarNotifications.vue
+++ b/front/src/features/topbar/topbarNotifications/ui/TopBarNotifications.vue
@@ -24,19 +24,20 @@ const setVisible = (visible: boolean) => {
 
 const count = computed(() => notificationCount.value);
 const hasError = computed(() => hasErrorNotification.value);
-/** 99를 넘으면 자릿수가 늘어 배지가 아이콘을 밀어낸다. */
+/** Past 99 the extra digit widens the badge until it pushes the icon aside. */
 const countLabel = computed(() =>
   count.value > 99 ? '99+' : String(count.value),
 );
 
 /**
- * 새 알림이 도착한 것을 *다른 화면을 보고 있어도* 알아채게 한다.
+ * Makes an arriving notification noticeable *while another screen has the attention*.
  *
- * 소리는 쓰지 않는다 — 브라우저가 사용자 조작 없는 재생을 막아 신뢰할 수 없고(무음으로 끝난다),
- * 업무 콘솔에서 예고 없는 소리는 방해가 된다. 소리가 필요하면 설정으로 켜는 편이 맞다.
+ * No sound: browsers block playback without a user gesture, so it cannot be relied on and
+ * ends in silence, and an unannounced noise is unwelcome in a work console. If sound is
+ * wanted, it belongs behind a setting.
  *
- * 대신 두 가지를 쓴다. 배지를 잠깐 흔들고, 탭 제목에 개수를 붙인다. 탭이 뒤에 있으면 화면은
- * 보이지 않지만 제목은 보인다.
+ * Two things instead — the badge shakes briefly, and the count goes into the tab title. A
+ * tab in the background hides the screen but not its title.
  */
 const justArrived = ref(false);
 let arrivalTimer: ReturnType<typeof setTimeout> | null = null;
@@ -47,7 +48,8 @@ watch(count, (now, before) => {
   if (now > (before ?? 0)) {
     justArrived.value = true;
     if (arrivalTimer) clearTimeout(arrivalTimer);
-    // 계속 흔들면 피로하다. 도착을 알리는 것까지가 목적이고, 남아 있다는 사실은 숫자가 말한다.
+    // Shaking on and on wears thin. Announcing the arrival is the point; that something is
+    // still waiting is what the number says.
     arrivalTimer = setTimeout(() => (justArrived.value = false), 2000);
   }
   document.title = now > 0 ? `(${now}) ${baseTitle}` : baseTitle;
@@ -79,10 +81,10 @@ const handleNotiButtonClick = () => {
     @keydown.esc="hideNotiMenu"
   >
     <!--
-      **패널을 열면 툴팁을 끈다.** 툴팁은 "이 아이콘이 무엇인지" 알려 주는 것이라 마우스를
-      올렸을 때만 쓸모가 있는데, 클릭해도 그대로 남아 검은 상자가 패널 위를 덮었다.
-      하필 그 자리가 [Mark all read] 여서 눌러야 할 것을 가렸다.
-      열려 있는 동안에는 아이콘이 무엇인지 이미 화면이 말해 주므로 설명이 필요 없다.
+      **Drop the tooltip once the panel is open.** A tooltip names the icon, which helps
+      while pointing at it and stops helping the moment the panel is showing. It used to
+      stay on after the click and the dark box covered the panel — over [Mark all read],
+      so the one control in the header could not be reached.
     -->
     <p-tooltip :contents="visible ? '' : 'Notifications'" position="absolute">
       <span
@@ -139,7 +141,7 @@ const handleNotiButtonClick = () => {
         @apply text-blue-600;
       }
     }
-    /* 숫자 배지. 색으로 급한 것과 그냥 볼 것을 가른다 — 배지를 둘로 나누지 않기 위해서다. */
+    /* Count badge. Colour separates urgent from informational so one badge can serve both. */
     .count-badge {
       @apply absolute rounded-full bg-blue-500 text-white font-bold;
       top: 0;
@@ -156,7 +158,7 @@ const handleNotiButtonClick = () => {
       }
     }
 
-    /* 도착 신호 — 다른 화면을 보고 있어도 눈에 걸리도록 잠깐 흔든다. */
+    /* Arrival cue — a brief shake so it registers while another screen has the attention. */
     &.arrived .count-badge {
       animation: notification-arrived 0.5s ease-in-out 3;
     }
@@ -167,11 +169,11 @@ const handleNotiButtonClick = () => {
   }
 
   /*
-    자리만 잡는 껍데기다 — **외형은 안쪽 패널이 그린다.**
-    예전엔 여기에도 배경·테두리·그림자와 27.5rem 너비가 있었는데, 안쪽 패널은 25rem 이라
-    바깥이 40px 더 넓었다. 안쪽이 왼쪽에 붙으면서 바깥의 오른쪽 끝이 그만큼 삐져나와
-    **패널이 조금 엇갈려 두 개로 보였다.** 껍데기가 외형을 함께 들면 둘의 너비를 늘
-    맞춰야 하므로, 아예 위치 잡기만 남긴다.
+    Placement only — **the panel inside draws the look.**
+    This used to carry a background, border, shadow and a width of 27.5rem while the panel
+    inside is 25rem, so the wrapper was 40px wider. The panel sat against the left edge and
+    the wrapper's right side stayed visible past it, reading as a second, staggered panel.
+    Holding the look here as well would mean keeping two widths in step forever.
   */
   .notification-content {
     @apply absolute;

--- a/front/src/features/topbar/topbarNotifications/ui/TopBarNotifications.vue
+++ b/front/src/features/topbar/topbarNotifications/ui/TopBarNotifications.vue
@@ -78,7 +78,13 @@ const handleNotiButtonClick = () => {
     @click.stop
     @keydown.esc="hideNotiMenu"
   >
-    <p-tooltip contents="Notifications" position="absolute">
+    <!--
+      **패널을 열면 툴팁을 끈다.** 툴팁은 "이 아이콘이 무엇인지" 알려 주는 것이라 마우스를
+      올렸을 때만 쓸모가 있는데, 클릭해도 그대로 남아 검은 상자가 패널 위를 덮었다.
+      하필 그 자리가 [Mark all read] 여서 눌러야 할 것을 가렸다.
+      열려 있는 동안에는 아이콘이 무엇인지 이미 화면이 말해 주므로 설명이 필요 없다.
+    -->
+    <p-tooltip :contents="visible ? '' : 'Notifications'" position="absolute">
       <span
         :class="{ 'menu-button': true, opened: visible, arrived: justArrived }"
         tabindex="0"

--- a/front/src/features/workload/actionLoadConfig/ui/LoadConfig.vue
+++ b/front/src/features/workload/actionLoadConfig/ui/LoadConfig.vue
@@ -168,9 +168,9 @@ async function handleConfirm() {
         },
       })
       .then(res => {
-        // cm-ant 는 실행 키를 응답으로 돌려준다. 그동안 이 응답을 그대로 버리고 있었는데,
-        // 그 키가 없으면 나중에 "이 실행이 어떻게 됐나" 를 물을 방법이 이름밖에 남지 않는다.
-        // 이름은 재사용되므로 다른 VM 의 실행을 답으로 받게 된다(BAR-1544/1546).
+        // cm-ant returns the execution key, and this response was being discarded. Without
+        // that key the only way left to ask how the run turned out is by name, and names are
+        // reused, so the answer can come back describing another VM's run.
         const loadTestKey = res?.data?.responseData?.result ?? '';
         emit(
           'success',

--- a/front/src/features/workload/actionLoadConfig/ui/LoadConfig.vue
+++ b/front/src/features/workload/actionLoadConfig/ui/LoadConfig.vue
@@ -168,7 +168,15 @@ async function handleConfirm() {
         },
       })
       .then(res => {
-        emit('success', loadConfigModel.inputModels.scenarioName.value);
+        // cm-ant 는 실행 키를 응답으로 돌려준다. 그동안 이 응답을 그대로 버리고 있었는데,
+        // 그 키가 없으면 나중에 "이 실행이 어떻게 됐나" 를 물을 방법이 이름밖에 남지 않는다.
+        // 이름은 재사용되므로 다른 VM 의 실행을 답으로 받게 된다(BAR-1544/1546).
+        const loadTestKey = res?.data?.responseData?.result ?? '';
+        emit(
+          'success',
+          loadConfigModel.inputModels.scenarioName.value,
+          loadTestKey,
+        );
       })
       .catch(e => {
         showErrorMessage('error', e.errorMsg);

--- a/front/src/main.ts
+++ b/front/src/main.ts
@@ -16,6 +16,7 @@ import { startNotificationPolling } from '@/entities/notification/lib/notificati
 // 체커는 import 되는 순간 러너에 자기를 등록한다. 아무도 이 모듈을 부르지 않으면 번들에서
 // 통째로 사라지므로(BAR-1531 에서 겪었다) 여기서 명시적으로 들여온다.
 import '@/entities/mci/lib/deleteTracker';
+import '@/entities/vm/lib/loadTestTracker';
 
 const pinia = createPinia();
 Vue.use(PiniaVuePlugin);

--- a/front/src/pages/workloadOperations/mci/ui/MciPage.vue
+++ b/front/src/pages/workloadOperations/mci/ui/MciPage.vue
@@ -60,11 +60,25 @@ function handleSelectVmListTableRow(id: string) {
           <template #detail>
             <div class="tab-section-header">
               <p>Workload Information</p>
+              <!--
+                **여기 두 버튼은 늘 비활성인 자리표시다.** 실제 기능은 Server 탭 안의
+                같은 이름 탭(`Evaluate Perf`·`Estimate Cost`)에 있다. 이름이 같아서
+                화면 자동화가 이쪽을 먼저 집어 "버튼이 안 눌린다"로 헤매기 쉬우므로,
+                무엇인지 식별자로 밝혀 둔다.
+              -->
               <div class="flex gap-1.5">
-                <p-button style-type="tertiary" :disabled="true">
+                <p-button
+                  data-testid="workload-detail-evaluate-perf-placeholder"
+                  style-type="tertiary"
+                  :disabled="true"
+                >
                   Evaluate Perf
                 </p-button>
-                <p-button style-type="tertiary" :disabled="true">
+                <p-button
+                  data-testid="workload-detail-estimate-cost-placeholder"
+                  style-type="tertiary"
+                  :disabled="true"
+                >
                   Estimate Cost
                 </p-button>
               </div>

--- a/front/src/pages/workloadOperations/mci/ui/MciPage.vue
+++ b/front/src/pages/workloadOperations/mci/ui/MciPage.vue
@@ -61,10 +61,10 @@ function handleSelectVmListTableRow(id: string) {
             <div class="tab-section-header">
               <p>Workload Information</p>
               <!--
-                **여기 두 버튼은 늘 비활성인 자리표시다.** 실제 기능은 Server 탭 안의
-                같은 이름 탭(`Evaluate Perf`·`Estimate Cost`)에 있다. 이름이 같아서
-                화면 자동화가 이쪽을 먼저 집어 "버튼이 안 눌린다"로 헤매기 쉬우므로,
-                무엇인지 식별자로 밝혀 둔다.
+                **These two are placeholders and stay disabled.** The working controls are
+                tabs of the same name (`Evaluate Perf`, `Estimate Cost`) inside Server.
+                Screen automation reaches for these first because the names match, and then
+                reports a button that will not respond, so name them for what they are.
               -->
               <div class="flex gap-1.5">
                 <p-button

--- a/front/src/shared/libs/store/auth/index.ts
+++ b/front/src/shared/libs/store/auth/index.ts
@@ -7,6 +7,7 @@ import {
 } from '@/entities/notification/lib/notificationStore';
 // 체커 자기 등록을 위한 부수효과 import (트리 셰이킹 방지).
 import '@/entities/mci/lib/deleteTracker';
+import '@/entities/vm/lib/loadTestTracker';
 
 export type AuthorizationType = null | 'admin' | 'client';
 

--- a/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
@@ -11,7 +11,7 @@ import { computed, reactive, ref, watch } from 'vue';
 import { useDeleteMci } from '@/entities/mci/api';
 import {
   putDeleteRecord,
-  clearDeleteRecord,
+  markDeleteSucceeded,
   markDeleteFailed,
   getDeleteRecord,
   isDeleteInProgress,
@@ -139,7 +139,9 @@ function fireDeletes(mciList: any[], option: string): string[] {
     useDeleteMci({ nsId: props.nsId, infraId, option }, reqId)
       .execute()
       // A success keeps no record — the infra leaves the list, so there is nothing to show.
-      .then(() => clearDeleteRecord(uid))
+      // Announce the success from here. The tracker cannot: clearing on success would take
+      // the record out of what it inspects, so nothing would ever report the completion.
+      .then(() => markDeleteSucceeded(uid))
       .catch((rejected: any) =>
         markDeleteFailed(uid, reasonFrom(rejected) ?? undefined),
       );

--- a/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
@@ -238,9 +238,9 @@ watch(
         data-testid="mci-delete-error"
       >
         <div class="force-warning-banner">
-          기존 삭제 요청이 처리 중에 실패했습니다.
+          A previous delete request failed while it was being processed.
         </div>
-        <p class="description">실패한 워크로드</p>
+        <p class="description">Failed workloads</p>
         <div class="error-reason-box" data-testid="wl-delete-error-dialog">
           <div
             v-for="rec in erroredRecords"
@@ -254,8 +254,9 @@ watch(
           </div>
         </div>
         <p class="hint">
-          강제 삭제는 CSP 리소스는 남기고 텀블벅 내부 데이터만 지웁니다. 남은
-          CSP 리소스는 직접 삭제하셔야 합니다.
+          Force delete removes only the internal records and leaves the CSP
+          resources in place. Any resources left behind keep billing and must be
+          removed by hand.
         </p>
       </div>
 
@@ -266,10 +267,10 @@ watch(
         data-testid="mci-delete-progress"
       >
         <div v-if="state.alreadyInProgress" class="warning-banner">
-          이미 처리 중인 삭제가 있습니다. 새로 시작하지 않고 현재 진행 상태를
-          보여줍니다.
+          A delete is already in progress. Showing its current state instead of
+          starting a new one.
         </div>
-        <p class="description">삭제 처리 중</p>
+        <p class="description">Deleting</p>
         <div class="mci-list">
           <div
             v-for="rec in trackedRecords"
@@ -282,23 +283,23 @@ watch(
               class="progress-status handling"
             >
               <span class="spinner" />
-              {{ rec.stage ? `삭제 중 · ${rec.stage}` : '삭제 처리 중' }}
+              {{ rec.stage ? `Deleting · ${rec.stage}` : 'Deleting' }}
             </span>
             <span
               v-else-if="rec.status === 'Error'"
               class="progress-status error"
               data-testid="mci-delete-progress-error"
             >
-              에러<template v-if="rec.errorReason"
+              Error<template v-if="rec.errorReason"
                 >: {{ rec.errorReason }}</template
               >
             </span>
-            <span v-else class="progress-status done">삭제 완료</span>
+            <span v-else class="progress-status done">Deleted</span>
           </div>
         </div>
         <p v-if="anyHandling" class="hint">
-          이 창을 닫아도 삭제는 계속되고, 목록의 <b>삭제 상태</b> 컬럼에서 진행
-          상황을 볼 수 있습니다.
+          Closing this dialog does not stop the delete. You can follow it in the
+          <b>Delete Status</b> column of the list.
         </p>
       </div>
 

--- a/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
@@ -93,6 +93,26 @@ function newReqId(): string {
     : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
+/**
+ * Pulls the failure reason out of what `execute()` rejects with.
+ *
+ * It does not reject with the axios error — it rejects with `{ error, errorMsg, status }`,
+ * where each is a ref and `errorMsg` already holds the message it worked out from the
+ * response. Passing that wrapper back into `extractErrorMessage` finds neither `response`
+ * nor `request` on it and falls through to the last resort, so a perfectly good server
+ * reason was being reported as "Error in setting up request" — a phrase that means the
+ * request never went out, which was not what happened.
+ *
+ * Read the message that was already prepared, and fall back to the raw error only if it is
+ * missing.
+ */
+function reasonFrom(rejected: any): string | null {
+  const prepared = rejected?.errorMsg?.value;
+  if (prepared) return prepared;
+  const raw = rejected?.error?.value ?? rejected;
+  return extractErrorMessage(raw);
+}
+
 // Issues delete requests for the given infras (terminate|force), recording each for tracking.
 function fireDeletes(mciList: any[], option: string): string[] {
   const uids: string[] = [];
@@ -120,8 +140,8 @@ function fireDeletes(mciList: any[], option: string): string[] {
       .execute()
       // A success keeps no record — the infra leaves the list, so there is nothing to show.
       .then(() => clearDeleteRecord(uid))
-      .catch((error: any) =>
-        markDeleteFailed(uid, extractErrorMessage(error) ?? undefined),
+      .catch((rejected: any) =>
+        markDeleteFailed(uid, reasonFrom(rejected) ?? undefined),
       );
     uids.push(uid);
   }

--- a/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
@@ -33,17 +33,17 @@ interface IEmits {
 const props = defineProps<IProps>();
 const emit = defineEmits<IEmits>();
 
-// 모달은 두 단계다.
-//   confirm  — 삭제 방식(Normal/Force) 선택 + 이름 타이핑 확인
-//   progress — "삭제 처리 중". 요청을 낸 뒤 완료까지 진행 상태를 보여준다.
-// 기존과 달리 삭제는 *비동기*다: reqId 로 요청을 추적하므로(deleteTracker), 이 모달을 닫고
-// 다른 화면에 갔다 돌아와도 목록의 `삭제 상태` 컬럼이 같은 상태를 이어 보여준다.
+// The modal has two steps.
+//   confirm  — choose the method (Normal/Force) and type the name to confirm
+//   progress — shows how the delete is going, from request until it finishes.
+// The delete is *asynchronous*: the request is tracked by reqId (deleteTracker), so
+// closing this modal and coming back later still shows the same state in the list.
 const state = reactive({
   deleteMethod: 'normal',
   confirmKeyword: '',
-  // confirm  — 삭제 방식 선택 + 이름 타이핑
-  // progress — 삭제 처리 중 (완료까지 표시)
-  // error    — 기존 삭제가 실패한 상태에서 다시 열림 → 에러 + 강제 삭제/취소
+  // confirm  — choose the method and type the name
+  // progress — deleting, shown until it finishes
+  // error    — reopened after an earlier delete failed: reason, plus force delete or cancel
   phase: 'confirm' as 'confirm' | 'progress' | 'error',
   alreadyInProgress: false,
 });
@@ -56,7 +56,8 @@ const checkKeyword = computed(() => {
     : 'Delete All';
 });
 
-// confirm 단계에선 이름을 정확히 입력해야 활성. progress 단계에선 확인 버튼을 막는다(재요청 방지).
+// In confirm the name must match exactly; in progress the confirm button is blocked so the
+// request cannot be sent twice.
 const isDeleteDisabled = computed(() => {
   if (state.phase === 'progress') return true;
   return state.confirmKeyword !== checkKeyword.value;
@@ -67,7 +68,7 @@ const deleteMethodOptions = [
   { label: 'Force Delete', key: 'force' },
 ];
 
-// 이 모달이 추적하는 인프라들의 현재 삭제 기록.
+// Current delete records for the infras this modal is tracking.
 const trackedRecords = computed<DeleteRecord[]>(() =>
   trackedIds.value
     .map(id => getDeleteRecord(id))
@@ -81,7 +82,7 @@ const anyError = computed(() =>
   trackedRecords.value.some(r => r.status === 'Error'),
 );
 
-// error 단계에서 보여줄 실패 기록(에러 사유 표시용).
+// Failed records shown in the error step, for their reasons.
 const erroredRecords = computed<DeleteRecord[]>(() =>
   trackedRecords.value.filter(r => r.status === 'Error'),
 );
@@ -92,16 +93,16 @@ function newReqId(): string {
     : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
-// 지정한 인프라들에 삭제 요청을 낸다(옵션: terminate|force). 진행 기록을 남기고 추적한다.
+// Issues delete requests for the given infras (terminate|force), recording each for tracking.
 function fireDeletes(mciList: any[], option: string): string[] {
   const uids: string[] = [];
   for (const mci of mciList) {
     const uid = mci?.uid as string;
     const infraId = mci?.name as string;
-    // uid 가 없으면 추적할 방법이 없다(이름은 재사용되므로 키가 될 수 없다).
+    // Without a uid there is nothing to track — a name is reused and cannot be the key.
     if (!uid) continue;
 
-    // 이미 진행 중이면 새 요청을 내지 않고(중복 방어) 그 기록을 그대로 추적한다.
+    // Already running: do not issue another request, just track the existing record.
     if (isDeleteInProgress(uid)) {
       uids.push(uid);
       continue;
@@ -117,7 +118,7 @@ function fireDeletes(mciList: any[], option: string): string[] {
     });
     useDeleteMci({ nsId: props.nsId, infraId, option }, reqId)
       .execute()
-      // 성공은 기록을 남기지 않는다 — 인프라가 목록에서 사라지므로 보여줄 대상이 없다.
+      // A success keeps no record — the infra leaves the list, so there is nothing to show.
       .then(() => clearDeleteRecord(uid))
       .catch((error: any) =>
         markDeleteFailed(uid, extractErrorMessage(error) ?? undefined),
@@ -127,18 +128,18 @@ function fireDeletes(mciList: any[], option: string): string[] {
   return uids;
 }
 
-// confirm 단계에서 삭제 실행 — 요청을 내고 progress 단계로 전환한다(즉시 닫지 않는다).
+// Runs the delete from confirm: issue the request and move to progress rather than closing.
 function handleConfirm() {
   if (state.phase !== 'confirm') return;
   const option = state.deleteMethod === 'force' ? 'force' : 'terminate';
   trackedIds.value = fireDeletes(props.selectedMciList, option);
   state.phase = 'progress';
-  emit('deleted'); // 목록이 즉시 `삭제 상태` 컬럼을 띄우도록 갱신
+  emit('deleted'); // refresh so the list brings up the Delete Status column at once
 }
 
-// error 단계에서 [강제 삭제] — 실패한 대상을 force 로 다시 삭제하고 progress 로 전환한다.
-// force 는 CSP 자원을 남기고 텀블벅 내부 데이터만 지운다(배너로 이미 고지).
-// 기록이 Error 상태(진행 중 아님)이므로 fireDeletes 가 새 reqId 로 다시 발행한다.
+// [Force Delete] in the error step: retry the failed targets with force and move to progress.
+// Force leaves the CSP resources and removes only the internal records, as the banner says.
+// The records are in Error rather than in flight, so fireDeletes issues fresh reqIds.
 function handleForceDelete() {
   const targets = erroredRecords.value.map(r => ({
     uid: r.uid,
@@ -149,16 +150,16 @@ function handleForceDelete() {
   emit('deleted');
 }
 
-// error 단계에서 [재시도] — 선택 화면(confirm)으로 돌아간다. 일반 삭제가 되는 경우도 있어
-// (텀블벅이 일시적으로 막혔던 등) 다시 일반/강제를 골라 재시도한다. 강제 삭제는 CSP 자원을
-// 남기므로, 먼저 일반 삭제로 되는지 확인하고 안 되면 강제로 가는 흐름을 사용자가 고른다.
+// [Retry] in the error step goes back to confirm. A normal delete sometimes succeeds on a
+// second attempt — the earlier failure may have been temporary — and since force leaves CSP
+// resources behind, the choice of trying normal first is left to the user.
 function handleRetry() {
   state.deleteMethod = 'normal';
   state.confirmKeyword = '';
   state.phase = 'confirm';
 }
 
-// progress 단계에서 모두 삭제되면(진행 중·에러 없음) 모달을 닫는다. 에러가 있으면 열어 둔다.
+// Close once everything is gone (nothing in flight, no errors); stay open if any failed.
 watch([anyHandling, anyError], ([handling, error]) => {
   if (state.phase !== 'progress') return;
   if (!handling && !error) {
@@ -180,17 +181,17 @@ function resetState() {
   trackedIds.value = [];
 }
 
-// 닫기 — 삭제는 계속되고 목록이 상태를 이어 보여준다("백그라운드로 보내기").
-// 지금 목록 화면을 보고 있으므로, 닫으면서 목록을 새로고침해 `삭제 상태` 컬럼이 뜨게 한다.
+// Close — the delete carries on and the list keeps showing its state.
+// The list is what is behind this modal, so refresh on close to bring up Delete Status.
 function handleClose() {
   emit('deleted');
   closeAndReset();
 }
 
-// 모달이 열릴 때 대상의 현재 삭제 기록으로 단계를 정한다.
-//   진행 중(Handling) → progress ("이미 처리 중" 안내 + 진행 상태)
-//   실패(Error)       → error (기존 삭제 실패 + 에러 메시지 + 강제 삭제/취소)
-//   없음              → confirm (삭제 방식 선택 + 타이핑)
+// The step is chosen from the targets' current delete records when the modal opens.
+//   Handling → progress (says one is already running, and shows its state)
+//   Error    → error (the earlier failure, its reason, and force delete or cancel)
+//   none     → confirm (choose the method and type the name)
 watch(
   () => props.visible,
   visible => {
@@ -231,7 +232,7 @@ watch(
     @update:visible="$emit('update:visible', $event)"
   >
     <template #body>
-      <!-- error 단계 — 기존 삭제가 실패한 상태에서 다시 열림. 에러 메시지(길면 스크롤) + 강제 삭제/취소. -->
+      <!-- error step — reopened after a failure: the reason (scrolls if long), force delete or cancel -->
       <div
         v-if="state.phase === 'error'"
         class="delete-modal-content"
@@ -260,7 +261,7 @@ watch(
         </p>
       </div>
 
-      <!-- progress 단계 — 삭제 처리 중 (완료까지 계속 표시). 닫아도 목록이 상태를 이어 보여준다. -->
+      <!-- progress step — shown until it finishes; the list carries the state after closing -->
       <div
         v-else-if="state.phase === 'progress'"
         class="delete-modal-content"
@@ -303,7 +304,7 @@ watch(
         </p>
       </div>
 
-      <!-- confirm 단계 — 삭제 방식 선택 + 이름 타이핑 확인 -->
+      <!-- confirm step — choose the method and type the name -->
       <div v-else class="delete-modal-content">
         <div class="warning-banner">
           ⚠️ Deleting workloads will also delete
@@ -363,50 +364,50 @@ watch(
       </div>
 
       <!--
-        단계별 버튼.
+        Buttons per step.
 
-        ★ PButtonModal 에는 `footer` 슬롯이 없다 — 푸터는 `v-if="!hideFooter"` 로 감싼 고정 영역이고,
-          바꿀 수 있는 건 그 안의 `close-button`/`confirm-button` 슬롯뿐이다. 그래서 `hide-footer` 로
-          기본 푸터를 끈 뒤 `#footer` 슬롯에 버튼을 넣으면 *아무것도 렌더되지 않는다*(실제로 그랬다).
-          에러 단계는 버튼이 셋(재시도·강제 삭제·닫기)이라 기본 두 슬롯으로는 부족하므로,
-          기본 푸터는 끈 채 버튼 줄을 body 끝에 직접 그린다.
+        ★ PButtonModal has no `footer` slot. The footer is a fixed area behind
+          `v-if="!hideFooter"`, and only its `close-button`/`confirm-button` slots can be
+          replaced. Turning the footer off with `hide-footer` and putting buttons in a
+          `#footer` slot renders *nothing at all* — which is what happened. The error step
+          so the default footer stays off and the button row is drawn at the end of the body.
       -->
       <div class="modal-footer">
-        <!-- error: 재시도(선택 화면으로) / 강제 삭제 / 닫기 -->
+        <!-- error: retry (back to the choice) / force delete / close -->
         <template v-if="state.phase === 'error'">
           <p-button
             style-type="transparent"
             data-testid="wl-delete-close"
             @click="handleClose"
           >
-            닫기
+            Close
           </p-button>
           <p-button
             style-type="secondary"
             data-testid="wl-delete-retry"
             @click="handleRetry"
           >
-            재시도
+            Retry
           </p-button>
           <p-button
             style-type="negative-primary"
             data-testid="wl-delete-force-enter"
             @click="handleForceDelete"
           >
-            강제 삭제
+            Force Delete
           </p-button>
         </template>
-        <!-- progress: 닫기만 (삭제는 계속되고 목록이 이어 보여줌) -->
+        <!-- progress: close only; the delete carries on and the list keeps showing it -->
         <template v-else-if="state.phase === 'progress'">
           <p-button
             style-type="transparent"
             data-testid="wl-delete-close"
             @click="handleClose"
           >
-            닫기
+            Close
           </p-button>
         </template>
-        <!-- confirm: 취소 / 삭제(이름 타이핑 시 활성) -->
+        <!-- confirm: cancel / delete, enabled once the name matches -->
         <template v-else>
           <p-button
             style-type="transparent"
@@ -504,7 +505,7 @@ watch(
     line-height: 1.5;
   }
 
-  /* 에러 사유가 길어도 강제 삭제 버튼이 밀려나지 않도록 스크롤 영역에 담는다. */
+  /* Keep a long reason in a scroll area so it cannot push the buttons out of reach. */
   .error-reason-box {
     max-height: 180px;
     overflow-y: auto;
@@ -539,7 +540,7 @@ watch(
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  /* 기본 푸터를 끄고 body 안에 그리므로(위 템플릿 주석 참고), 구분선과 여백으로 푸터처럼 보이게 한다. */
+  /* Drawn inside the body with the default footer off, so a rule and spacing make it read as one. */
   margin-top: 20px;
   padding-top: 16px;
   border-top: 1px solid #e5e7eb;

--- a/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
@@ -12,7 +12,7 @@ import { useDeleteMci } from '@/entities/mci/api';
 import {
   putDeleteRecord,
   markDeleteSucceeded,
-  markDeleteFailed,
+  noteDeleteRequestError,
   getDeleteRecord,
   isDeleteInProgress,
   type DeleteRecord,
@@ -142,8 +142,18 @@ function fireDeletes(mciList: any[], option: string): string[] {
       // Announce the success from here. The tracker cannot: clearing on success would take
       // the record out of what it inspects, so nothing would ever report the completion.
       .then(() => markDeleteSucceeded(uid))
+      // **A failed request is not a failed delete.** This call runs for minutes and the proxy
+      // gives up at 504 long before the server does; the delete carries on and usually
+      // succeeds. Marking Error here told the user it had failed while the infra was in fact
+      // being removed — observed on the dev server, where the infra was gone and the screen
+      // said it had failed.
+      //
+      // So leave the record in Handling and let the tracker decide: it asks cm-beetle for the
+      // request, and when that cannot answer it falls back to whether the infra is still
+      // listed. Only that can tell a delete that failed from one that is merely slow. The
+      // reason is kept on the record so it can be shown if the tracker does conclude failure.
       .catch((rejected: any) =>
-        markDeleteFailed(uid, reasonFrom(rejected) ?? undefined),
+        noteDeleteRequestError(uid, reasonFrom(rejected) ?? undefined),
       );
     uids.push(uid);
   }

--- a/front/src/widgets/workload/mci/mciList/ui/MciList.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciList.vue
@@ -45,7 +45,7 @@ const { toolboxTableRef, adjustedDynamicHeight } = useToolboxTableHeight(
   computed(() => dynamicHeight.value),
 );
 
-const tableKey = ref(0); // 컴포넌트 재렌더링을 위한 key
+const tableKey = ref(0); // bumped to force the table to re-render
 
 const mciCreateModalState = reactive({
   open: false,
@@ -81,7 +81,7 @@ function handleDelete(item: string) {
 
 async function handleDeleted() {
   await fetchMciList();
-  // 데이터 로드 후 컴포넌트 재렌더링
+  // re-render once the data has loaded
   tableKey.value++;
 }
 
@@ -98,11 +98,11 @@ function handleSelectedIndex(index: number[]) {
   }
 }
 
-// ── 삭제 상태 추적 (BAR-1444) ──────────────────────────────────────────────
-// 현재 목록에 뜬 인프라 중 삭제 요청이 있는 것의 상태를 `삭제 상태` 컬럼으로 보여준다.
-// 삭제 요청이 하나도 없으면 컬럼 자체가 나타나지 않는다.
+// ── Delete status ──────────────────────────────────────────────────────────
+// Shows a `Delete Status` column for any listed infra that has a delete request against it.
+// With no delete requests at all, the column does not appear.
 
-/** 현재 표시 중인 행 이름 집합에 걸린 삭제 기록만 추린다. */
+/** Narrows the delete records to those matching the rows currently on screen. */
 function activeRecords(): DeleteRecord[] {
   const uids = new Set(
     mciTableModel.tableState.displayItems.map((it: any) => it?.uid),
@@ -112,18 +112,18 @@ function activeRecords(): DeleteRecord[] {
 
 const hasActiveDeletes = computed(() => activeRecords().length > 0);
 
-/** 슬롯에서 행별 삭제 기록 조회. */
+/** Looks up one row's delete record from the slot. */
 function deleteStatusOf(uid: string): DeleteRecord | undefined {
   return getDeleteRecord(uid);
 }
 
-// 삭제 요청이 있을 때만 `삭제 상태` 컬럼을 넣고, 없으면 뺀다.
+// Add the `Delete Status` column only while delete requests exist; drop it otherwise.
 const DELETE_STATUS_FIELD = { name: 'deleteStatus', label: 'Delete Status' };
 watch(hasActiveDeletes, active => {
   const fields = mciTableModel.tableState.fields;
   const idx = fields.findIndex((f: any) => f.name === 'deleteStatus');
   if (active && idx === -1) {
-    // 첫 컬럼(name) 바로 뒤에 끼운다.
+    // insert right after the first column (name)
     const nameIdx = fields.findIndex((f: any) => f.name === 'name');
     fields.splice(nameIdx === -1 ? 0 : nameIdx + 1, 0, {
       ...DELETE_STATUS_FIELD,
@@ -133,8 +133,8 @@ watch(hasActiveDeletes, active => {
   }
 });
 
-// 상태 갱신(폴링)은 이 화면이 하지 않는다 — deleteTracker 가 앱 전역에서 돌기 때문에
-// 다른 화면에 있는 동안에도 결과가 반영된다. 여기서는 그 결과를 보여주기만 한다.
+// This screen does not poll for status. deleteTracker runs app-wide, so results arrive even
+// while another screen is open; here they are only displayed.
 
 onBeforeMount(() => {
   initToolBoxTableModel();
@@ -142,7 +142,7 @@ onBeforeMount(() => {
 
 onMounted(async () => {
   await fetchMciList();
-  // 초기 데이터 로드 후 컴포넌트 재렌더링
+  // re-render after the initial data load
   tableKey.value++;
 });
 </script>
@@ -151,14 +151,14 @@ onMounted(async () => {
   <div>
     <p-horizontal-layout :key="tableKey" :height="adjustedDynamicHeight">
       <template #container="{ height }">
-        <!-- 로딩 중일 때 스피너 표시 -->
+        <!-- spinner while loading -->
         <table-loading-spinner
           :loading="loading"
           :height="height"
           message="Loading Infra list..."
         />
 
-        <!-- 로딩 완료 후 테이블 표시 -->
+        <!-- table once loading has finished -->
         <p-toolbox-table
           v-if="!loading"
           ref="toolboxTableRef"
@@ -219,9 +219,9 @@ onMounted(async () => {
               <span class="spinner" /> In progress
             </span>
             <!--
-              사유는 두 곳에 싣는다. 꾸민 팝오버는 표의 스크롤 영역에 잘릴 수 있어서,
-              브라우저가 직접 그리는 `title` 을 함께 둔다 — 이쪽은 어떤 영역에도 갇히지 않는다.
-              사유가 없으면 어디서 볼 수 있는지를 대신 알린다.
+              The reason is carried twice. The styled popover can be clipped by the table's
+              scroll area, so a native `title` carries it as well — the browser draws that one
+              and no container can trap it. With no reason, say where one can be obtained.
             -->
             <span
               v-else-if="deleteStatusOf(item.uid)?.status === 'Error'"
@@ -276,7 +276,7 @@ onMounted(async () => {
     transform: rotate(360deg);
   }
 }
-/* 에러 사유는 마우스오버 즉시 레이어 팝업으로(툴팁 지연 없이). 사유가 있을 때만 표시된다. */
+/* The reason appears on hover with no tooltip delay, and only when there is one. */
 .delete-status.error-cell {
   position: relative;
   color: #dc2626;
@@ -287,7 +287,7 @@ onMounted(async () => {
   display: none;
   position: absolute;
   top: 100%;
-  /* 왼쪽 기준이면 긴 사유가 표 오른쪽 밖으로 나가 잘린다. 오른쪽 끝에 맞춘다. */
+  /* Anchored left, a long reason runs past the right edge of the table and is clipped. */
   right: 0;
   z-index: 20;
   max-width: 360px;

--- a/front/src/widgets/workload/mci/mciList/ui/MciList.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciList.vue
@@ -118,7 +118,7 @@ function deleteStatusOf(uid: string): DeleteRecord | undefined {
 }
 
 // 삭제 요청이 있을 때만 `삭제 상태` 컬럼을 넣고, 없으면 뺀다.
-const DELETE_STATUS_FIELD = { name: 'deleteStatus', label: '삭제 상태' };
+const DELETE_STATUS_FIELD = { name: 'deleteStatus', label: 'Delete Status' };
 watch(hasActiveDeletes, active => {
   const fields = mciTableModel.tableState.fields;
   const idx = fields.findIndex((f: any) => f.name === 'deleteStatus');
@@ -216,14 +216,23 @@ onMounted(async () => {
               class="delete-status handling"
               data-testid="wl-row-delete-status"
             >
-              <span class="spinner" /> 진행 중
+              <span class="spinner" /> In progress
             </span>
+            <!--
+              사유는 두 곳에 싣는다. 꾸민 팝오버는 표의 스크롤 영역에 잘릴 수 있어서,
+              브라우저가 직접 그리는 `title` 을 함께 둔다 — 이쪽은 어떤 영역에도 갇히지 않는다.
+              사유가 없으면 어디서 볼 수 있는지를 대신 알린다.
+            -->
             <span
               v-else-if="deleteStatusOf(item.uid)?.status === 'Error'"
               class="delete-status error-cell"
               data-testid="wl-row-delete-status"
+              :title="
+                deleteStatusOf(item.uid)?.errorReason ||
+                'No reason was returned. Deleting it again shows the reason before it starts.'
+              "
             >
-              에러
+              Failed
               <span
                 v-if="deleteStatusOf(item.uid)?.errorReason"
                 class="error-popover"
@@ -278,7 +287,8 @@ onMounted(async () => {
   display: none;
   position: absolute;
   top: 100%;
-  left: 0;
+  /* 왼쪽 기준이면 긴 사유가 표 오른쪽 밖으로 나가 잘린다. 오른쪽 끝에 맞춘다. */
+  right: 0;
   z-index: 20;
   max-width: 360px;
   padding: 8px 10px;

--- a/front/src/widgets/workload/vm/vmList/ui/VmList.vue
+++ b/front/src/widgets/workload/vm/vmList/ui/VmList.vue
@@ -45,7 +45,7 @@ const resGetMci = useGetMciInfo(null);
 const selectedVm = ref<IVm | null>(null);
 const loadConfigRef = ref();
 
-// 부하테스트 진행 상태 폴링(FR-M7-WL-003-07). cm-ant 상태: on_processing→on_fetching→successed/test_failed.
+// Polls load test progress. cm-ant states: on_processing → on_fetching → successed/test_failed.
 const LOADTEST_TERMINAL_STATUS = ['successed', 'test_failed'];
 const LOADTEST_STATUS_LABEL: Record<string, string> = {
   on_processing: 'Running',
@@ -54,13 +54,14 @@ const LOADTEST_STATUS_LABEL: Record<string, string> = {
   test_failed: 'Failed',
 };
 /**
- * 지금 화면에 쓸 부하 테스트 결과.
+ * The load test result this screen should use.
  *
- * 조회 응답이 *다른 VM* 의 실행이면 `undefined` 를 준다 — 화면의 모든 표시(상태 라벨·결과 표·
- * 차트·Re-run)가 이 하나를 통해 나가므로, 여기서 한 번 걸러야 새 VM 에 삭제된 VM 의 결과가
- * 새는 곳이 없다.
+ * Returns `undefined` when the response describes *another VM's* run. Everything on screen —
+ * the status label, the result table, the chart, Re-run — goes through this one accessor, so
+ * filtering here is what stops a deleted VM's result from surfacing under a new one.
  *
- * 처음에는 스토어만 비웠는데 화면은 원 응답을 직접 읽고 있어서 **결과 표가 그대로 남았다**(BAR-1547).
+ * Clearing the store alone was not enough: the screen was reading the raw response directly,
+ * and **the result table stayed on**.
  */
 const currentLoadTestResult = computed<any | undefined>(() => {
   const result = (resLoadStatus as any).data?.value?.responseData?.result;
@@ -70,19 +71,19 @@ const currentLoadTestResult = computed<any | undefined>(() => {
     : result;
 });
 
-// Evaluate Perf 헤더(Load Config 옆)에 노출할 현재 부하테스트 상태 라벨. 폴링 시마다 갱신.
+// Status label shown in the Evaluate Perf header next to Load Config; refreshed on each poll.
 const currentLoadTestStatusLabel = computed(() => {
   const status = currentLoadTestResult.value?.executionStatus as
     | string
     | undefined;
   return status ? (LOADTEST_STATUS_LABEL[status] ?? status) : '';
 });
-// 관리(중단·Re-run)용 loadTestKey.
+// loadTestKey used for stopping and re-running.
 const currentLoadTestKey = computed(
   () => (currentLoadTestResult.value?.loadTestKey as string) ?? '',
 );
-// 경량 상태 hover(Load Config 우측 상태 라벨)용 시각·실패 메시지.
-// front 상태 타입엔 없지만 백엔드(state/last)가 finishAt·failureMessage를 내려줌.
+// Timestamp and failure message for the hover on that status label. The front-end state
+// type does not carry them, but the backend returns finishAt and failureMessage.
 const currentLoadTestStartAt = computed(
   () => (currentLoadTestResult.value?.startAt as string) ?? '',
 );
@@ -92,16 +93,16 @@ const currentLoadTestFinishAt = computed(
 const currentLoadTestFailureMessage = computed(
   () => (currentLoadTestResult.value?.failureMessage as string) ?? '',
 );
-// 세분화 단계 진행(cm-ant FR-007-08 steps[]). 구버전 cm-ant면 빈 배열.
+// Fine-grained step progress from cm-ant steps[]; empty on older cm-ant.
 const currentLoadTestSteps = computed(
   () => (currentLoadTestResult.value?.steps as any[]) ?? [],
 );
-// 진행률 바용 예상 총 소요(초).
+// Expected total duration in seconds, for the progress bar.
 const currentLoadTestExpectedSeconds = computed(
   () =>
     (currentLoadTestResult.value?.totalExpectedExecutionSecond as number) ?? 0,
 );
-// 성공 모달의 실시간 상태 표시용 — 종료(성공/실패) 여부.
+// Drives the live status in the success modal — whether it has finished, either way.
 const currentLoadTestRawStatus = computed(
   () => currentLoadTestResult.value?.executionStatus as string | undefined,
 );
@@ -111,13 +112,13 @@ const isCurrentLoadTestTerminal = computed(() => {
 });
 
 const resStopLoadTest = useStopLoadTest(null);
-// Re-run: 마지막 실행 파라미터(infos)로 Load Config를 pre-fill 하기 위한 상태.
+// Re-run: state used to pre-fill Load Config from the last run's parameters.
 const resLoadTestInfo = useGetLoadTestInfo(null);
 const rerunConfig = ref<ILoadConfigInitialValues | null>(null);
 async function handleReRun() {
   const key = currentLoadTestKey.value;
   if (!key) {
-    // 실행 이력이 없으면 그냥 빈 Load Config
+    // With no run history, open an empty Load Config
     handleLoadStatus();
     return;
   }
@@ -144,7 +145,7 @@ async function handleReRun() {
       rerunConfig.value = null;
     }
   } catch (e) {
-    // infos 조회 실패해도 빈 Load Config로 진행(차단하지 않음)
+    // Carry on with an empty Load Config if that lookup fails; do not block on it
     rerunConfig.value = null;
   }
   modalState.loadConfigRequest.open = true;
@@ -283,10 +284,10 @@ async function handleMciIdChange() {
 }
 
 /**
- * 조회된 실행 결과가 *다른 VM* 의 것인가.
+ * Whether the run that came back belongs to *another VM*.
  *
- * 판단 근거는 uid 하나뿐이다 — 이름은 재사용되므로 아무것도 말해 주지 않는다.
- * 양쪽 uid 를 모두 아는데 다를 때만 참이고, 한쪽이라도 비어 있으면 판단하지 않는다.
+ * The uid is the only thing that can answer this — names are reused and say nothing. True
+ * only when both uids are known and differ; if either is missing, decide nothing.
  */
 function isOtherVmResult(result: any, targetVmId: string): boolean {
   const resultUid = result?.nodeUid;
@@ -301,7 +302,7 @@ function isOtherVmResult(result: any, targetVmId: string): boolean {
 
 function setVmLoadTestResult() {
   if (selectedVm.value === null) return;
-  // 다른 노드로 전환/재조회 시 이전 폴링 중단
+  // stop the previous poll when switching nodes or re-querying
   stopLoadStatusPolling();
   const targetVmId = selectedVm.value.id;
 
@@ -314,20 +315,21 @@ function setVmLoadTestResult() {
       },
     })
     .then(res => {
-      // 선택 노드가 그새 바뀌었으면 무시
+      // ignore if the selected node changed in the meantime
       if (selectedVm.value?.id !== targetVmId) return;
       if (res.data.responseData) {
         const result = res.data.responseData.result;
 
-        // 이 결과가 *지금 보고 있는 VM* 것인지 확인한다 (BAR-1547).
+        // Check that this result belongs to the VM currently on screen.
         //
-        // cm-ant 는 "이 노드의 마지막 실행" 을 이름(ns/infra/node)으로 찾는데, 그 이름들은
-        // 재사용된다 — cb-tumblebug 이 노드 id 를 `{그룹명}-{순번}` 으로 만들기 때문에, VM 을
-        // 지우고 같은 이름으로 다시 만들면 **삭제된 VM 의 부하 테스트 결과가 돌아온다.**
-        // 그 결과를 새 VM 것처럼 보여주면 사용자는 돌린 적 없는 테스트를 봤다고 믿게 된다.
+        // cm-ant finds "the last run on this node" by name (ns/infra/node), and those names
+        // are reused — cb-tumblebug builds a node id as `{group}-{index}`, so deleting a VM
+        // and recreating it under the same name brings back **the deleted VM's load test
+        // result.** Shown as the new VM's, it convinces the user of a test they never ran.
         //
-        // uid 를 모르는 경우(BAR-1546 이전 기록·조회 실패)는 불일치로 보지 않는다. 모른다는 것과
-        // 다른 VM 이라는 것은 다르고, 여기서 막으면 과거 기록이 전부 사라져 보인다.
+        // A missing uid (older records, or a failed lookup) is not treated as a mismatch.
+        // Not knowing is not the same as belonging elsewhere, and blocking here would make
+        // every earlier record look as though it had vanished.
         if (isOtherVmResult(result, targetVmId)) {
           mciStore.assignLastLoadTestStateToVm(
             props.mciId,
@@ -342,11 +344,11 @@ function setVmLoadTestResult() {
 
         const status = result?.executionStatus;
         if (status && !LOADTEST_TERMINAL_STATUS.includes(status)) {
-          // 진행 중(on_processing/on_fetching) → 주기 폴링으로 상태 갱신
+          // still running → keep polling for status
           loadStatusPollTimer = setTimeout(() => setVmLoadTestResult(), 5000);
         } else if (status && LOADTEST_TERMINAL_STATUS.includes(status)) {
-          // 완료/실패 → 폴링 종료. 결과는 상태 전환(v-if/v-else)으로 결과 컴포넌트가
-          // 새로 mount되며 자동 조회되므로 별도 강제 갱신 불필요.
+          // finished or failed → stop polling. The state change remounts the result
+          // component, which fetches on its own, so nothing needs forcing here.
           stopLoadStatusPolling();
         }
       }
@@ -370,7 +372,7 @@ function handleCardClick(value: any) {
 }
 
 function handleLoadStatus() {
-  // 일반 Load Config 열기 → pre-fill 없음(Re-run만 마지막 파라미터를 채운다)
+  // opening Load Config normally → no pre-fill; only Re-run carries the last parameters
   rerunConfig.value = null;
   modalState.loadConfigRequest.open = true;
   modalState.loadConfigSuccess.open = false;
@@ -388,13 +390,13 @@ function handleLoadConfigRequestSuccess(e: string, loadTestKey?: string) {
   modalState.loadConfigSuccess.open = true;
   modalState.loadConfigRequest.context.scenarioName = e;
 
-  // 화면 밖에서도 결과를 잡도록 전역 추적에 올린다(BAR-1544).
+  // Hand it to the app-wide tracker so the outcome is caught even off this screen.
   //
-  // 추적 키는 **실행 키**다. 이름으로 추적하면 이름이 재사용될 때 다른 VM 의 실행을 알리게 되고,
-  // 같은 노드에서 두 번 돌렸을 때도 어느 쪽이 끝난 것인지 구분하지 못한다.
+  // The key is the **execution key**. Tracking by name announces another VM's run once the
+  // name is reused, and cannot tell two runs on the same node apart.
   //
-  // 이름표(label)는 여기서만 알 수 있다 — 완료 시점에는 실행 키뿐이라 "어느 VM 이었는지" 를
-  // 문장으로 만들 수 없다.
+  // The label can only be known here — at completion there is just the execution key, which
+  // cannot be turned into a sentence saying which VM this was.
   if (loadTestKey && selectedVm.value) {
     void trackLoadTest({
       loadTestKey,
@@ -402,9 +404,10 @@ function handleLoadConfigRequestSuccess(e: string, loadTestKey?: string) {
     });
   }
 
-  // 아래 폴링은 *이 화면의 실시간 표시*를 위한 것이고, 위 추적은 *화면을 떠난 뒤의 알림*을
-  // 위한 것이다. 목적이 달라 한쪽으로 합치지 않는다 — 표시를 추적 주기(10초)에 맡기면
-  // 진행이 굼떠지고, 알림을 화면에 맡기면 화면을 떠나는 순간 끊긴다.
+  // The poll below drives *live display on this screen*; the tracking above drives *the
+  // notification after leaving it*. They are kept apart because their purposes differ —
+  // handing display to the tracker's ten-second interval makes progress crawl, and handing
+  // the notification to the screen ends it the moment the screen is left.
   setVmLoadTestResult();
 }
 
@@ -450,13 +453,13 @@ function handleTemplateManagerClose() {
         </template>
       </p-toolbox>
 
-      <!-- 로딩 중일 때 스피너 표시 -->
+      <!-- spinner while loading -->
       <table-loading-spinner
         :loading="vmListTableModel.tableState.loading"
         message="Loading servers..."
       />
 
-      <!-- 로딩 완료 후 카드 표시 -->
+      <!-- cards once loading has finished -->
       <div v-if="!vmListTableModel.tableState.loading" class="vmList-content">
         <p-data-loader
           v-if="vmListTableModel.tableState.displayItems.length === 0"

--- a/front/src/widgets/workload/vm/vmList/ui/VmList.vue
+++ b/front/src/widgets/workload/vm/vmList/ui/VmList.vue
@@ -18,6 +18,7 @@ import {
 } from 'vue';
 import SuccessfullyLoadConfigModal from '@/features/workload/successfullyModal/ui/SuccessfullyLoadConfigModal.vue';
 import LoadConfig from '@/features/workload/actionLoadConfig/ui/LoadConfig.vue';
+import { trackLoadTest } from '@/entities/vm/lib/loadTestTracker';
 import { showErrorMessage, toErrorMessage } from '@/shared/utils';
 import { IVm } from '@/entities/mci/model';
 import VmInformation from '@/widgets/workload/vm/vmInformation/ui/VmInformation.vue';
@@ -377,11 +378,28 @@ function handleLoadConfigRequestClose() {
   modalState.loadConfigRequest.open = false;
 }
 
-function handleLoadConfigRequestSuccess(e: string) {
+function handleLoadConfigRequestSuccess(e: string, loadTestKey?: string) {
   modalState.loadConfigRequest.open = false;
   modalState.loadConfigSuccess.open = true;
   modalState.loadConfigRequest.context.scenarioName = e;
 
+  // 화면 밖에서도 결과를 잡도록 전역 추적에 올린다(BAR-1544).
+  //
+  // 추적 키는 **실행 키**다. 이름으로 추적하면 이름이 재사용될 때 다른 VM 의 실행을 알리게 되고,
+  // 같은 노드에서 두 번 돌렸을 때도 어느 쪽이 끝난 것인지 구분하지 못한다.
+  //
+  // 이름표(label)는 여기서만 알 수 있다 — 완료 시점에는 실행 키뿐이라 "어느 VM 이었는지" 를
+  // 문장으로 만들 수 없다.
+  if (loadTestKey && selectedVm.value) {
+    void trackLoadTest({
+      loadTestKey,
+      label: selectedVm.value.name || selectedVm.value.id,
+    });
+  }
+
+  // 아래 폴링은 *이 화면의 실시간 표시*를 위한 것이고, 위 추적은 *화면을 떠난 뒤의 알림*을
+  // 위한 것이다. 목적이 달라 한쪽으로 합치지 않는다 — 표시를 추적 주기(10초)에 맡기면
+  // 진행이 굼떠지고, 알림을 화면에 맡기면 화면을 떠나는 순간 끊긴다.
   setVmLoadTestResult();
 }
 

--- a/front/src/widgets/workload/vm/vmList/ui/VmList.vue
+++ b/front/src/widgets/workload/vm/vmList/ui/VmList.vue
@@ -18,9 +18,7 @@ import {
 } from 'vue';
 import SuccessfullyLoadConfigModal from '@/features/workload/successfullyModal/ui/SuccessfullyLoadConfigModal.vue';
 import LoadConfig from '@/features/workload/actionLoadConfig/ui/LoadConfig.vue';
-import { showErrorMessage,
-  toErrorMessage,
-} from '@/shared/utils';
+import { showErrorMessage, toErrorMessage } from '@/shared/utils';
 import { IVm } from '@/entities/mci/model';
 import VmInformation from '@/widgets/workload/vm/vmInformation/ui/VmInformation.vue';
 import VmEvaluatePerf from '@/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue';
@@ -58,7 +56,7 @@ const LOADTEST_STATUS_LABEL: Record<string, string> = {
 const currentLoadTestStatusLabel = computed(() => {
   const status = (resLoadStatus as any).data?.value?.responseData?.result
     ?.executionStatus as string | undefined;
-  return status ? LOADTEST_STATUS_LABEL[status] ?? status : '';
+  return status ? (LOADTEST_STATUS_LABEL[status] ?? status) : '';
 });
 // 관리(중단·Re-run)용 loadTestKey.
 const currentLoadTestKey = computed(
@@ -262,7 +260,10 @@ async function getMciInfo() {
       }
     })
     .catch(e => {
-      showErrorMessage('Error', toErrorMessage(e, 'Failed to load node information.'));
+      showErrorMessage(
+        'Error',
+        toErrorMessage(e, 'Failed to load node information.'),
+      );
     });
 }
 
@@ -273,6 +274,23 @@ async function handleMciIdChange() {
   vmListTableModel.tableState.selectIndex = [];
   selectedVm.value = null;
   vmListTableModel.tableState.loading = false;
+}
+
+/**
+ * 조회된 실행 결과가 *다른 VM* 의 것인가.
+ *
+ * 판단 근거는 uid 하나뿐이다 — 이름은 재사용되므로 아무것도 말해 주지 않는다.
+ * 양쪽 uid 를 모두 아는데 다를 때만 참이고, 한쪽이라도 비어 있으면 판단하지 않는다.
+ */
+function isOtherVmResult(result: any, targetVmId: string): boolean {
+  const resultUid = result?.nodeUid;
+  if (!resultUid) return false;
+
+  const vmUid =
+    selectedVm.value?.id === targetVmId ? selectedVm.value?.uid : undefined;
+  if (!vmUid) return false;
+
+  return resultUid !== vmUid;
 }
 
 function setVmLoadTestResult() {
@@ -294,6 +312,26 @@ function setVmLoadTestResult() {
       if (selectedVm.value?.id !== targetVmId) return;
       if (res.data.responseData) {
         const result = res.data.responseData.result;
+
+        // 이 결과가 *지금 보고 있는 VM* 것인지 확인한다 (BAR-1547).
+        //
+        // cm-ant 는 "이 노드의 마지막 실행" 을 이름(ns/infra/node)으로 찾는데, 그 이름들은
+        // 재사용된다 — cb-tumblebug 이 노드 id 를 `{그룹명}-{순번}` 으로 만들기 때문에, VM 을
+        // 지우고 같은 이름으로 다시 만들면 **삭제된 VM 의 부하 테스트 결과가 돌아온다.**
+        // 그 결과를 새 VM 것처럼 보여주면 사용자는 돌린 적 없는 테스트를 봤다고 믿게 된다.
+        //
+        // uid 를 모르는 경우(BAR-1546 이전 기록·조회 실패)는 불일치로 보지 않는다. 모른다는 것과
+        // 다른 VM 이라는 것은 다르고, 여기서 막으면 과거 기록이 전부 사라져 보인다.
+        if (isOtherVmResult(result, targetVmId)) {
+          mciStore.assignLastLoadTestStateToVm(
+            props.mciId,
+            targetVmId,
+            undefined,
+          );
+          stopLoadStatusPolling();
+          return;
+        }
+
         mciStore.assignLastLoadTestStateToVm(props.mciId, targetVmId, result);
 
         const status = result?.executionStatus;
@@ -308,7 +346,10 @@ function setVmLoadTestResult() {
       }
     })
     .catch(e => {
-      showErrorMessage('Error', toErrorMessage(e, 'Failed to load node information.'));
+      showErrorMessage(
+        'Error',
+        toErrorMessage(e, 'Failed to load node information.'),
+      );
     });
 }
 
@@ -340,7 +381,7 @@ function handleLoadConfigRequestSuccess(e: string) {
   modalState.loadConfigRequest.open = false;
   modalState.loadConfigSuccess.open = true;
   modalState.loadConfigRequest.context.scenarioName = e;
-  // 성공 모달이 실시간 상태를 보여주도록 새 실행 상태 폴링을 즉시 시작한다.
+
   setVmLoadTestResult();
 }
 
@@ -385,13 +426,13 @@ function handleTemplateManagerClose() {
           </p-button>
         </template>
       </p-toolbox>
-      
+
       <!-- 로딩 중일 때 스피너 표시 -->
       <table-loading-spinner
         :loading="vmListTableModel.tableState.loading"
         message="Loading servers..."
       />
-      
+
       <!-- 로딩 완료 후 카드 표시 -->
       <div v-if="!vmListTableModel.tableState.loading" class="vmList-content">
         <p-data-loader

--- a/front/src/widgets/workload/vm/vmList/ui/VmList.vue
+++ b/front/src/widgets/workload/vm/vmList/ui/VmList.vue
@@ -53,52 +53,57 @@ const LOADTEST_STATUS_LABEL: Record<string, string> = {
   successed: 'Completed',
   test_failed: 'Failed',
 };
+/**
+ * 지금 화면에 쓸 부하 테스트 결과.
+ *
+ * 조회 응답이 *다른 VM* 의 실행이면 `undefined` 를 준다 — 화면의 모든 표시(상태 라벨·결과 표·
+ * 차트·Re-run)가 이 하나를 통해 나가므로, 여기서 한 번 걸러야 새 VM 에 삭제된 VM 의 결과가
+ * 새는 곳이 없다.
+ *
+ * 처음에는 스토어만 비웠는데 화면은 원 응답을 직접 읽고 있어서 **결과 표가 그대로 남았다**(BAR-1547).
+ */
+const currentLoadTestResult = computed<any | undefined>(() => {
+  const result = (resLoadStatus as any).data?.value?.responseData?.result;
+  if (!result) return undefined;
+  return isOtherVmResult(result, selectedVm.value?.id ?? '')
+    ? undefined
+    : result;
+});
+
 // Evaluate Perf 헤더(Load Config 옆)에 노출할 현재 부하테스트 상태 라벨. 폴링 시마다 갱신.
 const currentLoadTestStatusLabel = computed(() => {
-  const status = (resLoadStatus as any).data?.value?.responseData?.result
-    ?.executionStatus as string | undefined;
+  const status = currentLoadTestResult.value?.executionStatus as
+    | string
+    | undefined;
   return status ? (LOADTEST_STATUS_LABEL[status] ?? status) : '';
 });
 // 관리(중단·Re-run)용 loadTestKey.
 const currentLoadTestKey = computed(
-  () =>
-    ((resLoadStatus as any).data?.value?.responseData?.result
-      ?.loadTestKey as string) ?? '',
+  () => (currentLoadTestResult.value?.loadTestKey as string) ?? '',
 );
 // 경량 상태 hover(Load Config 우측 상태 라벨)용 시각·실패 메시지.
 // front 상태 타입엔 없지만 백엔드(state/last)가 finishAt·failureMessage를 내려줌.
 const currentLoadTestStartAt = computed(
-  () =>
-    ((resLoadStatus as any).data?.value?.responseData?.result
-      ?.startAt as string) ?? '',
+  () => (currentLoadTestResult.value?.startAt as string) ?? '',
 );
 const currentLoadTestFinishAt = computed(
-  () =>
-    ((resLoadStatus as any).data?.value?.responseData?.result
-      ?.finishAt as string) ?? '',
+  () => (currentLoadTestResult.value?.finishAt as string) ?? '',
 );
 const currentLoadTestFailureMessage = computed(
-  () =>
-    ((resLoadStatus as any).data?.value?.responseData?.result
-      ?.failureMessage as string) ?? '',
+  () => (currentLoadTestResult.value?.failureMessage as string) ?? '',
 );
 // 세분화 단계 진행(cm-ant FR-007-08 steps[]). 구버전 cm-ant면 빈 배열.
 const currentLoadTestSteps = computed(
-  () =>
-    ((resLoadStatus as any).data?.value?.responseData?.result
-      ?.steps as any[]) ?? [],
+  () => (currentLoadTestResult.value?.steps as any[]) ?? [],
 );
 // 진행률 바용 예상 총 소요(초).
 const currentLoadTestExpectedSeconds = computed(
   () =>
-    ((resLoadStatus as any).data?.value?.responseData?.result
-      ?.totalExpectedExecutionSecond as number) ?? 0,
+    (currentLoadTestResult.value?.totalExpectedExecutionSecond as number) ?? 0,
 );
 // 성공 모달의 실시간 상태 표시용 — 종료(성공/실패) 여부.
 const currentLoadTestRawStatus = computed(
-  () =>
-    (resLoadStatus as any).data?.value?.responseData?.result
-      ?.executionStatus as string | undefined,
+  () => currentLoadTestResult.value?.executionStatus as string | undefined,
 );
 const isCurrentLoadTestTerminal = computed(() => {
   const s = currentLoadTestRawStatus.value;


### PR DESCRIPTION
## 왜 하나

알림 배지는 완료로 닫혀 있었는데 **삭제가 끝나도 알림이 뜨지 않았습니다.**

알림을 만드는 함수 세 개가 **정의 없이 호출만 남은 채** 머지돼 있었습니다. 작성된 지 24초 뒤 같은 파일의 뒷부분을 다시 쓰는 편집이 그보다 위를 자르며 함께 지웠고, 그대로 커밋됐습니다. 호출부가 `try` 안이라 예외는 조용히 삼켜졌고, 화면에는 아무 일도 없는 것처럼 보였습니다.

세 겹이 모두 비켜갔습니다 — `git add -A` 는 바뀐 것을 보지 않았고, `vite build` 는 타입을 검사하지 않으며, 타입 검사는 **검사 대상 0개로 판단하고 성공**했습니다(`"files": []` 솔루션 파일이라 `-b` 가 필요합니다).

## 무엇을 고쳤나

**알림이 실제로 전달되게 했습니다.**

- 유실된 `notifyDone`·`notifyFailed`·`notifyUnknown` 복원
- **성공도 알립니다.** 성공하면 그 자리에서 기록을 지워, `Handling` 만 확인하는 추적기가 볼 기회가 없었습니다. 성공 알림은 *진행 중 새로고침한 경우*에만 떴습니다
- **요청 실패를 삭제 실패로 단정하지 않습니다.** 삭제는 몇 분 걸리는데 프록시가 504 로 먼저 끊습니다. 인프라는 지워졌는데 화면이 실패라고 알리고 있었습니다. 이제 결과 미상으로 두고 추적기가 판정합니다(cm-beetle 조회 → 안 되면 인프라가 목록에 남아 있는지)
- **사유를 제대로 싣습니다.** `execute()` 가 axios 에러가 아니라 래퍼를 던지는데 호출부가 그것을 다시 해석해 `Error in setting up request`(요청이 나가지도 못했다는 뜻)로 떨어졌습니다. 이미 준비된 메시지를 읽습니다

**부하 테스트 완료 알림**(2단계)도 이 브랜치에 함께 있습니다. 추적 키를 이름 3종이 아니라 실행 키로 잡아, VM 을 지우고 같은 이름으로 다시 만들어도 다른 실행을 알리지 않습니다.

**화면 결함 둘**

- 패널이 두 개로 엇갈려 보이던 것 — 껍데기와 패널이 둘 다 외형을 갖고 너비가 40px 달랐습니다
- 종 아이콘 툴팁이 클릭 후에도 남아 `Mark all read` 를 덮던 것

**삭제 화면 문구를 영문으로.** 한국어가 하드코딩돼 있어 언어 설정과 무관하게 늘 그렇게 나왔습니다. 이 작업이 새로 더한 주석도 영문으로 옮겼습니다.

## 검증 (개발 서버 실화면)

| 확인 | 결과 |
|---|---|
| 삭제 성공 알림 | `Infra "notify-final" has been deleted.` |
| 삭제 실패 알림 | `Failed to delete infra …` + 사유 + 재시도 안내 |
| 부하 완료 알림 | `Load test on "vm-…" completed.` |
| 패널 겹침 | 패널 1개, 오른쪽 끝 차이 0px |
| 툴팁 가림 | 해소 |
| 삭제 화면 한글 | 0 |

**위 결함 넷 중 셋은 화면을 열어 보고서야 드러났습니다.** 코드만 읽었다면 성공 알림이 없다는 것도, 성공을 실패로 알린다는 것도 찾지 못했을 것입니다.

검증이 만든 인프라만 삭제했고, 삭제 전 대상이 하나뿐인지 확인하는 가드를 두었습니다.

---

- [BAR-1536](https://mzdevs.atlassian.net/browse/BAR-1536) 장시간 작업 결과 알림 배지 — 1단계 재작업
- [BAR-1544](https://mzdevs.atlassian.net/browse/BAR-1544) 부하 테스트 완료 알림 (알림 배지 2단계)

테스트 결과서: `notion/cm-bf-ep-마이그레이션이행및결과추적개선/008_실행결과알림통지기능/ST3_단위테스트/TR-BAR-1536-1544-notification-delivery.md`