### PR TITLE
feat(notification): notify on workflow run completion (badge stage 3)

### DIFF
--- a/front/src/entities/workflow/lib/workflowTracker.ts
+++ b/front/src/entities/workflow/lib/workflowTracker.ts
@@ -1,0 +1,195 @@
+import { useGetWorkflowRuns } from '@/entities/workflow/api';
+import { isRunFinished } from '@/entities/workflow/lib/taskState';
+import { notify } from '@/entities/notification/lib/notificationStore';
+import { registerTracker } from '@/shared/libs/tracking/runner';
+import {
+  putTrackedJob,
+  clearTrackedJob,
+  retagTrackedJob,
+  trackedJobsOf,
+  hasTrackedJobs,
+  loadTrackedJobs,
+  type TrackedJob,
+} from '@/entities/tracking/lib/trackedJobs';
+import type { TrackedJobAction } from '@/entities/tracking/api';
+import type { IWorkflowRun } from '@/entities/workflow/model/types';
+
+/**
+ * Workflow run tracking (notification badge, stage 3).
+ *
+ * A workflow run takes minutes and the run viewer is usually left behind while it runs. As
+ * with the delete and load-test checkers, moving the polling here keeps the outcome catchable
+ * for as long as the app is open, rather than only on the screen that started it.
+ *
+ * ★ **Workflow is the hard one — there is no endpoint that returns a single run.** A run does
+ * not hand back its own id when it starts, and there is no "get this run" call. All that can
+ * be done is to list every run of the workflow (`get-workflow-runs`) and pick the newest. So
+ * the tracked record keeps the **workflow id** and the checker resolves the run from the list.
+ *
+ * The natural key is `"{wfId}/{runId}"`. Until the run id is known it is just `"{wfId}"`, and
+ * the checker retags it once the run shows up in the list. Keying on the run id keeps two
+ * runs of the same workflow apart; a re-run, though, reuses the same run id, so the run id
+ * alone cannot tell two attempts apart. `startedAt` does — it is what the dedup key and the
+ * "is this the new completion?" guard are built on.
+ *
+ * `label` and `action` are captured at the start because at completion there is only an id,
+ * which cannot be turned into a sentence. `action` ("run" / "rerun" / "rerun-failed") is what
+ * makes the message say **which attempt** finished, not just "a workflow finished".
+ */
+
+const KIND = 'workflow' as const;
+
+// Clock skew between this browser and the engine. Used only to loosen the time comparisons
+// below so a completion is not missed by a few seconds; the gap to a stale prior completion
+// is normally far larger, so this does not re-admit one.
+const SKEW_MS = 5_000;
+
+interface WorkflowKey {
+  wfId: string;
+  runId: string | null;
+}
+
+/** Splits the natural key back into its parts. The wfId is a UUID, so the first slash wins. */
+function parseKey(naturalKey: string): WorkflowKey {
+  const slash = naturalKey.indexOf('/');
+  if (slash < 0) return { wfId: naturalKey, runId: null };
+  return {
+    wfId: naturalKey.slice(0, slash),
+    runId: naturalKey.slice(slash + 1),
+  };
+}
+
+const startTime = (r: IWorkflowRun): number =>
+  new Date(r.start_date || r.execution_date || 0).getTime();
+
+/**
+ * Records that a workflow run has started.
+ *
+ * `runId` is optional because most triggers do not have it yet — a plain run only knows the
+ * workflow. A re-run does know it (it re-clears an existing run), so it passes it and the
+ * checker never has to resolve it.
+ */
+export async function trackWorkflow(params: {
+  wfId: string;
+  label: string;
+  action?: TrackedJobAction;
+  runId?: string | null;
+}): Promise<void> {
+  if (!params.wfId) {
+    // Without the workflow id there is nothing to list runs for. Track nothing rather than
+    // guess — no notification beats a wrong one.
+    console.warn('[workflowTracker] no workflow id; not tracking');
+    return;
+  }
+
+  await putTrackedJob({
+    kind: KIND,
+    naturalKey: params.runId ? `${params.wfId}/${params.runId}` : params.wfId,
+    label: params.label,
+    action: params.action ?? 'run',
+    startedAt: new Date().toISOString(),
+  });
+}
+
+/** Whether any workflow run is still being tracked (used to keep the session alive). */
+export function hasPendingWorkflows(): boolean {
+  return hasTrackedJobs(KIND);
+}
+
+/** The sentence shown in the badge, built from the action captured at the start. */
+function buildMessage(job: TrackedJob, ok: boolean): string {
+  const outcome = ok ? 'finished' : 'failed';
+  switch (job.action) {
+    case 'rerun':
+      return `Re-run of workflow "${job.label}" ${outcome}.`;
+    case 'rerun-failed':
+      return `Re-run of failed tasks in "${job.label}" ${outcome}.`;
+    default:
+      return `Workflow "${job.label}" ${outcome}.`;
+  }
+}
+
+/**
+ * A terminal state is only *this attempt's* result if the run finished at or after we started
+ * tracking. A re-run reuses the run id and leaves the previous completion's state in place
+ * until it finishes again, so without this guard the old success/failure would be announced
+ * the moment tracking starts.
+ */
+function completedAfterStart(run: IWorkflowRun, startedAt: string): boolean {
+  if (!run.end_date) return false;
+  return (
+    new Date(run.end_date).getTime() >= new Date(startedAt).getTime() - SKEW_MS
+  );
+}
+
+/** Checks the outcome of one tracked run. */
+async function checkOne(job: TrackedJob): Promise<void> {
+  const { wfId, runId } = parseKey(job.naturalKey);
+
+  let runs: IWorkflowRun[];
+  try {
+    const res: any = await useGetWorkflowRuns(wfId).execute();
+    runs = res?.data?.responseData ?? [];
+  } catch {
+    // The list failed. A freshly created workflow answers 400 (DAG not found) for a few
+    // seconds, and a transient error is not a completion. Look again next pass.
+    return;
+  }
+  if (!Array.isArray(runs) || runs.length === 0) return;
+
+  // Resolve which run this record is about.
+  let run: IWorkflowRun | undefined;
+  if (runId) {
+    // A re-run already knows the run id — find it directly.
+    run = runs.find(r => r.workflow_run_id === runId);
+  } else {
+    // A plain run does not. The run we started is the newest one that began at or after we
+    // started tracking; an older run must not be mistaken for it.
+    const startedAtMs = new Date(job.startedAt).getTime() - SKEW_MS;
+    run = runs
+      .filter(r => startTime(r) >= startedAtMs)
+      .sort((a, b) => startTime(b) - startTime(a))[0];
+  }
+  if (!run) return; // not registered yet — wait for the next pass
+
+  if (!isRunFinished(run.state)) {
+    // Pin the key to this exact run so later passes are stable and the dedup key is fixed.
+    // Only needed once, while the key is still the bare workflow id.
+    if (!runId) {
+      await retagTrackedJob(job, `${wfId}/${run.workflow_run_id}`);
+    }
+    return;
+  }
+
+  if (!completedAfterStart(run, job.startedAt)) {
+    // Terminal, but it is the previous attempt's result (a re-run that has not re-run yet).
+    return;
+  }
+
+  const ok = run.state.toLowerCase() === 'success';
+  await notify({
+    category: 'Workflow',
+    level: ok ? 'Info' : 'Error',
+    message: buildMessage(job, ok),
+    dedupKey: `workflow:${run.workflow_run_id}:${job.startedAt}:${
+      ok ? 'done' : 'error'
+    }`,
+  });
+
+  await clearTrackedJob(KIND, job.naturalKey);
+}
+
+registerTracker({
+  id: 'workflow-run',
+  check: async () => {
+    for (const job of trackedJobsOf(KIND)) {
+      await checkOne(job);
+    }
+  },
+  hasWork: hasPendingWorkflows,
+  resume: loadTrackedJobs,
+  reset: () => {
+    /* trackedJobs owns the list — it clears on logout, so nothing to do here */
+  },
+});
+

--- a/front/src/main.ts
+++ b/front/src/main.ts
@@ -17,6 +17,7 @@ import { startNotificationPolling } from '@/entities/notification/lib/notificati
 // 통째로 사라지므로(BAR-1531 에서 겪었다) 여기서 명시적으로 들여온다.
 import '@/entities/mci/lib/deleteTracker';
 import '@/entities/vm/lib/loadTestTracker';
+import '@/entities/workflow/lib/workflowTracker';
 
 const pinia = createPinia();
 Vue.use(PiniaVuePlugin);

--- a/front/src/widgets/workflow/workflows/workflowList/ui/WorkflowList.vue
+++ b/front/src/widgets/workflow/workflows/workflowList/ui/WorkflowList.vue
@@ -24,6 +24,7 @@ import {
 } from 'vue';
 import { useGetWorkflowList, useBulkDeleteWorkflow } from '@/entities';
 import { useRunWorkflow } from '@/entities';
+import { trackWorkflow } from '@/entities/workflow/lib/workflowTracker';
 import { useDynamicTableHeight } from '@/shared/hooks/table/useDynamicTableHeight';
 import { useToolboxTableHeight } from '@/shared/hooks/table/useToolboxTableHeight';
 
@@ -200,6 +201,14 @@ async function handleRunWorkflow(e: any) {
         'success',
         `Workflow ID: ${selectedWfId} run successfully`,
       );
+      // Hand it to the app-wide checker so the outcome is caught after leaving this screen.
+      // The name has to be captured here — at completion there is only the run id.
+      void trackWorkflow({
+        wfId: selectedWfId,
+        label:
+          workflowStore.getWorkflowById(selectedWfId)?.name || selectedWfId,
+        action: 'run',
+      });
     }
   } catch (error) {
     console.log(error);

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
@@ -21,6 +21,7 @@ import { buildRunGraph, IRunGraph } from '@/entities/workflow/lib/runGraph';
 import { useWorkflowStore } from '@/entities';
 import { showSuccessMessage } from '@/shared/utils';
 import { isRunFinished } from '@/entities/workflow/lib/taskState';
+import { trackWorkflow } from '@/entities/workflow/lib/workflowTracker';
 import {
   extractFailureSummary,
   normalizeTaskLog,
@@ -395,6 +396,14 @@ export function useWorkflowRunViewerModel() {
         resetDagRuns: true,
       });
       await execute();
+      // A re-run reuses this run id, so the checker leans on startedAt to tell this attempt
+      // from the last. onlyFailed decides whether the message says "failed tasks" or the run.
+      void trackWorkflow({
+        wfId,
+        label: workflow.value?.name || wfId,
+        action: option.onlyFailed ? 'rerun-failed' : 'rerun',
+        runId,
+      });
       cancelRerun();
       await fetchInstances(wfId, runId);
       startPolling();
@@ -465,6 +474,13 @@ export function useWorkflowRunViewerModel() {
     if (!wfId) return;
     const { execute } = useRunWorkflow(wfId);
     await execute();
+    // Hand it to the app-wide checker so the outcome is caught after leaving this screen.
+    // The name has to be captured here — at completion there is only the run id.
+    void trackWorkflow({
+      wfId,
+      label: workflow.value?.name || wfId,
+      action: 'run',
+    });
     // DAG 등록 직후에는 실행이 바로 보이지 않을 수 있으므로 잠시 뒤 다시 연다
     await new Promise(resolve => setTimeout(resolve, 3000));
     await open(wfId);

--- a/front/tests/e2e/features/workflow/워크플로우-실행완료-알림-실데이터.feature
+++ b/front/tests/e2e/features/workflow/워크플로우-실행완료-알림-실데이터.feature
@@ -1,0 +1,13 @@
+# language: ko
+@workflow @live
+기능: 워크플로우 실행 완료 알림 — 실 데이터 (BAR-1545)
+  mock 시나리오가 tracker 의 로직을 검증한다면, 이 시나리오는 마지막 연결을 실제로 확인한다 —
+  실제 화면의 Run 클릭이 trackWorkflow 를 부르고, 실제 cm-cicada 실행이 끝나며, 실제 알림 저장소가
+  배지에 그 결과를 올리는 것까지. 요금 안전 예제(bash·http echo — 클라우드 자원 없음)를 써서 비용
+  없이 수초 안에 끝난다.
+
+  시나리오: 실제 실행이 끝나면 배지에 실제 알림이 뜬다
+    먼저 "cmiguser"로 로그인한다
+    그리고 요금 안전 예제로 워크플로우 "notify-live-verify" 를 만든다
+    그리고 워크플로우 "notify-live-verify" 를 실제로 실행한다
+    그러면 실제 알림 배지에 "Workflow \"notify-live-verify\" finished." 알림이 뜬다

--- a/front/tests/e2e/features/workflow/워크플로우-실행완료-알림.feature
+++ b/front/tests/e2e/features/workflow/워크플로우-실행완료-알림.feature
@@ -1,0 +1,60 @@
+# language: ko
+@workflow @mock @notify
+기능: 워크플로우 실행 완료 알림 (BAR-1545 · 알림 배지 3단계)
+  워크플로우 실행은 몇 분이 걸리고, 끝나는 순간 사용자는 보통 다른 화면에 있다. 그 결과를 배지로
+  알리는 것이 이 기능이다. 삭제·부하 테스트와 달리 워크플로우는 진행 중 실행을 한 번에 조회하는
+  API 가 없어, 시작할 때 우리가 추적 레코드를 남기고 실행 목록으로 끝을 판정한다.
+
+  # 여기서 검증하는 것은 tracker 의 상태 기계다 — 로그인 시 재개(resume), 실행 해석, 완료 판정,
+  # 동작(run/rerun/rerun-failed)별 문구, 중복 제거, 완료 후 레코드 정리. cm-cicada 실제 응답 파싱은
+  # mock 으로 확인하지 않는다(우리 가정으로 우리 파서를 검증하는 셈) — 그 몫은 실 데이터 검증이 맡는다.
+  #
+  # 완료는 "브라우저가 로그인해 서버 레코드를 재개하는 순간" 잡힌다. 그래서 실제 실행을 몇 분 기다리는
+  # 대신, 각 시나리오는 (이미 시작됐던 것처럼) 추적 레코드 하나와 엔진이 보고할 실행을 seed 한 뒤
+  # 로그인한다. 배지가 관측 지점이다.
+
+  @notify
+  시나리오: 실행이 성공하면 완료 알림이 뜬다
+    먼저 추적에 남은 워크플로우 작업을 준비한다: 이름 "order-service", 동작 "run", 결과 "success"
+    그리고 "cmiguser"로 로그인한다
+    그러면 알림 배지에 "정보" 수준의 "Workflow \"order-service\" finished." 알림이 뜬다
+
+  @notify
+  시나리오: 실행이 실패하면 실패 알림이 뜬다
+    먼저 추적에 남은 워크플로우 작업을 준비한다: 이름 "billing-service", 동작 "run", 결과 "failed"
+    그리고 "cmiguser"로 로그인한다
+    그러면 알림 배지에 "오류" 수준의 "Workflow \"billing-service\" failed." 알림이 뜬다
+
+  @notify
+  시나리오: 전체 재실행이 끝나면 재실행 문구로 알린다
+    먼저 추적에 남은 워크플로우 작업을 준비한다: 이름 "order-service", 동작 "rerun", 결과 "success"
+    그리고 "cmiguser"로 로그인한다
+    그러면 알림 배지에 "정보" 수준의 "Re-run of workflow \"order-service\" finished." 알림이 뜬다
+
+  @notify
+  시나리오: 실패 태스크만 재실행했다가 다시 실패하면 그 문구로 알린다
+    먼저 추적에 남은 워크플로우 작업을 준비한다: 이름 "billing-service", 동작 "rerun-failed", 결과 "failed"
+    그리고 "cmiguser"로 로그인한다
+    그러면 알림 배지에 "오류" 수준의 "Re-run of failed tasks in \"billing-service\" failed." 알림이 뜬다
+
+  @notify
+  시나리오: 워크플로우 화면을 열지 않아도 완료가 잡힌다
+    먼저 추적에 남은 워크플로우 작업을 준비한다: 이름 "order-service", 동작 "run", 결과 "success"
+    그리고 "cmiguser"로 로그인한다
+    그러면 현재 화면은 워크플로우 화면이 아니다
+    그리고 알림 배지에 "정보" 수준의 "Workflow \"order-service\" finished." 알림이 뜬다
+
+  @notify
+  시나리오: 실행 id 를 시작 시 몰라도 목록에서 해석해 완료를 알린다
+    # 엔진이 실행 중을 먼저 보고하고 다음에 성공을 보고한다 — 그 사이 tracker 가 실행 id 를 해석해
+    # 레코드를 그 실행에 고정(retag)한 뒤 완료를 판정한다.
+    먼저 추적에 남은 워크플로우 작업을 준비한다: 이름 "order-service", 동작 "run", 결과 "running-then-success"
+    그리고 "cmiguser"로 로그인한다
+    그러면 알림 배지에 "정보" 수준의 "Workflow \"order-service\" finished." 알림이 뜬다
+
+  @notify
+  시나리오: 같은 완료를 두 번 알리지 않는다
+    먼저 추적에 남은 워크플로우 작업을 준비한다: 이름 "order-service", 동작 "run", 결과 "success"
+    그리고 "cmiguser"로 로그인한다
+    그러면 알림 배지에 "정보" 수준의 "Workflow \"order-service\" finished." 알림이 뜬다
+    그리고 잠시 뒤에도 워크플로우 알림은 하나뿐이다

--- a/front/tests/e2e/pages/notification.page.ts
+++ b/front/tests/e2e/pages/notification.page.ts
@@ -1,0 +1,76 @@
+import { Page, expect, Locator } from '@playwright/test';
+
+/**
+ * NotificationPage — the top-bar notification badge (BAR-1536 stage 1~3).
+ *
+ * The badge is where a long job's outcome surfaces after the user has left the screen that
+ * started it. Selectors live here so scenarios only speak of intent.
+ *
+ * testids (TopBarNotifications.vue / TopBarNotificationContextMenu.vue):
+ *   notification-badge · notification-count · notification-menu · notification-item ·
+ *   notification-detail · notification-mark-all · notification-empty
+ */
+export class NotificationPage {
+  constructor(private readonly page: Page) {}
+
+  private get badge(): Locator {
+    return this.page.getByTestId('notification-badge');
+  }
+
+  private get menu(): Locator {
+    return this.page.getByTestId('notification-menu');
+  }
+
+  private get items(): Locator {
+    return this.page.getByTestId('notification-item');
+  }
+
+  /** Opens the badge panel (idempotent — leaves it open whether or not it already was). */
+  async open(): Promise<void> {
+    await expect(this.badge).toBeVisible({ timeout: 15_000 });
+    if (await this.menu.isVisible()) return;
+    await this.badge.click();
+    await expect(this.menu).toBeVisible({ timeout: 10_000 });
+  }
+
+  /** Waits until at least one notification is present, then returns how many. */
+  async waitForAnyItem(timeout = 20_000): Promise<number> {
+    await expect(this.items.first()).toBeVisible({ timeout });
+    return this.items.count();
+  }
+
+  async count(): Promise<number> {
+    return this.items.count();
+  }
+
+  /** The item whose full (expanded) message equals `message`. */
+  private itemByMessage(message: string): Locator {
+    return this.items.filter({ hasText: message }).first();
+  }
+
+  /**
+   * Asserts an item is present whose **full** message is `message`, and that its level matches.
+   * The list may shorten the message, so the row is expanded and the detail text is asserted.
+   */
+  async expectNotification(
+    message: string,
+    level: 'Info' | 'Error',
+  ): Promise<void> {
+    // The list truncates long text; match on the row, then open its detail for the full string.
+    const row = this.items
+      .filter({ hasText: message.slice(0, 24) })
+      .first();
+    await expect(row).toBeVisible({ timeout: 20_000 });
+    await row.getByRole('button').first().click();
+    const detail = row.getByTestId('notification-detail');
+    await expect(detail).toContainText(message, { timeout: 10_000 });
+
+    // Level is carried as the `error` class on the item (Error) or its absence (Info).
+    const cls = (await row.getAttribute('class')) ?? '';
+    if (level === 'Error') {
+      expect(cls).toContain('error');
+    } else {
+      expect(cls).not.toContain('error');
+    }
+  }
+}

--- a/front/tests/e2e/playwright.config.ts
+++ b/front/tests/e2e/playwright.config.ts
@@ -94,6 +94,22 @@ export default defineConfig({
       grepInvert: includeCostly ? undefined : /@costly/,
     },
     {
+      // 알림 배지 검증(@notify)은 @mock 으로 hermetic 하게 돈다 — 실행 결과를 우리 tracker 가
+      // 어떻게 배지로 만드는지만 보므로 시드(실 소스 수집)나 클라우드 자원이 필요 없다. 그래서
+      // functional 과 달리 seed 에 의존하지 않는 독립 레인으로 둔다(로그인만 실 백엔드로 나간다).
+      name: 'notify',
+      use: { ...devices['Desktop Chrome'] },
+      grep: /@notify/,
+    },
+    {
+      // 알림 배지 실 데이터 검증(@live) — mock 없이 실제 실행/실제 알림까지 확인한다. 요금 안전
+      // 예제만 쓰므로 클라우드 자원을 만들지 않지만, 실 실행이 끝날 때까지 넉넉히 기다린다.
+      name: 'live',
+      use: { ...devices['Desktop Chrome'] },
+      grep: /@live/,
+      timeout: 8 * 60_000,
+    },
+    {
       name: 'scenario',
       use: { ...devices['Desktop Chrome'] },
       dependencies: ['seed'],

--- a/front/tests/e2e/steps/workflowNotification.steps.ts
+++ b/front/tests/e2e/steps/workflowNotification.steps.ts
@@ -1,0 +1,214 @@
+import { createBdd } from 'playwright-bdd';
+import { test, expect } from '../support/fixtures';
+import { NotificationPage } from '../pages/notification.page';
+import { ok } from '../support/apiMock';
+
+const { Given, Then } = createBdd(test);
+
+/**
+ * Workflow run completion notification (BAR-1545, notification badge stage 3) — @mock.
+ *
+ * What this verifies and what it does not
+ * ---------------------------------------
+ * The tracker (`entities/workflow/lib/workflowTracker.ts`) is our own state machine: it holds
+ * what was known when a run started (workflow id, name, action), asks the engine how the run
+ * ended, and turns that into one badge message. That logic — resume on login, resolve the run,
+ * guard the completion, word the message by action, dedup, drop the record — is what runs here.
+ *
+ * It does NOT verify cm-cicada's real response parsing; mocking the engine would only check our
+ * parser against our own assumptions (see 워크로드-삭제-화면상태.feature for the same reasoning).
+ * The real cm-cicada run is exercised separately with real data.
+ *
+ * How the cases are staged
+ * ------------------------
+ * A completion is caught the moment a browser logs in and the tracker resumes the server's
+ * records. So instead of driving a real run and waiting minutes, each case seeds one tracked
+ * record (as if a run had started earlier) plus the run the engine would report, then logs in.
+ * The badge is the observable outcome. This exercises exactly the login→resume→check→notify→
+ * badge path, which is the whole point of tracking off-screen.
+ */
+
+// ── stateful mock, reset at the start of every scenario ──────────────────────
+
+interface JobRec {
+  id: string;
+  kind: string;
+  natural_key: string;
+  label: string;
+  action: string;
+  started_at: string;
+}
+interface NotifRec {
+  id: string;
+  user_id: string;
+  category: string;
+  level: string;
+  message: string;
+  detail: string;
+  dedup_key: string;
+  created_at: string;
+}
+
+let jobs: JobRec[] = [];
+let notifs: NotifRec[] = [];
+let dedup: Set<string> = new Set();
+/** workflow id → the sequence of run states the engine reports across successive polls */
+let runSeq: Record<string, string[]> = {};
+let runPolls: Record<string, number> = {};
+let notifSeq = 0;
+
+const iso = (msAgo: number) => new Date(Date.now() - msAgo).toISOString();
+
+function resetState() {
+  jobs = [];
+  notifs = [];
+  dedup = new Set();
+  runSeq = {};
+  runPolls = {};
+  notifSeq = 0;
+}
+
+function slugOf(name: string): string {
+  return name.replace(/[^a-z0-9]+/gi, '-').toLowerCase();
+}
+
+/** Registers the stateful handlers on the scenario's mock. Idempotent. */
+function installHandlers(mockApi: any) {
+  mockApi.use({
+    // tracked jobs — the tracker resumes from this on login
+    listtrackedjobs: () => ok(jobs),
+    savetrackedjob: ({ body }: any) => {
+      jobs.push({ id: `job-${jobs.length}`, ...(body || {}) });
+      return ok(body);
+    },
+    removetrackedjob: ({ body }: any) => {
+      jobs = jobs.filter(
+        j => !(j.kind === body?.kind && j.natural_key === body?.natural_key),
+      );
+      return ok('removed');
+    },
+
+    // workflow runs — what the engine reports for a workflow id
+    'cm-cicada/get-workflow-runs': ({ body }: any) => {
+      const wfId = body?.pathParams?.wfId as string;
+      const seq = runSeq[wfId];
+      if (!seq || seq.length === 0) return ok([]);
+      const i = Math.min(runPolls[wfId] ?? 0, seq.length - 1);
+      runPolls[wfId] = (runPolls[wfId] ?? 0) + 1;
+      const state = seq[i];
+      return ok([
+        {
+          workflow_run_id: `run-${slugOf(wfId)}`,
+          workflow_id: wfId,
+          state,
+          start_date: iso(1_800_000), // 30m ago
+          end_date: state === 'running' ? '' : iso(1_200_000), // 20m ago when done
+          execution_date: iso(1_800_000),
+          run_type: 'manual',
+          duration_date: 600,
+          data_interval_start: '',
+          data_interval_end: '',
+          last_scheduling_decision: '',
+        },
+      ]);
+    },
+
+    // notification store — dedup enforced server-side, newest first
+    addnotification: ({ body }: any) => {
+      const key = body?.dedup_key || '';
+      if (key && dedup.has(key)) {
+        const existing = notifs.find(n => n.dedup_key === key);
+        return ok(existing);
+      }
+      const rec: NotifRec = {
+        id: `ntf-${notifSeq++}`,
+        user_id: 'cmiguser',
+        category: body?.category ?? '',
+        level: body?.level ?? 'Info',
+        message: body?.message ?? '',
+        detail: body?.detail ?? '',
+        dedup_key: key,
+        created_at: new Date().toISOString(),
+      };
+      notifs.unshift(rec);
+      if (key) dedup.add(key);
+      return ok(rec);
+    },
+    listnotifications: () => ok(notifs),
+    readnotification: ({ body }: any) => {
+      notifs = notifs.filter(n => n.id !== body?.id);
+      return ok('read');
+    },
+    readallnotifications: () => {
+      notifs = [];
+      return ok('read-all');
+    },
+  });
+}
+
+// ── steps ────────────────────────────────────────────────────────────────────
+
+/**
+ * Seeds one workflow run as if it had started earlier and finished with `result`.
+ *  - action "run": the run id is not known at start, so the record is keyed by the workflow id
+ *    (the tracker resolves and pins the run id itself).
+ *  - action "rerun" / "rerun-failed": the run id is known, so the record carries it.
+ *  - result "running-then-success": the engine reports running first, success next — this
+ *    drives the resolve-and-pin (retag) path before completion.
+ */
+Given(
+  '추적에 남은 워크플로우 작업을 준비한다: 이름 {string}, 동작 {string}, 결과 {string}',
+  async ({ mockApi }, name: string, action: string, result: string) => {
+    expect(mockApi, '이 시나리오는 @mock 태그가 필요하다').not.toBeNull();
+    resetState();
+    installHandlers(mockApi);
+
+    const slug = slugOf(name);
+    const wfId = `wf-${slug}`;
+    const runId = `run-wf-${slug}`;
+    const naturalKey = action === 'run' ? wfId : `${wfId}/${runId}`;
+
+    jobs = [
+      {
+        id: `job-${slug}`,
+        kind: 'workflow',
+        natural_key: naturalKey,
+        label: name,
+        action,
+        started_at: iso(3_600_000), // 1h ago — before the run's end_date
+      },
+    ];
+
+    runSeq[wfId] =
+      result === 'running-then-success'
+        ? ['running', 'success']
+        : [result];
+  },
+);
+
+/** Opens the badge and asserts a Workflow notification with the given wording and level. */
+Then(
+  '알림 배지에 {string} 수준의 {string} 알림이 뜬다',
+  async ({ page }, levelKo: string, message: string) => {
+    const level = levelKo === '오류' ? 'Error' : 'Info';
+    const noti = new NotificationPage(page);
+    await noti.open();
+    await noti.waitForAnyItem();
+    await noti.expectNotification(message, level as 'Info' | 'Error');
+  },
+);
+
+/** The badge caught the outcome without the workflow screen being open. */
+Then('현재 화면은 워크플로우 화면이 아니다', async ({ page }) => {
+  await expect(page).not.toHaveURL(/workflow-management/);
+});
+
+/** After another poll interval no duplicate is posted (the record was dropped on completion). */
+Then('잠시 뒤에도 워크플로우 알림은 하나뿐이다', async ({ page }) => {
+  const noti = new NotificationPage(page);
+  // one runner poll interval is 10s; wait past it, then confirm the count did not grow
+  await page.waitForTimeout(12_000);
+  await noti.open();
+  const count = await noti.count();
+  expect(count).toBe(1);
+});

--- a/front/tests/e2e/steps/workflowNotificationLive.steps.ts
+++ b/front/tests/e2e/steps/workflowNotificationLive.steps.ts
@@ -1,0 +1,118 @@
+import { createBdd } from 'playwright-bdd';
+import { test, expect } from '../support/fixtures';
+import { WorkflowPage } from '../pages/workflow.page';
+import { NotificationPage } from '../pages/notification.page';
+import { workflowData } from '../fixtures/test-data';
+
+const { Given, When, Then } = createBdd(test);
+
+/**
+ * Workflow completion notification — real data (@live, no mock).
+ *
+ * The @mock scenarios prove the tracker's own logic. This one closes the last gap: a real Run
+ * click in the real UI firing trackWorkflow, a real cm-cicada run finishing, and the real
+ * notification store surfacing it on the badge. It uses the cost-safe example workflow
+ * (bash/http echo — no cloud provisioning), so it finishes in seconds without spend.
+ */
+
+async function bearer(page: any): Promise<string> {
+  const token = await page.evaluate(() => {
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (!k) continue;
+      const v = localStorage.getItem(k) ?? '';
+      const m = v.match(/"access_token"\s*:\s*"([^"]+)"/);
+      if (m) return m[1];
+    }
+    return '';
+  });
+  expect(token, '로그인 세션에서 access token을 찾지 못했다').not.toEqual('');
+  return token;
+}
+
+/** Creates the cost-safe example workflow under an exact name (idempotent-ish per run). */
+Given(
+  '요금 안전 예제로 워크플로우 {string} 를 만든다',
+  async ({ page }, name: string) => {
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${await bearer(page)}`,
+    };
+    // Idempotent: a re-run must not pile up duplicates of the same name.
+    const existing = await page.request.post('/api/cm-cicada/list-workflow', {
+      data: {},
+      headers,
+    });
+    const wfs = (await existing.json())?.responseData ?? [];
+    if ((Array.isArray(wfs) ? wfs : []).some((w: any) => w?.name === name)) {
+      return;
+    }
+    const listRes = await page.request.post(
+      '/api/cm-cicada/list-workflow-template',
+      { data: {}, headers },
+    );
+    expect(listRes.ok()).toBeTruthy();
+    const templates = (await listRes.json())?.responseData ?? [];
+    const template = (Array.isArray(templates) ? templates : []).find(
+      (t: { name?: string }) => t?.name === workflowData.safeRunTemplateName,
+    );
+    expect(template, '요금 안전 예제 템플릿을 찾지 못했다').toBeTruthy();
+
+    const res = await page.request.post('/api/cm-cicada/create-workflow', {
+      data: {
+        request: {
+          name,
+          description:
+            'e2e — cost-safe example workflow (no cloud provisioning)',
+          data: {
+            task_groups:
+              template.data?.task_groups ?? template.task_groups ?? [],
+          },
+        },
+      },
+      headers,
+    });
+    expect(
+      res.ok(),
+      `워크플로우 생성 실패: ${res.status()} ${await res.text()}`,
+    ).toBeTruthy();
+  },
+);
+
+/**
+ * Runs it through the real UI. The Run click goes through the real handleRunWorkflow, which is
+ * where trackWorkflow fires. A freshly created workflow may need a moment for Airflow to
+ * register the DAG, so the click is retried a few times; the badge (asserted next) is the
+ * success signal.
+ */
+When(
+  '워크플로우 {string} 를 실제로 실행한다',
+  async ({ page }, name: string) => {
+    const wf = new WorkflowPage(page);
+    for (let i = 0; i < 4; i++) {
+      await wf.gotoWorkflows();
+      await wf.runWorkflow(name);
+      // give the run time to start and the DAG time to register before the next attempt
+      await page.waitForTimeout(15_000);
+      // if a notification has already landed, no need to trigger again
+      const badgeText = await page
+        .getByTestId('notification-count')
+        .textContent()
+        .catch(() => null);
+      if (badgeText && badgeText.trim() !== '' && badgeText.trim() !== '0')
+        break;
+    }
+  },
+);
+
+/** Waits for the real completion notification (a real run takes longer than a mock). */
+Then(
+  '실제 알림 배지에 {string} 알림이 뜬다',
+  async ({ page }, message: string) => {
+    const noti = new NotificationPage(page);
+    await noti.open();
+    // a real run plus the tracker's poll interval takes longer than a mocked one
+    await noti.waitForAnyItem(150_000);
+    await noti.expectNotification(message, 'Info');
+  },
+);


### PR DESCRIPTION
## 개요

알림 배지(BAR-1536)의 3단계 — 워크플로우 실행/재실행 완료를 콘솔 상단 배지로 통지한다. 삭제(1단계)·부하 테스트(2단계)에 이어 워크플로우를 태운다.

## 왜 별도 추적이 필요한가

워크플로우는 진행 중 실행을 한 번에 조회하는 엔드포인트가 없다. 그래서 실행을 시작할 때 추적 레코드(실행 id·이름·동작)를 남기고, 실행 목록(`get-workflow-runs`)으로 끝을 판정한다. 완료 시점엔 id밖에 안 남으므로 이름·동작을 시작할 때 적재해야 "…재실행이 끝났습니다" 같은 문구를 만들 수 있다.

## 변경

- `entities/workflow/lib/workflowTracker.ts` 신설 — 공통 추적 저장소(`tracked_jobs`) 사용. 키 `{wfId}/{runId}`(시작 직후 목록에서 해석해 pin), 동작 `run`/`rerun`/`rerun-failed`, 재실행은 같은 run id를 재사용하므로 시작 시각으로 시도를 구분. `end_date ≥ startedAt` 가드로 직전 완료 오보 방지.
- 실행 트리거 3곳 연결: 목록 실행(`WorkflowList`) · 실행 뷰어 실행/재실행(`workflowRunViewerModel`).
- `main.ts` 체커 등록.
- e2e: 워크플로우 알림 `@mock` 7종(성공·실패·rerun·rerun-failed·off-screen·retag·중복) + 실 데이터 `@live` 1종(요금 안전 예제).

## 검증

원격 dev에서 이 브랜치의 이미지를 별도 front-dev 컨테이너로 구동해 검증 — **mock 7/7 + 실 데이터 1/1 PASS.** 실제 실행 → 실제 배지 알림까지 확인.

---

- [BAR-1545](https://mzdevs.atlassian.net/browse/BAR-1545) [cm-butterfly] 워크플로우 실행 완료 알림 (알림 배지 3단계)
- 테스트 결과서: `notion/.../ST3_단위테스트/TR-BAR-1545-워크플로우실행완료알림.md`