### PR TITLE
fix(front): re-resolve the api upstream so a redeployed api does not 502

### DIFF
--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -19,7 +19,16 @@ server {
         #     return 403;
         # }
 
-        proxy_pass http://cm-butterfly-api:4000;
+        # nginx resolves an upstream hostname once at startup and caches that IP for the life of
+        # the process. When the api container is recreated (redeploy, image swap, compose recreate)
+        # Docker can hand it a new IP, and nginx keeps hitting the old one — every /api/* becomes a
+        # 502 while the api itself is healthy. Pointing at Docker's embedded DNS with a short TTL and
+        # proxying through a variable makes nginx re-resolve, so a redeployed api is picked up within
+        # ~10s without restarting the front. (A plain `docker restart api` keeps the same IP; only
+        # recreation changes it.) The host-only proxy_pass keeps the original /api/ path unchanged.
+        resolver 127.0.0.11 valid=10s ipv6=off;
+        set $cm_butterfly_api cm-butterfly-api;
+        proxy_pass http://$cm_butterfly_api:4000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## 변경 내용

front nginx가 upstream 호스트명(`cm-butterfly-api`)을 구동 시 1회만 IP로 해석해 캐싱하는 탓에, api 컨테이너가 재생성되며 내부 IP가 바뀌면 옛 IP를 계속 물어 `/api/*` 전체가 502가 났습니다(api는 healthy라 원인이 안 드러남). `front/nginx.conf`의 `/api/`에 Docker 내장 DNS resolver(TTL 10s)와 변수 upstream을 적용해, api가 재배포돼 IP가 바뀌어도 front 재기동 없이 ~10초 내 자동 추종하도록 했습니다.

- `resolver 127.0.0.11 valid=10s ipv6=off;` + `set $cm_butterfly_api cm-butterfly-api;` + `proxy_pass http://$cm_butterfly_api:4000;` (host-only라 `/api/` 경로 보존)

## 검증 (dev)

api를 새 IP(`172.18.0.2`→`172.18.0.23`)로 재생성해도 **front 무재기동**으로 `/api/` 정상(login 400·GET 401, 502 아님), nginx가 새 IP로 재해석 확인. 같은 날 오전 resolver 없을 때 같은 조건에서 발생하던 502를 차단.

---
- [BAR-1581](https://mzdevs.atlassian.net/browse/BAR-1581)