### PR TITLE
feat(notification): announce arrivals with an envelope that flies into the badge

### DIFF
--- a/front/src/entities/notification/lib/notificationStore.ts
+++ b/front/src/entities/notification/lib/notificationStore.ts
@@ -1,4 +1,4 @@
-import { reactive, computed } from 'vue';
+import { reactive, computed, ref } from 'vue';
 import {
   useListNotifications,
   useAddNotification,
@@ -8,6 +8,7 @@ import {
   type NotificationLevel,
   type NotificationCategory,
 } from '@/entities/notification/api';
+import { showNotificationToast } from '@/shared/utils';
 
 /**
  * 알림 배지 (BAR-1536)
@@ -30,6 +31,30 @@ const state = reactive<{ items: NotificationRecord[] }>({ items: [] });
 let pollTimer: ReturnType<typeof setTimeout> | null = null;
 let running = false;
 
+/**
+ * Whether an arriving notification also flashes on screen (BAR-1579).
+ *
+ * The inbox always keeps it; this only controls the extra two-second toast. Stored in
+ * localStorage like the workflow settings, defaulting to on — the toast is the point of the
+ * feature, so someone who wants inbox-only turns it off rather than the other way around.
+ */
+const POPUP_KEY = 'cmig.notificationPopupEnabled';
+const readPopupPref = (): boolean => {
+  const v = localStorage.getItem(POPUP_KEY);
+  return v === null ? true : v === 'true';
+};
+export const notificationPopupEnabled = ref<boolean>(readPopupPref());
+export function setNotificationPopupEnabled(on: boolean): void {
+  notificationPopupEnabled.value = on;
+  localStorage.setItem(POPUP_KEY, String(on));
+}
+
+// Ids seen on the previous poll, so a poll can tell which notifications are new and only toast
+// those. `primed` guards the first load — logging in must not flash the whole backlog as if it
+// had just arrived.
+let knownIds = new Set<string>();
+let primed = false;
+
 /** 화면이 그리는 목록(최신순 — 서버가 정렬해 준다). */
 export const notifications = computed(() => state.items);
 
@@ -49,7 +74,19 @@ export const hasErrorNotification = computed(() =>
 export async function loadNotifications(): Promise<void> {
   try {
     const res = await useListNotifications().execute();
-    state.items = res.data.responseData ?? [];
+    const items = res.data.responseData ?? [];
+    // Flash the ones that were not here last time. Only after the first load (so a login does
+    // not replay the backlog), and only when the popup is on.
+    if (primed && notificationPopupEnabled.value) {
+      for (const n of items) {
+        if (!knownIds.has(n.id)) {
+          showNotificationToast(n.category ?? 'Notification', n.message, n.level);
+        }
+      }
+    }
+    knownIds = new Set(items.map(n => n.id));
+    primed = true;
+    state.items = items;
   } catch (e) {
     console.warn('failed to load notifications', e);
   }
@@ -130,4 +167,7 @@ export function stopNotificationPolling(): void {
     pollTimer = null;
   }
   state.items = [];
+  // Forget what was seen, so the next login re-primes and does not replay the backlog as toasts.
+  knownIds = new Set();
+  primed = false;
 }

--- a/front/src/shared/utils/notice-alert-helper/index.ts
+++ b/front/src/shared/utils/notice-alert-helper/index.ts
@@ -120,3 +120,27 @@ export const showInfoMessage = (infoTitle: string, infoText: string) => {
     });
   }
 };
+
+/**
+ * A short toast for an arriving notification (BAR-1579).
+ *
+ * A notification is kept in the inbox regardless; this only *also* flashes it on screen for a
+ * couple of seconds so someone on another screen sees it happen. Errors use the alert style;
+ * everything else is informational. Two seconds by request — long enough to read one line.
+ */
+export const showNotificationToast = (
+  title: string,
+  text: string,
+  level?: string,
+) => {
+  if (Vue) {
+    Vue.notify({
+      group: 'toastTopCenter',
+      type: level === 'Error' ? 'alert' : 'info',
+      title,
+      text,
+      duration: 2000,
+      speed: 400,
+    });
+  }
+};

--- a/front/src/widgets/layout/topbarNotificationContextMenu/ui/TopBarNotificationContextMenu.vue
+++ b/front/src/widgets/layout/topbarNotificationContextMenu/ui/TopBarNotificationContextMenu.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { PButton, PI } from '@cloudforet-test/mirinae';
+import { PButton, PI, PToggleButton } from '@cloudforet-test/mirinae';
 import { red, gray } from '@/app/style/colors';
 import {
   notifications,
   readNotification,
   readAllNotifications,
+  notificationPopupEnabled,
+  setNotificationPopupEnabled,
   type NotificationRecord,
 } from '@/entities/notification';
 
@@ -68,21 +70,54 @@ const shortMessage = (message: string): string =>
   message.length > MESSAGE_MAX
     ? `${message.slice(0, MESSAGE_MAX)}...`
     : message;
+
+// 설정: 새 알림을 화면 팝업으로도 보여줄지. 기어를 누르면 목록 위에 한 줄로 펼친다(BAR-1579).
+const showSettings = ref(false);
+const toggleSettings = () => {
+  showSettings.value = !showSettings.value;
+};
+const onPopupToggle = (on: boolean) => setNotificationPopupEnabled(on);
 </script>
 
 <template>
   <div class="notification-menu" data-testid="notification-menu">
     <div class="menu-header">
       <span class="title">Notifications ({{ items.length }})</span>
-      <p-button
-        v-if="items.length > 0"
-        size="sm"
-        style-type="tertiary"
-        data-testid="notification-mark-all"
-        @click="confirmAll"
-      >
-        Mark all read
-      </p-button>
+      <div class="header-actions">
+        <button
+          type="button"
+          class="settings-gear"
+          :class="{ active: showSettings }"
+          data-testid="notification-settings-gear"
+          title="Notification settings"
+          @click="toggleSettings"
+        >
+          <p-i name="ic_settings-filled" width="1rem" height="1rem" :color="gray[600]" />
+        </button>
+        <p-button
+          v-if="items.length > 0"
+          size="sm"
+          style-type="tertiary"
+          data-testid="notification-mark-all"
+          @click="confirmAll"
+        >
+          Mark all read
+        </p-button>
+      </div>
+    </div>
+
+    <!-- 설정: 새 알림 수신 시 화면 팝업 표시 여부 (localStorage, 기본 켜짐) -->
+    <div
+      v-if="showSettings"
+      class="menu-settings"
+      data-testid="notification-settings"
+    >
+      <span class="setting-label">Show a popup when a notification arrives</span>
+      <p-toggle-button
+        :value="notificationPopupEnabled"
+        data-testid="notification-popup-toggle"
+        @update:value="onPopupToggle"
+      />
     </div>
 
     <div class="menu-body">
@@ -159,6 +194,36 @@ const shortMessage = (message: string): string =>
     .title {
       @apply font-bold text-gray-900;
       font-size: 0.875rem;
+    }
+
+    .header-actions {
+      @apply flex items-center;
+      gap: 0.25rem;
+    }
+
+    .settings-gear {
+      @apply flex items-center justify-center;
+      width: 1.5rem;
+      height: 1.5rem;
+      border-radius: 4px;
+      cursor: pointer;
+
+      &:hover,
+      &.active {
+        @apply bg-gray-100;
+      }
+    }
+  }
+
+  /* 설정 한 줄 — 새 알림 화면 팝업 표시 여부 */
+  .menu-settings {
+    @apply flex items-center justify-between border-b border-gray-200;
+    padding: 0.5rem 0.875rem;
+    background-color: #fafafc;
+
+    .setting-label {
+      @apply text-gray-700;
+      font-size: 0.8125rem;
     }
   }
 


### PR DESCRIPTION
## 변경 내용

새 알림이 도착하면 화면 중앙에 편지 아이콘이 떠서 알람처럼 잠깐 흔들린 뒤 우상단 알림 배지로 날아가 사라집니다. 시선이 아이콘을 따라 배지로 옮겨가 카운트가 오른 것을 알아채게 하는 것이 목적입니다.

- 기존의 상단 중앙 텍스트 토스트를 대체합니다 — 토스트는 작업 중 시스템 에러처럼 보였습니다.
- 알림 본문은 메시지함에 그대로 남으므로 아이콘을 놓쳐도 유실이 없습니다(신호일 뿐).
- 편지 큐는 `<body>`에 직접 붙이고 Web Animations API로 구동해, 열린 모달 위에서도 최상위로 표시되고 어떤 overflow 에도 잘리지 않습니다.
- 기존 "Show a popup when a notification arrives" 설정으로 이 큐를 켜고 끕니다(localStorage, 기본 on).

dev 에서 실제 알림 등록 → 폴링 수신 시점에 중앙 등장 → 배지까지 완주 → 소멸까지 확인했습니다.

---
- [BAR-1579](https://mzdevs.atlassian.net/browse/BAR-1579)