### PR TITLE
feat(notification): fly an envelope into the badge on arrival instead of a toast

### DIFF
--- a/front/src/entities/notification/lib/notificationStore.ts
+++ b/front/src/entities/notification/lib/notificationStore.ts
@@ -8,7 +8,6 @@ import {
   type NotificationLevel,
   type NotificationCategory,
 } from '@/entities/notification/api';
-import { showNotificationToast } from '@/shared/utils';
 
 /**
  * 알림 배지
@@ -49,6 +48,16 @@ export function setNotificationPopupEnabled(on: boolean): void {
   localStorage.setItem(POPUP_KEY, String(on));
 }
 
+/**
+ * Arrival pulse (BAR-1579).
+ *
+ * Bumped once whenever a poll brings a *genuinely new* notification (not the login backlog).
+ * The topbar watches this and plays the arrival cue — an envelope flying into the badge — so
+ * the store stays free of any DOM/animation concern. One bump per poll however many arrived;
+ * the badge count already says how many wait.
+ */
+export const arrivalSeq = ref(0);
+
 // Ids seen on the previous poll, so a poll can tell which notifications are new and only toast
 // those. `primed` guards the first load — logging in must not flash the whole backlog as if it
 // had just arrived.
@@ -75,14 +84,11 @@ export async function loadNotifications(): Promise<void> {
   try {
     const res = await useListNotifications().execute();
     const items = res.data.responseData ?? [];
-    // Flash the ones that were not here last time. Only after the first load (so a login does
-    // not replay the backlog), and only when the popup is on.
-    if (primed && notificationPopupEnabled.value) {
-      for (const n of items) {
-        if (!knownIds.has(n.id)) {
-          showNotificationToast(n.category ?? 'Notification', n.message, n.level);
-        }
-      }
+    // Signal the ones that were not here last time. Only after the first load (so a login does
+    // not replay the backlog as if it just arrived). The topbar owns the popup setting and the
+    // animation; here we only say "something new came in".
+    if (primed && items.some(n => !knownIds.has(n.id))) {
+      arrivalSeq.value += 1;
     }
     knownIds = new Set(items.map(n => n.id));
     primed = true;

--- a/front/src/features/topbar/topbarNotifications/ui/TopBarNotifications.vue
+++ b/front/src/features/topbar/topbarNotifications/ui/TopBarNotifications.vue
@@ -6,6 +6,8 @@ import { TopBarNotificationContextMenu } from '@/widgets/layout';
 import {
   notificationCount,
   hasErrorNotification,
+  arrivalSeq,
+  notificationPopupEnabled,
 } from '@/entities/notification/lib/notificationStore';
 
 interface Props {
@@ -60,6 +62,98 @@ onUnmounted(() => {
   document.title = baseTitle;
 });
 
+/**
+ * Arrival cue (BAR-1579) — the "you got mail" gesture.
+ *
+ * An envelope pops up at the screen centre, jitters like a ringing alarm for a beat, then
+ * swoops into the notification badge and vanishes. The eye follows the movement to the badge
+ * and catches the count going up — that is the whole point. This is only a cue: the message
+ * itself lives in the inbox, so nothing is lost if it is missed.
+ *
+ * Built by hand rather than as a toast. It is appended straight to <body> and driven by the
+ * Web Animations API, which keeps it above any open modal (mirinae's stacking tops out at
+ * 99999) and free of overflow clipping. Vue 2.7 has no <Teleport>, hence the imperative DOM.
+ */
+const badgeEl = ref<HTMLElement | null>(null);
+let cuePlaying = false;
+
+const playArrivalCue = () => {
+  if (typeof document === 'undefined' || cuePlaying) return;
+  const badge = badgeEl.value;
+  if (!badge) return;
+  const r = badge.getBoundingClientRect();
+  if (!r.width && !r.height) return; // badge not laid out — nothing to fly to
+
+  cuePlaying = true;
+  const dx = r.left + r.width / 2 - window.innerWidth / 2;
+  const dy = r.top + r.height / 2 - window.innerHeight / 2;
+
+  const el = document.createElement('div');
+  el.setAttribute('aria-hidden', 'true');
+  el.style.cssText = [
+    'position:fixed',
+    'left:50%',
+    'top:50%',
+    'width:64px',
+    'height:64px',
+    'margin:-32px 0 0 -32px',
+    'z-index:2147483000',
+    'pointer-events:none',
+    'opacity:0',
+    'will-change:transform,opacity',
+    'filter:drop-shadow(0 6px 14px rgba(0,0,0,.25))',
+  ].join(';');
+  el.innerHTML = `
+    <svg viewBox="0 0 64 64" width="64" height="64" xmlns="http://www.w3.org/2000/svg">
+      <rect x="6" y="14" width="52" height="36" rx="5" fill="#f6c445" stroke="#d9a520" stroke-width="2"/>
+      <path d="M8 18 L32 36 L56 18" fill="none" stroke="#d9a520" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <circle cx="52" cy="16" r="8" fill="#e5484d"/>
+    </svg>`;
+  document.body.appendChild(el);
+
+  const done = () => {
+    el.remove();
+    cuePlaying = false;
+  };
+
+  // Phase 1 — appear, then jitter in place like a ringing alarm (~1.2s).
+  const ring = el.animate(
+    [
+      { transform: 'scale(0.3) rotate(0deg)', opacity: 0, offset: 0 },
+      { transform: 'scale(1.12) rotate(0deg)', opacity: 1, offset: 0.14 },
+      { transform: 'scale(1) rotate(-14deg)', opacity: 1, offset: 0.28 },
+      { transform: 'scale(1) rotate(12deg)', opacity: 1, offset: 0.42 },
+      { transform: 'scale(1) rotate(-10deg)', opacity: 1, offset: 0.56 },
+      { transform: 'scale(1) rotate(9deg)', opacity: 1, offset: 0.7 },
+      { transform: 'scale(1) rotate(-5deg)', opacity: 1, offset: 0.84 },
+      { transform: 'scale(1) rotate(0deg)', opacity: 1, offset: 1 },
+    ],
+    { duration: 1200, easing: 'ease-in-out' },
+  );
+
+  ring.finished
+    .then(() =>
+      // Phase 2 — swoop into the badge, shrinking and fading (~0.7s).
+      el.animate(
+        [
+          { transform: 'translate(0,0) scale(1)', opacity: 1 },
+          { transform: `translate(${dx}px, ${dy}px) scale(0.15)`, opacity: 0 },
+        ],
+        {
+          duration: 700,
+          easing: 'cubic-bezier(.5,0,.9,.35)',
+          fill: 'forwards',
+        },
+      ).finished,
+    )
+    .then(done)
+    .catch(done);
+};
+
+watch(arrivalSeq, () => {
+  if (notificationPopupEnabled.value) playArrivalCue();
+});
+
 const showNotiMenu = () => {
   if (!props.visible) setVisible(true);
 };
@@ -88,6 +182,7 @@ const handleNotiButtonClick = () => {
     -->
     <p-tooltip :contents="visible ? '' : 'Notifications'" position="absolute">
       <span
+        ref="badgeEl"
         :class="{ 'menu-button': true, opened: visible, arrived: justArrived }"
         tabindex="0"
         role="button"

--- a/front/src/features/topbar/topbarNotifications/ui/TopBarNotifications.vue
+++ b/front/src/features/topbar/topbarNotifications/ui/TopBarNotifications.vue
@@ -133,15 +133,26 @@ const playArrivalCue = () => {
 
   ring.finished
     .then(() =>
-      // Phase 2 — swoop into the badge, shrinking and fading (~0.7s).
+      // Phase 2 — rise all the way to the badge, then vanish *into* it. Stays fully opaque for
+      // most of the trip (fading early made it look like it disappeared mid-air); only the last
+      // stretch shrinks and fades as it lands on the badge.
       el.animate(
         [
-          { transform: 'translate(0,0) scale(1)', opacity: 1 },
-          { transform: `translate(${dx}px, ${dy}px) scale(0.15)`, opacity: 0 },
+          { transform: 'translate(0,0) scale(1)', opacity: 1, offset: 0 },
+          {
+            transform: `translate(${dx * 0.9}px, ${dy * 0.9}px) scale(0.55)`,
+            opacity: 1,
+            offset: 0.8,
+          },
+          {
+            transform: `translate(${dx}px, ${dy}px) scale(0.12)`,
+            opacity: 0,
+            offset: 1,
+          },
         ],
         {
-          duration: 700,
-          easing: 'cubic-bezier(.5,0,.9,.35)',
+          duration: 1000,
+          easing: 'cubic-bezier(.35,0,.6,1)',
           fill: 'forwards',
         },
       ).finished,

--- a/front/src/shared/utils/notice-alert-helper/index.ts
+++ b/front/src/shared/utils/notice-alert-helper/index.ts
@@ -120,27 +120,3 @@ export const showInfoMessage = (infoTitle: string, infoText: string) => {
     });
   }
 };
-
-/**
- * A short toast for an arriving notification.
- *
- * A notification is kept in the inbox regardless; this only *also* flashes it on screen for a
- * couple of seconds so someone on another screen sees it happen. Errors use the alert style;
- * everything else is informational. Two seconds by request — long enough to read one line.
- */
-export const showNotificationToast = (
-  title: string,
-  text: string,
-  level?: string,
-) => {
-  if (Vue) {
-    Vue.notify({
-      group: 'toastTopCenter',
-      type: level === 'Error' ? 'alert' : 'info',
-      title,
-      text,
-      duration: 2000,
-      speed: 400,
-    });
-  }
-};


### PR DESCRIPTION
## 변경 내용

새 알림 도착 시 화면 중앙 편지 아이콘이 잠깐 흔들린 뒤 우측 상단 알림 배지로 날아가며 사라지는 도착 큐. 기존 상단 중앙 텍스트 토스트를 대체합니다(토스트가 작업 중 시스템 에러처럼 보이던 문제). Web Animations API로 `<body>`에 직접 붙여 열린 모달 위에서도 최상위로 표시되고, 내용은 표시하지 않아(신호만) 자세한 내용은 우측 상단 알림에서 확인합니다.

## 경위

이 UI는 PR #108에 *설명은 담겼으나*, 실제 머지된 head(`2fd839e`)는 이전 텍스트 토스트 구현이었습니다. 편지로 전환한 커밋(`15deccb`·`a808394`)이 #108 머지 이후 브랜치에만 남아 develop에 반영되지 않았습니다. 본 PR로 그 두 커밋을 develop에 반영합니다.

## 변경 파일

- `entities/notification/lib/notificationStore.ts` — 토스트 호출을 편지 도착 큐 트리거로 전환
- `features/topbar/topbarNotifications/ui/TopBarNotifications.vue` — 편지 등장·흔들림·배지 비행·페이드(Web Animations, `<body>` 부착)
- `shared/utils/notice-alert-helper/index.ts` — 사용처 없는 `showNotificationToast` 제거

## 검증

cherry-pick·onecloud-ci 빌드·로컬 컨테이너 스모크 정합 확인. 편지 UX 동작 자체는 #108 원 세션에서 dev 시각 검증됨.

- [BAR-1579](https://mzdevs.atlassian.net/browse/BAR-1579) 알림 도착 애니메이션(편지) develop 반영