### PR TITLE
fix(auth): handle session expiry once and stop all polling centrally

### DIFF
--- a/front/src/features/auth/model/useLogout.ts
+++ b/front/src/features/auth/model/useLogout.ts
@@ -5,6 +5,7 @@
 import { axiosPost } from '@/shared/libs/api';
 import {
   clearSession,
+  handleSessionExpired,
   msUntilExpiry,
   msSinceActivity,
   msSinceSessionStart,
@@ -40,11 +41,9 @@ export async function logout(): Promise<void> {
   window.location.replace(LOGIN_PATH);
 }
 
-/** 세션이 만료됐을 때의 처리 — 알린 뒤 로그인 화면으로 보낸다. */
+/** 세션이 만료됐을 때의 처리 — 중앙 핸들러가 한 번만 알리고 로그인 화면으로 보낸다. */
 function expireSession(): void {
-  clearSession();
-  alert('User Session Expired.\n Please login again');
-  window.location.replace(LOGIN_PATH);
+  handleSessionExpired();
 }
 
 const IDLE_LIMIT_MS = 60 * 60 * 1000; // 마지막 조작 후 이만큼 지나면 끊는다

--- a/front/src/shared/libs/api/instance.ts
+++ b/front/src/shared/libs/api/instance.ts
@@ -6,7 +6,7 @@ import axios, {
 import { McmpRouter } from '@/app/providers/router';
 import { AUTH_ROUTE } from '@/pages/auth/auth.route';
 import JwtTokenProvider from '@/shared/libs/token';
-import { clearSession } from '@/shared/libs/auth/session';
+import { clearSession, handleSessionExpired } from '@/shared/libs/auth/session';
 
 const url = import.meta.env.VITE_BACKEND_ENDPOINT;
 const createInstance = () => {
@@ -53,7 +53,9 @@ axiosInstance.interceptors.response.use(
       const { refresh_token } = jwtTokenProvider.getTokens();
 
       if (!refresh_token) {
-        // 되살릴 방법이 없는 세션이다. 흔적을 지우지 않으면 라우터 가드가 살아 있는 것으로 본다.
+        // 되살릴 토큰이 없다 — 로그인 전이거나 이미 세션이 없는 상태다. 폴링을 멈추고(clearSession)
+        // 로그인 화면으로 SPA 이동만 한다. 여기서 만료 팝업·전체 리로드를 하면 로그인 화면의 미인증
+        // 요청이 다시 401 → 리로드로 무한 반복된다. 만료 안내는 실제 만료(갱신 실패·403)에서만 한다.
         clearSession();
         McmpRouter.getRouter()
           .replace({ name: AUTH_ROUTE.LOGIN._NAME })
@@ -82,11 +84,7 @@ axiosInstance.interceptors.response.use(
         }
       }
     } else if (error.response?.status === 403) {
-      clearSession();
-      alert('User Session Expired.\n Please login again');
-      McmpRouter.getRouter()
-        .replace({ name: AUTH_ROUTE.LOGIN._NAME })
-        .catch(() => {});
+      handleSessionExpired();
     }
     return Promise.reject(error);
   },

--- a/front/src/shared/libs/auth/session.ts
+++ b/front/src/shared/libs/auth/session.ts
@@ -10,6 +10,7 @@
 import JwtTokenProvider from '@/shared/libs/token';
 import { stopTracking } from '@/shared/libs/tracking/runner';
 import { stopNotificationPolling } from '@/entities/notification/lib/notificationStore';
+import { stopAllPolling } from '@/shared/libs/polling';
 
 const LOGIN_AUTH_STORAGE = 'LOGIN_AUTH';
 const SESSION_STARTED_STORAGE = 'MCMP_SESSION_STARTED';
@@ -121,12 +122,36 @@ export function unwatchActivity(): void {
  * 브라우저에 남은 로그인 흔적을 모두 지운다.
  *
  * 화면 이동은 하지 않는다. 부르는 쪽이 이어서 처리한다.
+ *
+ * 폴링은 개별로 끄지 않고 `stopAllPolling()` 한 번으로 끈다 — 화면·기능마다 흩어진 폴링(작업 추적,
+ * 알림, 활동 감시, 부하테스트 상태)이 세션이 끊긴 뒤에도 남아 api를 때리면 다시 401 → 만료 처리로
+ * 돌아가기 때문이다. 새 폴링은 레지스트리에 등록만 하면 여기서 함께 멈춘다.
  */
 export function clearSession(): void {
   JwtTokenProvider.getProvider().removeToken();
   localStorage.removeItem(LOGIN_AUTH_STORAGE);
   localStorage.removeItem(SESSION_STARTED_STORAGE);
+  stopAllPolling();
+  // 레지스트리에 아직 등록되지 않은 앱 수준 폴러도 확실히 멈춘다(이중이어도 idempotent).
   stopTracking();
   stopNotificationPolling();
   unwatchActivity();
+}
+
+// 세션 만료를 화면 어디서 감지하든 처리는 한 번만 일어나게 한다. 만료 순간 진행 중이던 여러 요청이
+// 동시에 401을 받아 각자 갱신에 실패하는데, 가드가 없으면 저마다 blocking alert 를 띄워 사용자가
+// 만료 팝업을 여러 번 닫아야 했다. 첫 번째만 지우고·알리고·로그인 화면으로 보내고 나머지는 조용히
+// 세션만 정리한다. 전체 페이지 이동으로 다음 로그인 때 이 플래그가 자연히 초기화된다(BAR-1576).
+let sessionExpiredHandled = false;
+
+/** 세션 만료를 한 번만 처리한다 — 지우고, 한 번 알리고, 로그인 화면으로 보낸다. */
+export function handleSessionExpired(): void {
+  if (sessionExpiredHandled) {
+    clearSession();
+    return;
+  }
+  sessionExpiredHandled = true;
+  clearSession();
+  alert('User Session Expired.\n Please login again');
+  window.location.replace('/auth/login');
 }

--- a/front/src/shared/libs/polling/index.ts
+++ b/front/src/shared/libs/polling/index.ts
@@ -1,0 +1,34 @@
+// One place that knows about every background poll (BAR-1576).
+//
+// The app polls in several places — job tracking, notifications, the session-activity watch, the
+// load-test status on the workload screen. When a session ends, all of them have to stop, or a
+// leftover poll keeps hitting the API, gets a 401, and puts the user back on the "session expired"
+// path from a screen that has no session left. Stopping them one by one meant every new poll was a
+// place to forget; a registry makes "stop everything" a single call that new polls opt into.
+//
+// A poll registers a stop function and gets an unregister back to call when it ends on its own.
+
+const stoppers = new Set<() => void>();
+
+/**
+ * Register a poll's stop function. Returns an unregister to call when the poll ends normally, so a
+ * finished poll does not linger in the set.
+ */
+export function registerPoller(stop: () => void): () => void {
+  stoppers.add(stop);
+  return () => {
+    stoppers.delete(stop);
+  };
+}
+
+/** Stop every registered poll. Safe to call repeatedly; a stopper that throws does not block the rest. */
+export function stopAllPolling(): void {
+  for (const stop of [...stoppers]) {
+    try {
+      stop();
+    } catch (e) {
+      console.warn('a poller stop handler threw', e);
+    }
+  }
+  stoppers.clear();
+}

--- a/front/src/shared/libs/token/index.ts
+++ b/front/src/shared/libs/token/index.ts
@@ -1,11 +1,9 @@
 import axios from 'axios';
-import { McmpRouter } from '@/app/providers/router';
-import { AUTH_ROUTE } from '@/pages/auth/auth.route';
 import { axiosPost, IAxiosResponse } from '@/shared/libs/api/index';
 import { IUserLoginResponse } from '@/entities';
 import { jwtDecode } from 'jwt-decode';
 import LocalStorageConnector from '@/shared/libs/access-localstorage/localStorageConnector';
-import { clearSession } from '@/shared/libs/auth/session';
+import { handleSessionExpired } from '@/shared/libs/auth/session';
 
 interface IJwtToken {
   access_token: string;
@@ -85,17 +83,11 @@ export default class JwtTokenProvider {
       }
       return refreshRes;
     } catch (error: any) {
-      // A failed refresh means the session is over. Clear it fully — not just the token —
-      // so the background polling (job tracking, notifications, activity watch) stops. If it
-      // keeps running it hits the API again, gets another 401, fails to refresh, and shows
-      // this same popup on a loop, even on the login screen where there is no session left.
-      clearSession();
-
-      alert('User Session Expired.\n Please login again');
-      McmpRouter.getRouter()
-        .replace({ name: AUTH_ROUTE.LOGIN._NAME })
-        .catch(() => {});
-
+      // A failed refresh means the session is over. Hand it to the one place that clears the
+      // session (stopping all polling) and shows the expired popup exactly once — several
+      // in-flight requests fail to refresh at the same moment, and without the single handler
+      // each one popped its own blocking alert to dismiss.
+      handleSessionExpired();
       return Promise.reject(error);
     }
   }

--- a/front/src/widgets/workload/vm/vmList/ui/VmList.vue
+++ b/front/src/widgets/workload/vm/vmList/ui/VmList.vue
@@ -18,6 +18,7 @@ import {
 } from 'vue';
 import LoadConfig from '@/features/workload/actionLoadConfig/ui/LoadConfig.vue';
 import { trackLoadTest } from '@/entities/vm/lib/loadTestTracker';
+import { registerPoller } from '@/shared/libs/polling';
 import { showErrorMessage, toErrorMessage } from '@/shared/utils';
 import { IVm } from '@/entities/mci/model';
 import VmInformation from '@/widgets/workload/vm/vmInformation/ui/VmInformation.vue';
@@ -252,12 +253,17 @@ watch(
   { immediate: true },
 );
 
+// Register the load-test status poll so a session end stops it centrally (BAR-1576). Without
+// this the poll keeps hitting the API after logout and reopens the "session expired" path.
+let unregisterPoller: (() => void) | null = null;
 onMounted(() => {
   initToolBoxTableModel();
+  unregisterPoller = registerPoller(stopLoadStatusPolling);
 });
 
 onBeforeUnmount(() => {
   stopLoadStatusPolling();
+  unregisterPoller?.();
 });
 
 async function getMciInfo() {


### PR DESCRIPTION
세션 만료 팝업 반복 수정([#106](https://github.com/MZC-CSC/cm-butterfly/pull/106)) 후속입니다. 만료 순간 진행 중이던 여러 요청(알림·작업 추적·활동 감시·부하테스트 상태 폴링)이 거의 동시에 401을 받아 **각자 blocking alert를 띄워 만료 팝업이 누적**됐고(확인을 여러 번 눌러야 함), clearSession이 모르는 컴포넌트 폴링은 계속 돌아 만료 경로를 다시 열었습니다.

## 변경
- 세션 만료 처리를 `session.ts`의 `handleSessionExpired()` **한 곳으로 통일** — 모듈 플래그로 첫 호출만 정리·안내·이동, 나머지는 조용히 세션만 정리(1회 가드).
- 폴링을 **공통 레지스트리**(`shared/libs/polling`)로 관리하고 `clearSession`이 `stopAllPolling()`으로 전부 중단 — 부하테스트 상태 폴링(VmList)도 등록. 새 폴링은 등록만 하면 함께 멈춥니다.
- no-refresh-token 401은 만료 팝업·전체 리로드 대신 **SPA 이동**(로그인 화면의 미인증 401이 전체 리로드로 무한 반복되던 것 방지). 실제 만료(갱신 실패·403)만 팝업.

## 검증
개발 서버에서 무효 토큰으로 만료를 유발하고 여러 요청을 동시에 보내 확인: "User Session Expired" 팝업이 **정확히 1회**(누적 없음), 이후 로그인 화면으로 이동(리다이렉트 루프 없음).

## 관련
- [BAR-1576](https://mzdevs.atlassian.net/browse/BAR-1576) [cm-butterfly] 세션 만료 팝업이 로그인 화면에서 무한 반복

테스트 결과서: `notion/cm-bf-ep-워크로드관리기능개선/003_워크로드검증성능평가기능개선/ST3_단위테스트/TR-BAR-1576-session-expiry-central.md`