### PR TITLE
fix(source): show collected infra/software as JSON via get-infra-info

### DIFF
--- a/front/src/entities/sourceConnection/api/index.ts
+++ b/front/src/entities/sourceConnection/api/index.ts
@@ -20,6 +20,8 @@ const COLLECT_SW_SOURCE_GROUP = 'cm-honeybee/import-software-source-group';
 const DELETE_SOURCE_CONNECTION = 'cm-honeybee/delete-connection-info';
 const REFRESH_SOURCE_GROUP_CONNECTION_INFO_STATUS =
   'cm-honeybee/Refresh-Source-Group-Connection-Info-Status';
+const GET_INFRA_INFO = 'cm-honeybee/get-infra-info';
+const GET_SOFTWARE_INFO = 'cm-honeybee/get-software-info';
 const GET_INFRA_INFO_REFINED = 'cm-honeybee/get-infra-info-refined';
 const GET_INFRA_INFO_SOURCE_GROUP_REFINED = 'cm-honeybee/get-infra-info-source-group-refined';
 const GET_SOFTWARE_INFO_REFINED = 'cm-honeybee/get-software-info-refined';
@@ -198,6 +200,49 @@ export function useGetInfraInfoRefined(
       >
     >
   >(GET_INFRA_INFO_REFINED, requestWrapper);
+}
+
+// Structured (non-refined) view of the collected infra — the JSON form of the
+// same data collected by import-infra, shown in the viewer's left "Meta" pane.
+export function useGetInfraInfo(sgId: string | null, connId: string | null) {
+  const requestWrapper: Required<
+    Pick<
+      RequestBodyWrapper<{ sgId: string | null; connId: string | null }>,
+      'pathParams'
+    >
+  > = {
+    pathParams: { sgId, connId },
+  };
+  return useAxiosPost<
+    IAxiosResponse<any>,
+    Required<
+      Pick<
+        RequestBodyWrapper<{ sgId: string | null; connId: string | null }>,
+        'pathParams'
+      >
+    >
+  >(GET_INFRA_INFO, requestWrapper);
+}
+
+// Structured (non-refined) view of the collected software.
+export function useGetSoftwareInfo(sgId: string | null, connId: string | null) {
+  const requestWrapper: Required<
+    Pick<
+      RequestBodyWrapper<{ sgId: string | null; connId: string | null }>,
+      'pathParams'
+    >
+  > = {
+    pathParams: { sgId, connId },
+  };
+  return useAxiosPost<
+    IAxiosResponse<any>,
+    Required<
+      Pick<
+        RequestBodyWrapper<{ sgId: string | null; connId: string | null }>,
+        'pathParams'
+      >
+    >
+  >(GET_SOFTWARE_INFO, requestWrapper);
 }
 
 export function useGetSoftwareInfoRefined(

--- a/front/src/entities/sourceConnection/model/stores.ts
+++ b/front/src/entities/sourceConnection/model/stores.ts
@@ -81,6 +81,22 @@ export const useSourceConnectionStore = defineStore(NAMESPACE, () => {
     }
   }
 
+  // Store the structured (get-infra-info / get-software-info) JSON for a
+  // connection so the viewer shows it as a JSON tree instead of the raw string.
+  function setConnectionInfraModel(connId: string, data: any) {
+    const sourceConnection = getConnectionById(connId);
+    if (sourceConnection) {
+      sourceConnection.infraData = data;
+    }
+  }
+
+  function setConnectionSoftwareModel(connId: string, data: any) {
+    const sourceConnection = getConnectionById(connId);
+    if (sourceConnection) {
+      sourceConnection.softwareData = data;
+    }
+  }
+
   function clear() {
     connections.value = {};
   }
@@ -94,6 +110,8 @@ export const useSourceConnectionStore = defineStore(NAMESPACE, () => {
     setConnections,
     mapSourceConnectionCollectSWResponse,
     mapSourceConnectionCollectInfraResponse,
+    setConnectionInfraModel,
+    setConnectionSoftwareModel,
     clear,
     withSourceConnection,
     setWithSourceConnection,

--- a/front/src/entities/sourceConnection/model/types.ts
+++ b/front/src/entities/sourceConnection/model/types.ts
@@ -34,14 +34,16 @@ export interface ISourceSoftwareCollectResponse {
 export interface ISourceInfraInfo {
   collectInfraStatus: string;
   collectInfraDateTime: string;
-  infraData: string;
+  // Structured collected infra (object from get-infra-info) shown in the viewer.
+  infraData: any;
   viewInfra: boolean;
 }
 
 export interface ISourceSoftwareCollect {
   collectSwStatus: string;
   collectSwDateTime: string;
-  softwareData: string;
+  // Structured collected software (object from get-software-info).
+  softwareData: any;
   viewSW: boolean;
 }
 

--- a/front/src/entities/sourceService/api/index.ts
+++ b/front/src/entities/sourceService/api/index.ts
@@ -13,6 +13,9 @@ const GET_SOURCE_SERVICE_LIST = 'cm-honeybee/list-source-group';
 const GET_SOURCE_SERVICE = 'cm-honeybee/get-source-group';
 const DELETE_SOURCE_SERVICE = 'cm-honeybee/delete-source-group';
 const GET_INFRA_SOURCE_GROUP = 'cm-honeybee/import-infra-source-group';
+const GET_INFRA_INFO_SOURCE_GROUP = 'cm-honeybee/get-infra-info-source-group';
+const GET_SOFTWARE_INFO_SOURCE_GROUP =
+  'cm-honeybee/get-software-info-source-group';
 const GET_INFRA_INFO_SOURCE_GROUP_REFINE =
   'cm-honeybee/get-infra-info-source-group-refined';
 
@@ -88,6 +91,35 @@ export function useGetInfraSourceGroup(sourceGroupId: string | null) {
     IAxiosResponse<IInfraSourceGroupResponse>,
     Required<Pick<RequestBodyWrapper<{ sgId: string | null }>, 'pathParams'>>
   >(GET_INFRA_SOURCE_GROUP, requestWrapper);
+}
+
+// Structured (non-refined) view of the collected infra for a source group —
+// the JSON form of the data collected by import-infra-source-group.
+export function useGetInfraInfoSourceGroup(sourceGroupId: string | null) {
+  const requestWrapper: Required<
+    Pick<RequestBodyWrapper<{ sgId: string | null }>, 'pathParams'>
+  > = {
+    pathParams: { sgId: sourceGroupId },
+  };
+
+  return useAxiosPost<
+    IAxiosResponse<any>,
+    Required<Pick<RequestBodyWrapper<{ sgId: string | null }>, 'pathParams'>>
+  >(GET_INFRA_INFO_SOURCE_GROUP, requestWrapper);
+}
+
+// Structured (non-refined) view of the collected software for a source group.
+export function useGetSoftwareInfoSourceGroup(sourceGroupId: string | null) {
+  const requestWrapper: Required<
+    Pick<RequestBodyWrapper<{ sgId: string | null }>, 'pathParams'>
+  > = {
+    pathParams: { sgId: sourceGroupId },
+  };
+
+  return useAxiosPost<
+    IAxiosResponse<any>,
+    Required<Pick<RequestBodyWrapper<{ sgId: string | null }>, 'pathParams'>>
+  >(GET_SOFTWARE_INFO_SOURCE_GROUP, requestWrapper);
 }
 
 export function useGetInfraSourceGroupInfraRefine(

--- a/front/src/features/sourceServices/jsonViewer/ui/JsonViewer.vue
+++ b/front/src/features/sourceServices/jsonViewer/ui/JsonViewer.vue
@@ -20,6 +20,8 @@ const metaEditorRef = ref<InstanceType<typeof EnhancedJsonEditor> | null>(null);
 const modelEditorRef = ref<InstanceType<typeof EnhancedJsonEditor> | null>(null);
 
 // formData를 JSON string으로 변환
+// formData is the structured collected meta (an object from get-infra-info /
+// get-software-info), so it is stringified directly for the tree view.
 const metaDataString = computed(() => {
   if (!props.formData) return '{}';
   if (typeof props.formData === 'string') return props.formData;
@@ -122,7 +124,7 @@ function handleModelUpdate(value: string) {
     <!-- 좌측: Meta (읽기 전용) -->
     <p-pane-layout class="json-editor-pane">
       <p class="editor-title">Meta (data)</p>
-      <div class="editor-wrapper">
+      <div class="editor-wrapper" data-testid="source-meta-json">
         <EnhancedJsonEditor
           ref="metaEditorRef"
           :model-value="metaDataString"
@@ -155,7 +157,7 @@ function handleModelUpdate(value: string) {
     <!-- 우측: Model (편집 가능) -->
     <p-pane-layout class="json-editor-pane">
       <p class="editor-title">Model</p>
-      <div class="editor-wrapper">
+      <div class="editor-wrapper" data-testid="source-model-json">
         <EnhancedJsonEditor
           ref="modelEditorRef"
           :model-value="modelDataString"

--- a/front/src/widgets/source/sourceConnections/sourceConnectionDetail/infraCollect/ui/SourceInfraCollect.vue
+++ b/front/src/widgets/source/sourceConnections/sourceConnectionDetail/infraCollect/ui/SourceInfraCollect.vue
@@ -2,7 +2,7 @@
 import { PButton, PDefinitionTable, PStatus } from '@cloudforet-test/mirinae';
 import { onBeforeMount, watch } from 'vue';
 import { useSourceInfraCollectModel } from '@/widgets/source/sourceConnections/sourceConnectionDetail/infraCollect/model/sourceInfraCollectModel';
-import { useCollectInfra } from '@/entities/sourceConnection/api';
+import { useCollectInfra, useGetInfraInfo } from '@/entities/sourceConnection/api';
 import { showErrorMessage,
   toErrorMessage,
 } from '@/shared/utils';
@@ -28,6 +28,7 @@ const resCollectInfra = useCollectInfra({
   sgId: null,
   connId: null,
 });
+const resGetInfraInfo = useGetInfraInfo(null, null);
 
 watch(
   () => props.connectionId,
@@ -41,6 +42,8 @@ onBeforeMount(() => {
 });
 
 function handleCollectInfra() {
+  // Collect the infra (import-infra), then load its structured JSON form
+  // (get-infra-info) for the viewer's left "Meta" pane.
   resCollectInfra
     .execute({
       pathParams: {
@@ -49,13 +52,25 @@ function handleCollectInfra() {
       },
     })
     .then(res => {
-      if (res.data.responseData) {
-        if (props.connectionId) {
-          sourceConnectionStore.mapSourceConnectionCollectInfraResponse(
-            res.data.responseData,
-          );
-          loadInfraCollectTableData(props.connectionId);
-        }
+      if (!res.data.responseData || !props.connectionId) return undefined;
+      sourceConnectionStore.mapSourceConnectionCollectInfraResponse(
+        res.data.responseData,
+      );
+      loadInfraCollectTableData(props.connectionId);
+      return resGetInfraInfo.execute({
+        pathParams: {
+          sgId: props.sourceGroupId,
+          connId: props.connectionId,
+        },
+      });
+    })
+    .then(infoRes => {
+      if (infoRes && infoRes.data.responseData && props.connectionId) {
+        sourceConnectionStore.setConnectionInfraModel(
+          props.connectionId,
+          infoRes.data.responseData,
+        );
+        loadInfraCollectTableData(props.connectionId);
       }
     })
     .catch(e => {

--- a/front/src/widgets/source/sourceConnections/sourceConnectionDetail/softwareCollect/ui/SourceSoftwareCollect.vue
+++ b/front/src/widgets/source/sourceConnections/sourceConnectionDetail/softwareCollect/ui/SourceSoftwareCollect.vue
@@ -2,7 +2,7 @@
 import { PButton, PDefinitionTable, PStatus } from '@cloudforet-test/mirinae';
 import { onBeforeMount, watch } from 'vue';
 import { useSourceSoftwareCollectModel } from '@/widgets/source/sourceConnections/sourceConnectionDetail/softwareCollect/model/sourceSoftwareCollectModel';
-import { useCollectSW } from '@/entities/sourceConnection/api';
+import { useCollectSW, useGetSoftwareInfo } from '@/entities/sourceConnection/api';
 import { showErrorMessage,
   toErrorMessage,
 } from '@/shared/utils';
@@ -27,6 +27,7 @@ const resCollectSW = useCollectSW({
   sgId: null,
   connId: null,
 });
+const resGetSoftwareInfo = useGetSoftwareInfo(null, null);
 
 watch(
   () => props.connectionId,
@@ -41,6 +42,8 @@ onBeforeMount(() => {
 });
 
 function handleClickCollectSW() {
+  // Collect the software (import-software), then load its structured JSON form
+  // (get-software-info) for the viewer's left "Meta" pane.
   resCollectSW
     .execute({
       pathParams: {
@@ -49,9 +52,23 @@ function handleClickCollectSW() {
       },
     })
     .then(res => {
-      if (res.data.responseData && props.connectionId) {
-        sourceConnectionStore.mapSourceConnectionCollectSWResponse(
-          res.data.responseData,
+      if (!res.data.responseData || !props.connectionId) return undefined;
+      sourceConnectionStore.mapSourceConnectionCollectSWResponse(
+        res.data.responseData,
+      );
+      loadInfraSWTableData(props.connectionId);
+      return resGetSoftwareInfo.execute({
+        pathParams: {
+          sgId: props.sourceGroupId,
+          connId: props.connectionId,
+        },
+      });
+    })
+    .then(infoRes => {
+      if (infoRes && infoRes.data.responseData && props.connectionId) {
+        sourceConnectionStore.setConnectionSoftwareModel(
+          props.connectionId,
+          infoRes.data.responseData,
         );
         loadInfraSWTableData(props.connectionId);
       }

--- a/front/src/widgets/source/sourceServices/sourceServiceDetail/ui/SourceServiceDetail.vue
+++ b/front/src/widgets/source/sourceServices/sourceServiceDetail/ui/SourceServiceDetail.vue
@@ -4,6 +4,8 @@ import { onBeforeMount, reactive, ref, watch, watchEffect } from 'vue';
 import { useSourceServiceDetailModel } from '@/widgets/source/sourceServices/sourceServiceDetail/model/sourceServiceDetailModel';
 import {
   useGetInfraSourceGroup,
+  useGetInfraInfoSourceGroup,
+  useGetSoftwareInfoSourceGroup,
   useGetSourceService,
 } from '@/entities/sourceService/api';
 import { showErrorMessage } from '@/shared/utils';
@@ -36,11 +38,13 @@ const refreshSourceGroupConnectionInfoStatus =
   useRefreshSourceGroupConnectionInfoStatus(null);
 const getSourceService = useGetSourceService(null);
 const resGetInfraSourceGroup = useGetInfraSourceGroup(null);
+const resGetInfraInfoSourceGroup = useGetInfraInfoSourceGroup(null);
 const infraModel = ref<any>(null);
 
 // Software 관련 상태
 const softwareModel = ref<any>(null);
 const resCollectSWSourceGroup = useCollectSWSourceGroup(null);
+const resGetSoftwareInfoSourceGroup = useGetSoftwareInfoSourceGroup(null);
 
 const modalState = reactive({
   open: false,
@@ -81,6 +85,8 @@ watchEffect(() => {
 });
 
 function getSourceGroupInfras() {
+  // Collect the infra (import-infra-source-group), then show its structured
+  // JSON form (get-infra-info-source-group) in the viewer's left "Meta" pane.
   resGetInfraSourceGroup
     .execute({
       pathParams: {
@@ -88,14 +94,21 @@ function getSourceGroupInfras() {
       },
     })
     .then(res => {
-      if (res.data.responseData) {
-        sourceServiceStore.mappinginfraModel(
-          props.selectedServiceId,
-          res.data.responseData,
-        );
-        infraModel.value = res.data.responseData;
-        loadSourceServiceData(props.selectedServiceId);
-
+      if (!res.data.responseData) return undefined;
+      sourceServiceStore.mappinginfraModel(
+        props.selectedServiceId,
+        res.data.responseData,
+      );
+      loadSourceServiceData(props.selectedServiceId);
+      return resGetInfraInfoSourceGroup.execute({
+        pathParams: {
+          sgId: props.selectedServiceId,
+        },
+      });
+    })
+    .then(infoRes => {
+      if (infoRes && infoRes.data.responseData) {
+        infraModel.value = infoRes.data.responseData;
         // 데이터를 가져온 후 자동으로 모달 열기
         modalState.open = true;
       }
@@ -107,6 +120,8 @@ function getSourceGroupInfras() {
 }
 
 function getSourceGroupSoftware() {
+  // Collect the software (import-software-source-group), then show its
+  // structured JSON form (get-software-info-source-group) in the pane.
   resCollectSWSourceGroup
     .execute({
       pathParams: {
@@ -114,14 +129,21 @@ function getSourceGroupSoftware() {
       },
     })
     .then(res => {
-      if (res.data.responseData) {
-        sourceServiceStore.mappingSoftwareModel(
-          props.selectedServiceId,
-          res.data.responseData,
-        );
-        softwareModel.value = res.data.responseData;
-        loadSourceServiceData(props.selectedServiceId);
-
+      if (!res.data.responseData) return undefined;
+      sourceServiceStore.mappingSoftwareModel(
+        props.selectedServiceId,
+        res.data.responseData,
+      );
+      loadSourceServiceData(props.selectedServiceId);
+      return resGetSoftwareInfoSourceGroup.execute({
+        pathParams: {
+          sgId: props.selectedServiceId,
+        },
+      });
+    })
+    .then(infoRes => {
+      if (infoRes && infoRes.data.responseData) {
+        softwareModel.value = infoRes.data.responseData;
         // 데이터를 가져온 후 자동으로 모달 열기
         softwareModalState.open = true;
       }


### PR DESCRIPTION
## 문제
Source Services > Collect Infra 시 좌측 "Meta (data)" pane에 소스 서버의 메타 정보가 RAW 형태로 표현됐다. 수집 API(`import-infra` / `import-infra-source-group`)의 응답은 인프라 정보를 escape된 JSON 문자열 필드(`infra_data`)로 담고 있어, 뷰어에서 계층 없는 문자열 blob으로 보였다.

## 수정
RAW로 표시되던 내용을 JSON 형태로 바꾼다 — 강제 파싱이 아니라 호출 API를 변경했다.

- Collect Infra → `import-infra`(수집 수행) 후, 같은 데이터를 구조화 JSON으로 주는 `get-infra-info`를 호출해 그 결과를 좌측 pane에 표시.
- 그룹 경로는 `get-infra-info-source-group`, 소프트웨어는 `get-software-info`(-source-group).
- 좌/우 pane에 e2e용 `data-testid` 부여.

## 검증
원격 dev(front-dev)에서 실화면 검증 — Collect Infra 시 pane이 `get-infra-info`의 구조화 JSON 트리(`servers › compute › cpu/memory/disk/os/kernel …`)로 표시됨. before: `infra_data` 문자열 blob.

---
- [BAR-1590](https://mzdevs.atlassian.net/browse/BAR-1590)