### PR TITLE
fix(front): replace hardcoded Korean UI strings with English

### DIFF
--- a/front/src/entities/workflow/lib/designerSerialize.ts
+++ b/front/src/entities/workflow/lib/designerSerialize.ts
@@ -136,7 +136,7 @@ export function validateDesignerSequence(
       if (step.componentType === 'task') {
         const name = String(step.name ?? '').trim();
         if (!name) {
-          problems.push('이름이 비어 있는 task 가 있습니다.');
+          problems.push('There is a task with an empty name.');
           return;
         }
         nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
@@ -144,7 +144,7 @@ export function validateDesignerSequence(
       }
 
       if (!countTasks(step)) {
-        problems.push(`${step.name}: 상자가 비어 있어 저장되지 않습니다.`);
+        problems.push(`${step.name}: the box is empty and will not be saved.`);
       }
       visit(step.sequence);
     });
@@ -156,12 +156,12 @@ export function validateDesignerSequence(
     .filter(([, count]) => count > 1)
     .forEach(([name]) =>
       problems.push(
-        `이름이 겹칩니다: ${name} — 워크플로우 안에서 이름은 하나여야 합니다.`,
+        `Duplicate name: ${name} — names must be unique within a workflow.`,
       ),
     );
 
   if (!nameCounts.size) {
-    problems.push('실행할 task 가 없습니다.');
+    problems.push('There is no task to run.');
   }
 
   return problems;
@@ -185,7 +185,7 @@ export function reviewDesignerSequence(sequence: DesignerStepLike[]): string[] {
         );
         if (branches.length === 1) {
           notices.push(
-            `${step.name}: 갈래가 하나뿐입니다 — 이대로 저장하면 그냥 한 줄로 이어집니다. 갈래를 하나 더 넣거나 상자를 지우세요.`,
+            `${step.name}: only one branch — saving as is just links it into a single line. Add another branch or remove the box.`,
           );
         }
       }

--- a/front/src/entities/workflow/lib/designerTopology.ts
+++ b/front/src/entities/workflow/lib/designerTopology.ts
@@ -63,7 +63,7 @@ export function analyzeTopology(
   const groupOf = new Map<string, string>();
   flat.forEach(({ task, groupName }) => {
     if (byName.has(task.name)) {
-      warnings.push(`이름이 겹치는 task 가 있습니다: ${task.name}`);
+      warnings.push(`There are tasks with duplicate names: ${task.name}`);
     }
     byName.set(task.name, task);
     groupOf.set(task.name, groupName);
@@ -76,7 +76,7 @@ export function analyzeTopology(
       const name = String(dep);
       if (!byName.has(name)) {
         warnings.push(
-          `${task.name} 이(가) 존재하지 않는 task 에 의존합니다: ${name}`,
+          `${task.name} depends on a task that does not exist: ${name}`,
         );
         return;
       }
@@ -266,7 +266,7 @@ export function analyzeTopology(
 
   if (!representable) {
     warnings.push(
-      '이 워크플로우의 실행 순서는 화면이 그대로 그릴 수 있는 모양이 아닙니다 — 그림과 실제 실행이 달라지므로 열지 않습니다.',
+      'This workflow execution order cannot be drawn on screen as-is — the diagram would differ from the actual execution, so it will not be opened.',
     );
   }
 

--- a/front/src/features/sequential/designer/editor/demo/TaskComponentEditorDemo.vue
+++ b/front/src/features/sequential/designer/editor/demo/TaskComponentEditorDemo.vue
@@ -2,12 +2,12 @@
   <div class="task-component-editor-demo">
     <div class="demo-header">
       <h1>Task Component Editor Demo</h1>
-      <p>vue-json-ui-editor를 사용한 Task Component 설정 에디터</p>
+      <p>Task Component configuration editor using vue-json-ui-editor</p>
     </div>
 
     <div class="demo-content">
       <div class="demo-section">
-        <h2>Step 정보</h2>
+        <h2>Step Info</h2>
         <div class="step-info">
           <p><strong>Step Name:</strong> {{ step.name }}</p>
           <p><strong>Step Type:</strong> {{ step.type }}</p>
@@ -26,7 +26,7 @@
       </div>
 
       <div class="demo-section">
-        <h2>저장된 데이터</h2>
+        <h2>Saved Data</h2>
         <div class="saved-data">
           <h3>Component Name:</h3>
           <p>{{ savedComponentName }}</p>

--- a/front/src/features/sequential/designer/editor/model/commonTaskEditorModel.ts
+++ b/front/src/features/sequential/designer/editor/model/commonTaskEditorModel.ts
@@ -1030,7 +1030,7 @@ export function useCommonTaskEditorModel() {
           
           // 빈 객체임을 표시하기 위한 특별한 플래그 추가
           (emptyObjectContext as any).isEmptyObject = true;
-          (emptyObjectContext as any).emptyMessage = 'property 정의되지 않음';
+          (emptyObjectContext as any).emptyMessage = 'property not defined';
           
           contexts.push(emptyObjectContext);
           console.log(`✅ Empty nested object field ${key} created (depth: ${depth})`);

--- a/front/src/features/sequential/designer/editor/model/editorProviders.ts
+++ b/front/src/features/sequential/designer/editor/model/editorProviders.ts
@@ -94,7 +94,7 @@ export function editorProviders() {
               <label>Name:</label>
               <input type="text" id="if-name" value="${step.name}" style="width: 100%; padding: 8px; margin-top: 4px;" />
             </div>
-            <p style="margin-top: 16px; color: #666;">조건에 따라 true 또는 false 브랜치로 분기합니다.</p>
+            <p style="margin-top: 16px; color: #666;">Branches to the true or false branch depending on the condition.</p>
           </div>
         `;
 

--- a/front/src/features/sequential/designer/editor/ui/BashTaskEditor.vue
+++ b/front/src/features/sequential/designer/editor/ui/BashTaskEditor.vue
@@ -24,7 +24,7 @@
         placeholder="e.g. echo 'hello world'"
         @input="onCommand"
       ></textarea>
-      <p class="hint">BashOperator로 실행될 셸 명령입니다.</p>
+      <p class="hint">Shell command to be run by BashOperator.</p>
     </div>
   </div>
 </template>

--- a/front/src/features/sequential/designer/editor/ui/CommonTaskEditor.vue
+++ b/front/src/features/sequential/designer/editor/ui/CommonTaskEditor.vue
@@ -341,7 +341,7 @@ export default defineComponent({
     function getFieldDescription(description?: string, example?: string): string {
       let desc = description || '';
       if (example) {
-        desc += desc ? ` (예: ${example})` : `예: ${example}`;
+        desc += desc ? ` (e.g. ${example})` : `e.g. ${example}`;
       }
       return desc;
     }

--- a/front/src/features/sequential/designer/editor/ui/ContainerNameEditor.vue
+++ b/front/src/features/sequential/designer/editor/ui/ContainerNameEditor.vue
@@ -58,7 +58,7 @@
             @input="handleDescriptionChange"
             class="param-input"
             style="min-height: 80px; resize: vertical"
-            placeholder="설명을 입력하세요..."
+            placeholder="Enter a description..."
           />
         </div>
       </div>
@@ -123,8 +123,8 @@ export default defineComponent({
 
     const infoDescription = computed(() =>
       isLaunchPad.value
-        ? '이 Parallel 내의 task들은 동시에 병렬 실행됩니다.'
-        : '이 TaskGroup 내의 task들은 순차적으로 실행됩니다.',
+        ? 'Tasks in this Parallel run concurrently in parallel.'
+        : 'Tasks in this TaskGroup run sequentially.',
     );
 
     const infoBoxStyle = computed(() => ({

--- a/front/src/features/sequential/designer/editor/ui/HttpXcomTaskEditor.vue
+++ b/front/src/features/sequential/designer/editor/ui/HttpXcomTaskEditor.vue
@@ -16,7 +16,7 @@
     <div v-if="endpoint" class="field">
       <label class="field-label">Endpoint</label>
       <input class="text-input readonly" type="text" :value="`${method} ${endpoint}`" readonly />
-      <p class="hint">Task component에 고정된 API 요청입니다.</p>
+      <p class="hint">This is an API request fixed on the task component.</p>
     </div>
 
     <div class="field">
@@ -25,10 +25,10 @@
         class="text-input"
         type="text"
         :value="model.request_body"
-        placeholder="응답을 body로 사용할 이전 task 이름"
+        placeholder="Name of a previous task whose response is used as the body"
         @input="onSource"
       />
-      <p class="hint">지정한 task의 XCom 결과가 이 요청의 body로 전달됩니다.</p>
+      <p class="hint">The XCom result of the specified task is passed as the body of this request.</p>
     </div>
 
     <div class="field">
@@ -37,10 +37,10 @@
         class="text-input"
         type="text"
         :value="model.response_path"
-        placeholder="예: $.targetInfra (선택)"
+        placeholder="e.g. $.targetInfra (optional)"
         @input="onResponsePath"
       />
-      <p class="hint">이전 task 응답에서 추출할 JSONPath (선택).</p>
+      <p class="hint">JSONPath to extract from the previous task response (optional).</p>
     </div>
   </div>
 </template>

--- a/front/src/features/sequential/designer/editor/ui/SshTaskEditor.vue
+++ b/front/src/features/sequential/designer/editor/ui/SshTaskEditor.vue
@@ -16,7 +16,7 @@
     <div v-if="sshConnId" class="field">
       <label class="field-label">SSH Connection</label>
       <input class="text-input readonly" type="text" :value="sshConnId" readonly />
-      <p class="hint">Task component에 고정된 SSH 연결입니다.</p>
+      <p class="hint">This is an SSH connection fixed on the task component.</p>
     </div>
 
     <div class="field">
@@ -28,7 +28,7 @@
         placeholder="e.g. df -h"
         @input="onCommand"
       ></textarea>
-      <p class="hint">원격 호스트에서 SSHOperator로 실행됩니다.</p>
+      <p class="hint">Runs on the remote host via SSHOperator.</p>
     </div>
   </div>
 </template>

--- a/front/src/features/sequential/designer/editor/ui/TriggerWorkflowTaskEditor.vue
+++ b/front/src/features/sequential/designer/editor/ui/TriggerWorkflowTaskEditor.vue
@@ -16,7 +16,7 @@
     <div v-if="triggerDagId" class="field">
       <label class="field-label">Trigger Workflow (DAG)</label>
       <input class="text-input readonly" type="text" :value="triggerDagId" readonly />
-      <p class="hint">Task component에 고정된 트리거 대상 워크플로우입니다.</p>
+      <p class="hint">This is the trigger target workflow fixed on the task component.</p>
     </div>
 
     <div class="field">
@@ -29,7 +29,7 @@
         @input="onConf"
       ></textarea>
       <p v-if="error" class="error">{{ error }}</p>
-      <p v-else class="hint">트리거되는 워크플로우로 전달할 conf 객체 (선택).</p>
+      <p v-else class="hint">conf object to pass to the triggered workflow (optional).</p>
     </div>
   </div>
 </template>

--- a/front/src/features/sequential/designer/editor/utils/dataMapper.ts
+++ b/front/src/features/sequential/designer/editor/utils/dataMapper.ts
@@ -183,22 +183,22 @@ export class DataMapper {
     if (schema.required && Array.isArray(schema.required)) {
       schema.required.forEach((field: string) => {
         if (data === undefined || data === null || data[field] === undefined) {
-          errors.push(`필수 필드 '${field}'가 누락되었습니다.`);
+          errors.push(`Required field '${field}' is missing.`);
         }
       });
     }
 
     // 타입 검증
     if (schema.type === 'string' && typeof data !== 'string') {
-      errors.push(`문자열 타입이어야 합니다.`);
+      errors.push(`Must be a string type.`);
     } else if (schema.type === 'integer' && typeof data !== 'number') {
-      errors.push(`정수 타입이어야 합니다.`);
+      errors.push(`Must be an integer type.`);
     } else if (schema.type === 'boolean' && typeof data !== 'boolean') {
-      errors.push(`불린 타입이어야 합니다.`);
+      errors.push(`Must be a boolean type.`);
     } else if (schema.type === 'object' && typeof data !== 'object') {
-      errors.push(`객체 타입이어야 합니다.`);
+      errors.push(`Must be an object type.`);
     } else if (schema.type === 'array' && !Array.isArray(data)) {
-      errors.push(`배열 타입이어야 합니다.`);
+      errors.push(`Must be an array type.`);
     }
 
     return {

--- a/front/src/features/sequential/designer/editor/utils/schemaAnalyzer.ts
+++ b/front/src/features/sequential/designer/editor/utils/schemaAnalyzer.ts
@@ -173,11 +173,11 @@ export class SchemaAnalyzer {
    */
   static getComplexityDescription(complexity: string): string {
     const descriptions: Record<string, string> = {
-      'basic': '기본 타입 - 단순한 값',
-      'composite': '복합 타입 - 기본 타입들의 조합',
-      'complex': '복잡한 타입 - 중첩된 구조 포함'
+      'basic': 'Basic type - a simple value',
+      'composite': 'Composite type - a combination of basic types',
+      'complex': 'Complex type - includes nested structure'
     };
     
-    return descriptions[complexity] || '알 수 없는 타입';
+    return descriptions[complexity] || 'Unknown type';
   }
 }

--- a/front/src/pages/auth/cookie/CookiePage.vue
+++ b/front/src/pages/auth/cookie/CookiePage.vue
@@ -15,7 +15,7 @@ async function setServerCookie() {
 
 async function setClientCookie() {
   document.cookie =
-    'clientCookie=클라이언트에 대한 정보; path=/; max-age=3600; SameSite=None; Secure;';
+    'clientCookie=client information; path=/; max-age=3600; SameSite=None; Secure;';
   alert('Client cookie is set');
 }
 

--- a/front/src/pages/cloudResources/cloudCredentials/ui/cloudCredentialsPage.vue
+++ b/front/src/pages/cloudResources/cloudCredentials/ui/cloudCredentialsPage.vue
@@ -90,7 +90,7 @@ function handleClickCredentialName(credential: { id: string }) {
 // 모달 관련 핸들러 (필요 시 구현)
 // 모달에서 트리거된 이벤트 처리
 function handleAddCredentialTrigger() {
-  showSuccessMessage('Success', 'Credential이 성공적으로 추가되었습니다.');
+  showSuccessMessage('Success', 'Credential added successfully.');
   modalStates.addCredentialGroup.trigger = true;
 }
 </script>

--- a/front/src/shared/ui/EnhancedJsonEditor/EnhancedJsonEditor.vue
+++ b/front/src/shared/ui/EnhancedJsonEditor/EnhancedJsonEditor.vue
@@ -146,11 +146,11 @@ function handleExport() {
   try {
     json = getCurrentJson();
   } catch (err) {
-    setError(`내보내기 실패: JSON 형식이 올바르지 않습니다 (${(err as Error).message})`);
+    setError(`Export failed: invalid JSON format (${(err as Error).message})`);
     return;
   }
   if (json === null) {
-    setError('내보내기 실패: 내보낼 JSON 내용이 없습니다');
+    setError('Export failed: no JSON content to export');
     return;
   }
 
@@ -180,7 +180,7 @@ function applyImportedText(text: string, sourceName: string) {
   try {
     json = JSON.parse(text);
   } catch (err) {
-    setError(`가져오기 실패: JSON 파싱 오류 (${(err as Error).message})`);
+    setError(`Import failed: JSON parse error (${(err as Error).message})`);
     return;
   }
 
@@ -201,7 +201,7 @@ function handleFileSelected(event: Event) {
 
   if (file.size > props.maxImportSize) {
     const limitMb = Math.round(props.maxImportSize / (1024 * 1024));
-    setError(`가져오기 실패: 파일이 너무 큽니다 (최대 ${limitMb}MB)`);
+    setError(`Import failed: file is too large (max ${limitMb}MB)`);
     input.value = '';
     return;
   }
@@ -212,7 +212,7 @@ function handleFileSelected(event: Event) {
     input.value = ''; // 같은 파일을 다시 선택할 수 있도록 비운다
   };
   reader.onerror = () => {
-    setError('가져오기 실패: 파일을 읽을 수 없습니다');
+    setError('Import failed: cannot read file');
     input.value = '';
   };
   reader.readAsText(file);
@@ -435,7 +435,7 @@ defineExpose({
         v-if="showImport"
         type="button"
         class="file-btn"
-        title="JSON 파일 가져오기"
+        title="Import JSON file"
         @click="triggerImport"
       >
         ↑ Import
@@ -444,7 +444,7 @@ defineExpose({
         v-if="showExport"
         type="button"
         class="file-btn"
-        title="JSON 파일로 내보내기"
+        title="Export to JSON file"
         @click="handleExport"
       >
         ↓ Export

--- a/front/src/shared/ui/Input/Accordian/ServerAccordion.vue
+++ b/front/src/shared/ui/Input/Accordian/ServerAccordion.vue
@@ -1773,7 +1773,7 @@ export default {
                   </div>
                   <div class="field-content-box">
                     <div @click="logMigrationList(field)" style="cursor: pointer; margin-bottom: 8px;">
-                      {{ getMigrationListContent(field) }} (클릭하여 로그 출력)
+                      {{ getMigrationListContent(field) }} (click to view log)
                     </div>
                   </div>
                 </div>

--- a/front/src/shared/ui/Input/NestedObject/NestedObject.vue
+++ b/front/src/shared/ui/Input/NestedObject/NestedObject.vue
@@ -53,7 +53,7 @@ const getRawDataValue = () => {
       <!-- Property 정의되지 않음 메시지 -->
       <div class="no-properties-message">
         <div class="message-icon">⚠️</div>
-        <div class="message-text">Property 정의되지 않음</div>
+        <div class="message-text">Property not defined</div>
       </div>
       
       <!-- 기본 입력 필드 -->

--- a/front/src/shared/ui/JsonDataViewer/JsonDataViewer.vue
+++ b/front/src/shared/ui/JsonDataViewer/JsonDataViewer.vue
@@ -44,13 +44,13 @@
               @click="copyToClipboard"
               :disabled="!rawJsonString"
             >
-              📋 복사
+              📋 Copy
             </button>
             <button
               class="format-button"
               @click="toggleFormat"
             >
-              {{ isFormatted ? '압축' : '포맷' }}
+              {{ isFormatted ? 'Minify' : 'Format' }}
             </button>
           </div>
           <pre class="raw-json-content">{{ rawJsonString }}</pre>
@@ -62,24 +62,24 @@
     <div v-if="selectedNode" class="node-info-modal" @click="closeNodeInfo">
       <div class="modal-content" @click.stop>
         <div class="modal-header">
-          <h3>노드 정보</h3>
+          <h3>Node Info</h3>
           <button class="close-button" @click="closeNodeInfo">×</button>
         </div>
         <div class="modal-body">
           <div class="info-item">
-            <label>경로:</label>
+            <label>Path:</label>
             <span>{{ selectedNode.path }}</span>
           </div>
           <div class="info-item">
-            <label>타입:</label>
+            <label>Type:</label>
             <span>{{ selectedNode.type }}</span>
           </div>
           <div class="info-item">
-            <label>라벨:</label>
+            <label>Label:</label>
             <span>{{ selectedNode.label }}</span>
           </div>
           <div v-if="selectedNode.value !== undefined" class="info-item">
-            <label>값:</label>
+            <label>Value:</label>
             <pre class="value-content">{{ formatNodeValue(selectedNode.value) }}</pre>
           </div>
         </div>
@@ -130,8 +130,8 @@ export default defineComponent({
     // 사용 가능한 탭들
     const tabs = computed(() => {
       const allTabs = [
-        { key: 'table', label: '표', icon: '📊' },
-        { key: 'tree', label: '트리', icon: '🌳' },
+        { key: 'table', label: 'Table', icon: '📊' },
+        { key: 'tree', label: 'Tree', icon: '🌳' },
         { key: 'raw', label: 'JSON', icon: '📄' }
       ];
       
@@ -146,7 +146,7 @@ export default defineComponent({
           ? JSON.stringify(data, null, 2)
           : JSON.stringify(data);
       } catch (error) {
-        return 'JSON 파싱 오류: ' + (error as Error).message;
+        return 'JSON parse error: ' + (error as Error).message;
       }
     });
 

--- a/front/src/shared/ui/JsonDataViewer/JsonDataViewerExample.vue
+++ b/front/src/shared/ui/JsonDataViewer/JsonDataViewerExample.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="json-data-viewer-example">
-    <h2 class="text-2xl font-bold mb-6">JSON 데이터 뷰어 예시</h2>
+    <h2 class="text-2xl font-bold mb-6">JSON Data Viewer Example</h2>
     
     <div class="mb-6">
-      <h3 class="text-lg font-semibold mb-3">통합 뷰어 (표 + 트리 + JSON)</h3>
+      <h3 class="text-lg font-semibold mb-3">Combined Viewer (Table + Tree + JSON)</h3>
       <JsonDataViewer
         :json-data="migrationData"
         :use-migration-format="true"
-        :table-titles="['서버 정보', '바이너리', '컨테이너', 'Kubernetes', '패키지', '소프트웨어 모델']"
+        :table-titles="['Server Info', 'Binary', 'Container', 'Kubernetes', 'Package', 'Software Model']"
         :available-views="['table', 'tree', 'raw']"
       />
     </div>
 
     <div class="mb-6">
-      <h3 class="text-lg font-semibold mb-3">트리 뷰만</h3>
+      <h3 class="text-lg font-semibold mb-3">Tree View Only</h3>
       <JsonDataTree
         :json-data="generalData"
         :show-search="true"
@@ -24,7 +24,7 @@
     </div>
 
     <div class="mb-6">
-      <h3 class="text-lg font-semibold mb-3">표 뷰만</h3>
+      <h3 class="text-lg font-semibold mb-3">Table View Only</h3>
       <JsonDataTable
         :json-data="generalData"
         :use-migration-format="false"
@@ -33,12 +33,12 @@
 
     <!-- 노드 클릭 정보 -->
     <div v-if="clickedNode" class="node-info">
-      <h4 class="text-md font-semibold mb-2">클릭된 노드 정보:</h4>
+      <h4 class="text-md font-semibold mb-2">Clicked Node Info:</h4>
       <div class="p-4" style="background-color: #f3f4f6; border-radius: 4px;">
-        <p><strong>경로:</strong> {{ clickedNode.path }}</p>
-        <p><strong>타입:</strong> {{ clickedNode.type }}</p>
-        <p><strong>라벨:</strong> {{ clickedNode.label }}</p>
-        <p v-if="clickedNode.value !== undefined"><strong>값:</strong> {{ clickedNode.value }}</p>
+        <p><strong>Path:</strong> {{ clickedNode.path }}</p>
+        <p><strong>Type:</strong> {{ clickedNode.type }}</p>
+        <p><strong>Label:</strong> {{ clickedNode.label }}</p>
+        <p v-if="clickedNode.value !== undefined"><strong>Value:</strong> {{ clickedNode.value }}</p>
       </div>
     </div>
   </div>

--- a/front/src/shared/ui/Table/JsonDataTable.vue
+++ b/front/src/shared/ui/Table/JsonDataTable.vue
@@ -69,15 +69,15 @@ export default defineComponent({
       }
       
       const defaultTitles = [
-        '서버 정보',
-        '바이너리 정보',
-        '컨테이너 정보',
-        'Kubernetes 정보',
-        '패키지 정보',
-        '소프트웨어 모델 정보'
+        'Server Info',
+        'Binary Info',
+        'Container Info',
+        'Kubernetes Info',
+        'Package Info',
+        'Software Model Info'
       ];
       
-      return defaultTitles[index] || `표 ${index + 1}`;
+      return defaultTitles[index] || `Table ${index + 1}`;
     },
     formatCellValue(value: any): string {
       if (value === null || value === undefined) {

--- a/front/src/shared/ui/Table/JsonDataTableExample.vue
+++ b/front/src/shared/ui/Table/JsonDataTableExample.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="json-data-table-example">
-    <h2 class="text-2xl font-bold mb-6">JSON 데이터 표 변환 예시</h2>
+    <h2 class="text-2xl font-bold mb-6">JSON Data Table Conversion Example</h2>
     
     <div class="mb-6">
-      <h3 class="text-lg font-semibold mb-3">마이그레이션 데이터 표시</h3>
+      <h3 class="text-lg font-semibold mb-3">Migration Data Display</h3>
       <JsonDataTable 
         :json-data="migrationData" 
         :use-migration-format="true"
-        :table-titles="['서버 정보', '바이너리', '컨테이너', 'Kubernetes', '패키지', '소프트웨어 모델']"
+        :table-titles="['Server Info', 'Binary', 'Container', 'Kubernetes', 'Package', 'Software Model']"
       />
     </div>
 
     <div class="mb-6">
-      <h3 class="text-lg font-semibold mb-3">일반 JSON 데이터 표시</h3>
+      <h3 class="text-lg font-semibold mb-3">General JSON Data Display</h3>
       <JsonDataTable 
         :json-data="generalData" 
         :use-migration-format="false"

--- a/front/src/shared/ui/Tree/JsonDataTree.vue
+++ b/front/src/shared/ui/Tree/JsonDataTree.vue
@@ -5,7 +5,7 @@
       <input
         v-model="searchTerm"
         type="text"
-        placeholder="검색..."
+        placeholder="Search..."
         class="search-input"
         @input="handleSearch"
       />

--- a/front/src/shared/utils/jsonToTable/index.ts
+++ b/front/src/shared/utils/jsonToTable/index.ts
@@ -101,7 +101,7 @@ function createTableFromArray(
 
     return {
       columns: [
-        { key: '_index', label: '순번', width: '80px' },
+        { key: '_index', label: 'No.', width: '80px' },
         ...columns
       ],
       rows
@@ -110,8 +110,8 @@ function createTableFromArray(
     // 기본값 배열인 경우
     return {
       columns: [
-        { key: 'index', label: '순번', width: '80px' },
-        { key: 'value', label: '값', width: '200px' }
+        { key: 'index', label: 'No.', width: '80px' },
+        { key: 'value', label: 'Value', width: '200px' }
       ],
       rows: limitedArray.map((item, index) => ({
         index: index + 1,
@@ -148,8 +148,8 @@ function createTableFromObject(
 function createSimpleTable(key: string, value: any): TableData {
   return {
     columns: [
-      { key: 'key', label: '키', width: '200px' },
-      { key: 'value', label: '값', width: '300px' }
+      { key: 'key', label: 'Key', width: '200px' },
+      { key: 'value', label: 'Value', width: '300px' }
     ],
     rows: [{
       key,
@@ -220,7 +220,7 @@ function flattenObject(obj: any, maxDepth: number, currentDepth: number = 0): Re
     const value = obj[key];
     
     if (Array.isArray(value)) {
-      flattened[key] = `[${value.length}개 항목]`;
+      flattened[key] = `[${value.length} items]`;
     } else if (typeof value === 'object' && value !== null) {
       if (currentDepth < maxDepth - 1) {
         const nested = flattenObject(value, maxDepth, currentDepth + 1);
@@ -255,13 +255,13 @@ export function createMigrationDataTables(jsonData: any): TableData[] {
         // 서버 기본 정보 표
         tables.push({
           columns: [
-            { key: 'field', label: '필드', width: '200px' },
-            { key: 'value', label: '값', width: '300px' }
+            { key: 'field', label: 'Field', width: '200px' },
+            { key: 'value', label: 'Value', width: '300px' }
           ],
           rows: [
-            { field: '서버 인덱스', value: serverIndex + 1 },
-            { field: '에러', value: server.errors?.join(', ') || '없음' },
-            { field: '소스 연결 ID', value: data.source_connection_info_id || 'N/A' }
+            { field: 'Server Index', value: serverIndex + 1 },
+            { field: 'Error', value: server.errors?.join(', ') || 'None' },
+            { field: 'Source Connection ID', value: data.source_connection_info_id || 'N/A' }
           ]
         });
 
@@ -269,13 +269,13 @@ export function createMigrationDataTables(jsonData: any): TableData[] {
         if (server.migration_list?.binaries?.length > 0) {
           tables.push({
             columns: [
-              { key: 'name', label: '이름', width: '200px' },
-              { key: 'version', label: '버전', width: '100px' },
-              { key: 'binary_path', label: '바이너리 경로', width: '250px' },
-              { key: 'needed_libraries', label: '필요 라이브러리', width: '200px' },
-              { key: 'custom_configs', label: '커스텀 설정', width: '200px' },
-              { key: 'custom_data_paths', label: '커스텀 데이터 경로', width: '200px' },
-              { key: 'order', label: '순서', width: '80px' }
+              { key: 'name', label: 'Name', width: '200px' },
+              { key: 'version', label: 'Version', width: '100px' },
+              { key: 'binary_path', label: 'Binary Path', width: '250px' },
+              { key: 'needed_libraries', label: 'Required Libraries', width: '200px' },
+              { key: 'custom_configs', label: 'Custom Configs', width: '200px' },
+              { key: 'custom_data_paths', label: 'Custom Data Paths', width: '200px' },
+              { key: 'order', label: 'Order', width: '80px' }
             ],
             rows: server.migration_list.binaries.map((binary: any) => ({
               name: binary.name || 'N/A',
@@ -293,15 +293,15 @@ export function createMigrationDataTables(jsonData: any): TableData[] {
         if (server.migration_list?.containers?.length > 0) {
           tables.push({
             columns: [
-              { key: 'name', label: '컨테이너 이름', width: '200px' },
-              { key: 'container_id', label: '컨테이너 ID', width: '150px' },
-              { key: 'image_name', label: '이미지 이름', width: '150px' },
-              { key: 'image_version', label: '이미지 버전', width: '100px' },
-              { key: 'container_status', label: '상태', width: '100px' },
-              { key: 'runtime', label: '런타임', width: '100px' },
-              { key: 'network_mode', label: '네트워크 모드', width: '120px' },
-              { key: 'restart_policy', label: '재시작 정책', width: '120px' },
-              { key: 'order', label: '순서', width: '80px' }
+              { key: 'name', label: 'Container Name', width: '200px' },
+              { key: 'container_id', label: 'Container ID', width: '150px' },
+              { key: 'image_name', label: 'Image Name', width: '150px' },
+              { key: 'image_version', label: 'Image Version', width: '100px' },
+              { key: 'container_status', label: 'Status', width: '100px' },
+              { key: 'runtime', label: 'Runtime', width: '100px' },
+              { key: 'network_mode', label: 'Network Mode', width: '120px' },
+              { key: 'restart_policy', label: 'Restart Policy', width: '120px' },
+              { key: 'order', label: 'Order', width: '80px' }
             ],
             rows: server.migration_list.containers.map((container: any) => ({
               name: container.name || 'N/A',
@@ -321,14 +321,14 @@ export function createMigrationDataTables(jsonData: any): TableData[] {
         if (server.migration_list?.kubernetes?.length > 0) {
           tables.push({
             columns: [
-              { key: 'version', label: 'K8s 버전', width: '100px' },
+              { key: 'version', label: 'K8s Version', width: '100px' },
               { key: 'kube_config', label: 'Kube Config', width: '200px' },
-              { key: 'replicas', label: '레플리카 수', width: '100px' },
-              { key: 'cpu_limit', label: 'CPU 제한', width: '100px' },
-              { key: 'memory_limit', label: '메모리 제한', width: '100px' },
-              { key: 'cpu_request', label: 'CPU 요청', width: '100px' },
-              { key: 'memory_request', label: '메모리 요청', width: '100px' },
-              { key: 'order', label: '순서', width: '80px' }
+              { key: 'replicas', label: 'Replicas', width: '100px' },
+              { key: 'cpu_limit', label: 'CPU Limit', width: '100px' },
+              { key: 'memory_limit', label: 'Memory Limit', width: '100px' },
+              { key: 'cpu_request', label: 'CPU Request', width: '100px' },
+              { key: 'memory_request', label: 'Memory Request', width: '100px' },
+              { key: 'order', label: 'Order', width: '80px' }
             ],
             rows: server.migration_list.kubernetes.map((k8s: any) => ({
               version: k8s.version || 'N/A',
@@ -347,15 +347,15 @@ export function createMigrationDataTables(jsonData: any): TableData[] {
         if (server.migration_list?.packages?.length > 0) {
           tables.push({
             columns: [
-              { key: 'name', label: '패키지 이름', width: '150px' },
-              { key: 'version', label: '버전', width: '100px' },
-              { key: 'needed_packages', label: '필요 패키지', width: '200px' },
-              { key: 'need_to_delete_packages', label: '삭제할 패키지', width: '200px' },
-              { key: 'repo_url', label: '저장소 URL', width: '200px' },
-              { key: 'gpg_key_url', label: 'GPG 키 URL', width: '200px' },
-              { key: 'custom_configs', label: '커스텀 설정', width: '200px' },
-              { key: 'custom_data_paths', label: '커스텀 데이터 경로', width: '200px' },
-              { key: 'order', label: '순서', width: '80px' }
+              { key: 'name', label: 'Package Name', width: '150px' },
+              { key: 'version', label: 'Version', width: '100px' },
+              { key: 'needed_packages', label: 'Required Packages', width: '200px' },
+              { key: 'need_to_delete_packages', label: 'Packages to Remove', width: '200px' },
+              { key: 'repo_url', label: 'Repository URL', width: '200px' },
+              { key: 'gpg_key_url', label: 'GPG Key URL', width: '200px' },
+              { key: 'custom_configs', label: 'Custom Configs', width: '200px' },
+              { key: 'custom_data_paths', label: 'Custom Data Paths', width: '200px' },
+              { key: 'order', label: 'Order', width: '80px' }
             ],
             rows: server.migration_list.packages.map((pkg: any) => ({
               name: pkg.name || 'N/A',
@@ -377,13 +377,13 @@ export function createMigrationDataTables(jsonData: any): TableData[] {
     if (data.softwareModel) {
       tables.push({
         columns: [
-          { key: 'field', label: '필드', width: '200px' },
-          { key: 'value', label: '값', width: '300px' }
+          { key: 'field', label: 'Field', width: '200px' },
+          { key: 'value', label: 'Value', width: '300px' }
         ],
         rows: [
           { field: 'ID', value: data.softwareModel.id || 'N/A' },
-          { field: '이름', value: data.softwareModel.name || 'N/A' },
-          { field: '설명', value: data.softwareModel.description || 'N/A' }
+          { field: 'Name', value: data.softwareModel.name || 'N/A' },
+          { field: 'Description', value: data.softwareModel.description || 'N/A' }
         ]
       });
     }
@@ -392,10 +392,10 @@ export function createMigrationDataTables(jsonData: any): TableData[] {
     console.error('JSON 파싱 오류:', error);
     tables.push({
       columns: [
-        { key: 'error', label: '오류', width: '500px' }
+        { key: 'error', label: 'Error', width: '500px' }
       ],
       rows: [
-        { error: 'JSON 데이터를 파싱할 수 없습니다.' }
+        { error: 'Cannot parse JSON data.' }
       ]
     });
   }

--- a/front/src/widgets/credentials/credentialsDetail/model/credentialsDetailModel.ts
+++ b/front/src/widgets/credentials/credentialsDetail/model/credentialsDetailModel.ts
@@ -42,7 +42,7 @@ export function useCredentialsDetailModel() {
       };
     } else {
       tableModel.tableState.data = {};
-      showErrorMessage('Error', '선택한 Credential을 찾을 수 없습니다.');
+      showErrorMessage('Error', 'The selected Credential could not be found.');
     }
     tableModel.tableState.loading = false;
   }

--- a/front/src/widgets/credentials/credentialsList/ui/CredentialsList.vue
+++ b/front/src/widgets/credentials/credentialsList/ui/CredentialsList.vue
@@ -215,7 +215,7 @@ async function handleDeleteCredentials() {
   );
 
   if (selectedCredentialIds.length === 0) {
-    showErrorMessage('Error', '삭제할 Credential을 선택하지 않았습니다.');
+    showErrorMessage('Error', 'No Credential selected to delete.');
     return;
   }
 
@@ -229,13 +229,13 @@ async function handleDeleteCredentials() {
 
         showSuccessMessage(
           'Success',
-          `Credential '${credentialName}'이(가) 성공적으로 삭제되었습니다.`,
+          `Credential '${credentialName}' deleted successfully.`,
         );
       } else {
         showErrorMessage(
           'Error',
           data.status?.message ||
-            `Credential '${credentialName}' 삭제에 실패했습니다.`,
+            `Failed to delete Credential '${credentialName}'.`,
         );
       }
     }
@@ -248,7 +248,7 @@ async function handleDeleteCredentials() {
   } catch (error: any) {
     showErrorMessage(
       'Error',
-      error.message || '삭제 요청 중 오류가 발생했습니다.',
+      error.message || 'An error occurred during the delete request.',
     );
   } finally {
     // 모달 닫기

--- a/front/src/widgets/models/recommendedInfraModel/ui/RecommendedInfraModel.vue
+++ b/front/src/widgets/models/recommendedInfraModel/ui/RecommendedInfraModel.vue
@@ -521,7 +521,7 @@ function handleSave(e: { name: string; description: string }) {
                 :data-id="item.name || ''"
                 :title="
                   item.hasMissingInfo
-                    ? `필수정보가 누락돼 있습니다. 워크플로우 구현할 때 해당 항목(${item.missingFields || 'Spec, Image'})을 채워야 합니다`
+                    ? `Required information is missing. You must fill in these fields (${item.missingFields || 'Spec, Image'}) when building the workflow.`
                     : undefined
                 "
               >

--- a/front/src/widgets/workflow/workflows/workflowHistory/ui/SoftwareMigrationOverlay.vue
+++ b/front/src/widgets/workflow/workflows/workflowHistory/ui/SoftwareMigrationOverlay.vue
@@ -93,7 +93,7 @@ const loadSwMigrationStatus = async () => {
   if (!props.executionIds || props.executionIds.length === 0) {
     swMigrationDataList.value = [];
     swError.value =
-      '이 태스크에 소프트웨어 마이그레이션 실행 ID가 없어 결과를 조회할 수 없습니다.';
+      'This task has no software migration execution ID, so results cannot be retrieved.';
     return;
   }
 
@@ -113,13 +113,13 @@ const loadSwMigrationStatus = async () => {
           // 응답이 비어 있으면 그대로 드러낸다. 예전에는 목업으로 대체해서
           // 마이그레이션이 성공한 것처럼 보였다.
           throw new Error(
-            `소프트웨어 마이그레이션 상태를 가져오지 못했습니다 (execution ${executionId})`,
+            `Failed to fetch software migration status (execution ${executionId})`,
           );
         } catch (apiError) {
           swError.value =
             apiError instanceof Error
               ? apiError.message
-              : `소프트웨어 마이그레이션 상태를 가져오지 못했습니다 (execution ${executionId})`;
+              : `Failed to fetch software migration status (execution ${executionId})`;
           return null;
         }
       }),
@@ -135,7 +135,7 @@ const loadSwMigrationStatus = async () => {
     swError.value =
       error instanceof Error
         ? error.message
-        : '소프트웨어 마이그레이션 상태를 가져오지 못했습니다';
+        : 'Failed to fetch software migration status';
   } finally {
     swLoading.value = false;
   }

--- a/front/src/widgets/workflow/workflows/workflowList/ui/WorkflowList.vue
+++ b/front/src/widgets/workflow/workflows/workflowList/ui/WorkflowList.vue
@@ -174,7 +174,7 @@ async function fetchWorkflowList() {
     });
   } catch (e) {
     workflowStore.setWorkFlows([]);
-    showErrorMessage('error', 'Workflow 목록 조회 중 오류가 발생했습니다.');
+    showErrorMessage('error', 'An error occurred while loading the workflow list.');
     isDataLoaded.value = true;
   } finally {
     tableModel.tableState.loading = false;


### PR DESCRIPTION
소스에 하드코딩된 화면 문구 한글 140줄(29개 파일)을 영문 리터럴로 바꿉니다.

표 컬럼 라벨·토스트/에러 메시지·템플릿 텍스트·placeholder·검증 메시지가 대상이고, 문자열 내용만 1:1로 치환했습니다. 조건부 렌더 구조·레이아웃·로직은 손대지 않았고, 기존 한글 주석과 개발용 console 로그는 범위 밖이라 그대로 뒀습니다.

다국어(i18n) 처리로 한국어가 선택된 것이 아니라 리터럴이라 언어 설정과 무관하게 항상 한국어로 나오던 문제입니다. 지금은 영문 단일이므로 영문 리터럴로 바꿉니다.

## 검증
- 화면 문구 잔여 한글 0 · diff 추가 한글 0 · 문자열 구분자 균형 140/140 · 신규 파싱 오류 0
- 프로덕션 빌드는 이 PR의 CI(continuous-integration.yaml)가 검증

- [BAR-1567](https://mzdevs.atlassian.net/browse/BAR-1567) 화면 문구 영문화 — 소스에 하드코딩된 한글 제거
테스트 결과서: notion/cm-bf-ep-플랫폼아키텍처리팩토링/004_화면문구영문화/ST3_단위테스트/TR-BAR-1567-화면문구영문화.md