### PR TITLE
fix(auth): stop the session-expired popup from looping on the login screen

### DIFF
--- a/front/src/shared/libs/token/index.ts
+++ b/front/src/shared/libs/token/index.ts
@@ -5,6 +5,7 @@ import { axiosPost, IAxiosResponse } from '@/shared/libs/api/index';
 import { IUserLoginResponse } from '@/entities';
 import { jwtDecode } from 'jwt-decode';
 import LocalStorageConnector from '@/shared/libs/access-localstorage/localStorageConnector';
+import { clearSession } from '@/shared/libs/auth/session';
 
 interface IJwtToken {
   access_token: string;
@@ -84,9 +85,13 @@ export default class JwtTokenProvider {
       }
       return refreshRes;
     } catch (error: any) {
-      this.removeToken();
+      // A failed refresh means the session is over. Clear it fully — not just the token —
+      // so the background polling (job tracking, notifications, activity watch) stops. If it
+      // keeps running it hits the API again, gets another 401, fails to refresh, and shows
+      // this same popup on a loop, even on the login screen where there is no session left.
+      clearSession();
 
-      alert('User Session Expired.\n Pleas login again');
+      alert('User Session Expired.\n Please login again');
       McmpRouter.getRouter()
         .replace({ name: AUTH_ROUTE.LOGIN._NAME })
         .catch(() => {});


### PR DESCRIPTION
세션이 만료되면 토큰 갱신에 실패한 뒤에도 백그라운드 폴링이 계속 돌아, 로그인 화면에서 세션 만료 팝업이 무한 반복되던 문제를 수정합니다.

## 변경
- 토큰 갱신(refreshTokens) 실패 시 세션 폴링을 `clearSession()`으로 정지해 반복을 끊는다.
- "Pleas" → "Please" 오타 수정.

## 검증
개발 서버(통합 이미지)에서 세션 만료 후 로그인 화면으로 전환 시 팝업이 더 이상 반복되지 않음을 확인.

## 관련
- [BAR-1576](https://mzdevs.atlassian.net/browse/BAR-1576) [cm-butterfly] 세션 만료 팝업이 로그인 화면에서 무한 반복

테스트 결과서: `notion/cm-bf-ep-워크로드관리기능개선/003_워크로드검증성능평가기능개선/ST3_단위테스트/TR-BAR-1576-session-expiry-loop.md`