### PR TITLE
feat(workflow): show that a run is alive, and say what it waits for after Run

### DIFF
--- a/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
@@ -471,22 +471,65 @@ export function useWorkflowRunViewerModel() {
     }
   }
 
+  /**
+   * Wait until the run we just started shows up.
+   *
+   * The engine accepts the request immediately but the new run does not appear in the run
+   * list right away, so reading the list at once picks up the *previous* run as the newest.
+   * This used to be handled by sleeping a fixed 3 seconds, which is wrong in both directions:
+   * if it is ready sooner we wait for nothing, and if 3 seconds is not enough we select the
+   * wrong run. And for those 3 seconds the screen did not change at all, so the click looked
+   * like it had done nothing.
+   *
+   * So we ask repeatedly instead, and the screen says it is starting the whole time.
+   */
+  const NEW_RUN_INTERVAL_MS = 1000;
+  const NEW_RUN_TIMEOUT_MS = 30000;
+
+  /** A run has been requested and we are waiting for it to appear — drives the screen's lock */
+  const runStarting = ref(false);
+
   /** Run directly from the viewer — no need to go to the list screen */
   async function runWorkflow() {
     const wfId = workflow.value?.id;
     if (!wfId) return;
-    const { execute } = useRunWorkflow(wfId);
-    await execute();
-    // Hand it to the app-wide checker so the outcome is caught after leaving this screen.
-    // The name has to be captured here — at completion there is only the run id.
-    void trackWorkflow({
-      wfId,
-      label: workflow.value?.name || wfId,
-      action: 'run',
-    });
-    // Right after DAG registration the run may not appear immediately, so reopen after a short delay
-    await new Promise(resolve => setTimeout(resolve, 3000));
-    await open(wfId);
+
+    // Turn this on *before* the request. What the user is waiting on starts at the click,
+    // not at the response.
+    runStarting.value = true;
+    loadError.value = null;
+    try {
+      const known = new Set(runs.value.map(r => r.workflow_run_id));
+      const { execute } = useRunWorkflow(wfId);
+      await execute();
+      // Hand it to the app-wide checker so the outcome is caught after leaving this screen.
+      // The name has to be captured here — at completion there is only the run id.
+      void trackWorkflow({
+        wfId,
+        label: workflow.value?.name || wfId,
+        action: 'run',
+      });
+
+      const deadline = Date.now() + NEW_RUN_TIMEOUT_MS;
+      let started: IWorkflowRun | undefined;
+      for (;;) {
+        await loadRuns(wfId);
+        // Identify it by "a run id we had not seen", not by time — the engine's clock and
+        // ours are different clocks, and sorting by start_date would pick the previous run
+        // whenever they disagree.
+        started = runs.value.find(r => !known.has(r.workflow_run_id));
+        if (started) break;
+        if (Date.now() + NEW_RUN_INTERVAL_MS > deadline) break;
+        await new Promise(resolve => setTimeout(resolve, NEW_RUN_INTERVAL_MS));
+      }
+
+      // If it never showed up, do not leave the screen on the old run pretending nothing
+      // happened — reopen so at least what *is* readable is drawn, and the run list is fresh.
+      if (started) await selectRun(wfId, started.workflow_run_id);
+      else await open(wfId);
+    } finally {
+      runStarting.value = false;
+    }
   }
 
   // Ensure polling does not linger after leaving the screen
@@ -529,6 +572,7 @@ export function useWorkflowRunViewerModel() {
     cancelRerun,
     cloneForEdit,
     progress,
+    runStarting,
     runWorkflow,
     stopPolling,
   };

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/RunGraph.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/RunGraph.vue
@@ -37,9 +37,19 @@ const emit = defineEmits<{ (e: 'select', taskId: string): void }>();
 const NAME_PADDING_X = 14;
 const NAME_CHAR_WIDTH = 7.1; // average glyph width for 13px semibold
 
+/*
+  The running spinner sits in the node's top-right corner. Its slot is reserved for *every*
+  node, not only the running one — if the name budget changed with the state, a name would
+  grow and shrink again as the task started and finished.
+*/
+const SPINNER_RADIUS = 7;
+const SPINNER_INSET_X = 20;
+const SPINNER_INSET_Y = 18;
+const NAME_RESERVED_X = SPINNER_INSET_X + SPINNER_RADIUS;
+
 function fitName(name: string): string {
   const max = Math.floor(
-    (GRAPH_NODE_WIDTH - NAME_PADDING_X * 2) / NAME_CHAR_WIDTH,
+    (GRAPH_NODE_WIDTH - NAME_PADDING_X - NAME_RESERVED_X) / NAME_CHAR_WIDTH,
   );
   return name.length <= max ? name : `${name.slice(0, max - 1)}…`;
 }
@@ -213,6 +223,26 @@ const edgePaths = computed(() =>
             · try {{ item.tryNumber }}
           </template>
         </text>
+
+        <!--
+          A task that takes a long time keeps the same box and the same "Running" text for
+          minutes on end, so nothing on screen moves and it reads as frozen. This spinner is
+          the one thing that keeps moving, and it says *which* task the run is sitting on.
+
+          The wrapper only positions it; the rotation is applied to the arc, whose local
+          origin (0 0) is the circle's own center after that translate.
+        -->
+        <g
+          v-if="item.kind === 'running'"
+          class="run-graph__spinner"
+          data-testid="workflow-run-node-spinner"
+          :transform="`translate(${item.x + NODE_WIDTH - SPINNER_INSET_X}, ${
+            item.y + SPINNER_INSET_Y
+          })`"
+        >
+          <circle :r="SPINNER_RADIUS" class="run-graph__spinner-track" />
+          <circle :r="SPINNER_RADIUS" class="run-graph__spinner-arc" />
+        </g>
       </g>
     </svg>
   </div>
@@ -306,6 +336,30 @@ const edgePaths = computed(() =>
   animation: run-graph-pulse 1.2s ease-in-out infinite;
 }
 
+/* Running spinner — circumference at r=7 is ~44, so 33/11 leaves a quarter open */
+.run-graph__spinner-track {
+  fill: none;
+  stroke: #c7d4f7;
+  stroke-width: 2;
+}
+
+.run-graph__spinner-arc {
+  fill: none;
+  stroke: #3e6ee8;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-dasharray: 33 11;
+  /* the arc's own center — the parent <g> already translated it into place */
+  transform-origin: 0 0;
+  animation: run-graph-spin 0.9s linear infinite;
+}
+
+@keyframes run-graph-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @keyframes run-graph-pulse {
   0%,
   100% {
@@ -316,8 +370,13 @@ const edgePaths = computed(() =>
   }
 }
 
+/*
+  With motion turned off the ring stays put. It is still an open ring only running tasks
+  carry, so "which task is running" survives — only the movement goes away.
+*/
 @media (prefers-reduced-motion: reduce) {
-  .run-graph__node--running .run-graph__box {
+  .run-graph__node--running .run-graph__box,
+  .run-graph__spinner-arc {
     animation: none;
   }
 }

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -13,6 +13,7 @@ import SoftwareMigrationOverlay from '../../workflowHistory/ui/SoftwareMigration
 import { graphPixelWidth } from '@/entities/workflow/lib/runGraph';
 import { useWorkflowRunViewerModel } from '../model/workflowRunViewerModel';
 import {
+  isRunFinished,
   taskStateBadgeType,
   taskStateKind,
   taskStateLabel,
@@ -55,6 +56,7 @@ const {
   designerSupport,
   progress,
   isPolling,
+  runStarting,
   cloning,
   loadError,
   logText,
@@ -226,11 +228,19 @@ function requestRerunFailed() {
   });
 }
 
-/** Is it running now — the progress indicator and the button lock use the same basis */
-const runInProgress = computed(() =>
-  ['running', 'queued'].includes(
-    (selectedRun.value?.state ?? '').toLowerCase(),
-  ),
+/**
+ * Is it running now — the progress indicator and the button lock use the same basis.
+ *
+ * **"Has not finished" is the basis, not a list of in-flight state names.** The engine passes
+ * the execution engine's state strings through as they are, and a just-started run reports
+ * `scheduled` or `none` before it reports `running`. Listing the names meant those moments fell
+ * outside every state and the screen went blank again — right after the click, which is exactly
+ * when the user is watching. Polling already stops on the same "finished" judgement, so this
+ * also keeps the indicator and the polling from disagreeing: while we are still asking, the
+ * screen says so.
+ */
+const runInProgress = computed(
+  () => !!selectedRun.value && !isRunFinished(selectedRun.value.state),
 );
 
 /*
@@ -274,11 +284,14 @@ const { pause: pauseClock, resume: resumeClock } = useIntervalFn(
   screen says which one is being shown.
 */
 const elapsedFrom = computed(() => {
+  // Drop the ones that are not real times *before* choosing the earliest — otherwise the
+  // engine's zero value sorts first and wins, and we end up with no counter at all even
+  // though a task did report a genuine start.
   const starts = runningTasks.value
-    .map(t => t.startDate)
-    .filter(Boolean)
-    .sort();
-  return starts[0] ?? selectedRun.value?.start_date ?? null;
+    .map(t => startedAtMs(t.startDate))
+    .filter((ms): ms is number => ms !== null)
+    .sort((a, b) => a - b);
+  return starts[0] ?? startedAtMs(selectedRun.value?.start_date);
 });
 
 function formatElapsed(ms: number): string {
@@ -289,12 +302,27 @@ function formatElapsed(ms: number): string {
   return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
 }
 
+/**
+ * A run that has been queued but not actually begun reports its start time as the engine's
+ * zero value (`0001-01-01T00:00:00Z`), and a task that has not started reports an empty
+ * string. Neither is a time — counting from them printed things like "17755691h 11m", which
+ * destroys any trust in the number next to it. Anything at or before the epoch is not a real
+ * start, so we show nothing rather than a number that cannot be true.
+ */
+function startedAtMs(value?: string | null): number | null {
+  if (!value) return null;
+  const parsed = new Date(value).getTime();
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
 const elapsedText = computed(() => {
-  if (!elapsedFrom.value) return '';
-  const ms = now.value - new Date(elapsedFrom.value).getTime();
+  const startedAt = elapsedFrom.value;
+  if (startedAt === null) return '';
+  const ms = now.value - startedAt;
   // A clock skew between the engine and the browser can put the start in the future.
-  // Showing a negative or nonsensical duration is worse than showing none.
-  if (!Number.isFinite(ms) || ms < 0) return '';
+  // Showing a negative duration is worse than showing none.
+  if (ms < 0) return '';
   return formatElapsed(ms);
 });
 
@@ -478,7 +506,7 @@ async function onRunChange(runId: string) {
                 data-testid="workflow-viewer-run-first-btn"
                 size="sm"
                 style-type="primary"
-                :disabled="runInProgress"
+                :disabled="runInProgress || runStarting"
                 @click="showRunConfirm = true"
               >
                 Run
@@ -531,7 +559,7 @@ async function onRunChange(runId: string) {
                 data-testid="workflow-viewer-run-btn"
                 size="sm"
                 style-type="primary"
-                :disabled="runInProgress"
+                :disabled="runInProgress || runStarting"
                 @click="showRunConfirm = true"
               >
                 Start new run
@@ -636,8 +664,28 @@ async function onRunChange(runId: string) {
       <div
         class="run-viewer__graph"
         data-testid="workflow-run-graph"
+        :class="{ 'run-viewer__graph--locked': runStarting }"
         :style="{ flexBasis: graphFlexBasis }"
       >
+        <!--
+          From the click until the new run can be drawn, the graph still shows the *previous*
+          run. Leaving it live would let the user read a stale picture as the new run's, so we
+          gray it out and say what we are waiting for. It sits on top rather than replacing the
+          graph — losing the picture entirely reads as if something broke.
+        -->
+        <div
+          v-if="runStarting"
+          class="run-viewer__starting"
+          data-testid="workflow-run-starting"
+        >
+          <span class="run-viewer__running-spinner" aria-hidden="true" />
+          <p class="run-viewer__starting-title">Preparing run data…</p>
+          <p class="run-viewer__starting-hint">
+            The run has been requested. Waiting until it appears in the run
+            history — the graph below still shows the previous run until then.
+          </p>
+        </div>
+
         <!--
           Progress appears in the row above the graph *only while it is running*.
           Leaving the bar on a finished run keeps a 100%-filled bar stuck there, which
@@ -1051,6 +1099,7 @@ async function onRunChange(runId: string) {
           <p-button
             data-testid="workflow-run-confirm-ok"
             style-type="primary"
+            :disabled="runStarting"
             @click="confirmRun"
           >
             Run
@@ -1080,6 +1129,7 @@ async function onRunChange(runId: string) {
           <p-button
             data-testid="workflow-run-confirm-ok"
             style-type="primary"
+            :disabled="runStarting"
             @click="confirmRun"
           >
             Start new run
@@ -1287,6 +1337,46 @@ async function onRunChange(runId: string) {
   graph. To react to the actual remaining width rather than the viewport, we use wrap instead
   of a media query.
 */
+/*
+  While a run is starting, the graph below is grayed out and the overlay sits on top of it.
+  `position: relative` is what the overlay anchors to.
+*/
+.run-viewer__graph {
+  position: relative;
+}
+
+.run-viewer__graph--locked > *:not(.run-viewer__starting) {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.run-viewer__starting {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 1rem;
+  border-radius: 0.375rem;
+  background: rgb(250 250 251 / 82%);
+  text-align: center;
+}
+
+.run-viewer__starting-title {
+  font-weight: 600;
+  font-size: 0.8125rem;
+  color: #374151;
+}
+
+.run-viewer__starting-hint {
+  font-size: 0.75rem;
+  color: #6b6e78;
+  max-width: 20rem;
+}
+
 .run-viewer__graph {
   /*
     flex-basis is decided by the script based on the number of parallel branches. Turning

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue';
+import { useIntervalFn } from '@vueuse/core';
 import {
   PBadge,
   PButton,
@@ -13,6 +14,7 @@ import { graphPixelWidth } from '@/entities/workflow/lib/runGraph';
 import { useWorkflowRunViewerModel } from '../model/workflowRunViewerModel';
 import {
   taskStateBadgeType,
+  taskStateKind,
   taskStateLabel,
 } from '@/entities/workflow/lib/taskState';
 
@@ -229,6 +231,84 @@ const runInProgress = computed(() =>
   ['running', 'queued'].includes(
     (selectedRun.value?.state ?? '').toLowerCase(),
   ),
+);
+
+/*
+  Which task the run is currently sitting on, and for how long.
+
+  The progress bar only moves when a task *finishes*. A task that takes ten minutes leaves
+  the bar at the same width and every number on screen unchanged for ten minutes, and the
+  screen becomes indistinguishable from one that has died. So we say the task's name out
+  loud and let the seconds tick — a number that keeps changing is the proof that the screen
+  is still alive, and the elapsed time is what tells you whether it is taking unusually long.
+*/
+const nodeNameById = computed(
+  () => new Map(graph.value.nodes.map(n => [n.id, n.name])),
+);
+
+const runningTasks = computed(() =>
+  instances.value
+    .filter(i => taskStateKind(i.state) === 'running')
+    .map(i => ({
+      name: nodeNameById.value.get(i.task_id) ?? i.task_name ?? i.task_id,
+      startDate: i.start_date,
+    })),
+);
+
+const runningTaskNames = computed(() => runningTasks.value.map(t => t.name));
+
+/** Ticks only while a run is in progress — a clock that runs on a finished run is pure waste */
+const now = ref(Date.now());
+const { pause: pauseClock, resume: resumeClock } = useIntervalFn(
+  () => {
+    now.value = Date.now();
+  },
+  1000,
+  { immediate: false },
+);
+
+/*
+  Where the elapsed time is counted from. While tasks are running it is the earliest of
+  them (that is the one the run is waiting on); between tasks there is nothing running, so
+  it falls back to the run's own start. The two mean different things, so the wording on
+  screen says which one is being shown.
+*/
+const elapsedFrom = computed(() => {
+  const starts = runningTasks.value
+    .map(t => t.startDate)
+    .filter(Boolean)
+    .sort();
+  return starts[0] ?? selectedRun.value?.start_date ?? null;
+});
+
+function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  if (total < 60) return `${total}s`;
+  const minutes = Math.floor(total / 60);
+  if (minutes < 60) return `${minutes}m ${total % 60}s`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}
+
+const elapsedText = computed(() => {
+  if (!elapsedFrom.value) return '';
+  const ms = now.value - new Date(elapsedFrom.value).getTime();
+  // A clock skew between the engine and the browser can put the start in the future.
+  // Showing a negative or nonsensical duration is worse than showing none.
+  if (!Number.isFinite(ms) || ms < 0) return '';
+  return formatElapsed(ms);
+});
+
+watch(
+  runInProgress,
+  inProgress => {
+    if (!inProgress) {
+      pauseClock();
+      return;
+    }
+    now.value = Date.now();
+    resumeClock();
+  },
+  { immediate: true },
 );
 
 const hasFailedTask = computed(() =>
@@ -589,6 +669,52 @@ async function onRunChange(runId: string) {
             <template v-if="progress.failed">
               · {{ progress.failed }} failed
             </template>
+          </span>
+        </div>
+
+        <!--
+          The progress bar only moves when a task finishes, so during a long task nothing on
+          this screen changes and it reads as frozen. This sits in the gap between the bar and
+          the graph — the empty strip you look at while waiting — and keeps moving: a spinner,
+          the name of the task being waited on, and a second counter that ticks.
+        -->
+        <div
+          v-if="runInProgress && graph.nodes.length"
+          class="run-viewer__running"
+          data-testid="workflow-run-running"
+        >
+          <!--
+            Not PSpinner: it only comes in gray, and on this near-white panel a gray ring at
+            its 2s turn is easy to miss — which is the one thing this indicator must not be.
+            This is the same spinner the running node carries, so the two read as one signal.
+          -->
+          <span class="run-viewer__running-spinner" aria-hidden="true" />
+          <span
+            v-if="runningTaskNames.length"
+            class="run-viewer__running-text"
+            data-testid="workflow-run-running-tasks"
+          >
+            Running: {{ runningTaskNames.join(', ') }}
+            <span v-if="elapsedText" class="run-viewer__running-elapsed">
+              · elapsed
+              <b data-testid="workflow-run-elapsed">{{ elapsedText }}</b>
+            </span>
+          </span>
+          <!--
+            Between tasks nothing is running for a moment. Saying "Running: —" would be a lie,
+            so we name what is actually happening and count from the run's own start instead —
+            hence the different wording on the elapsed time, which now means something else.
+          -->
+          <span
+            v-else
+            class="run-viewer__running-text"
+            data-testid="workflow-run-running-tasks"
+          >
+            Waiting for the next task to start
+            <span v-if="elapsedText" class="run-viewer__running-elapsed">
+              · run elapsed
+              <b data-testid="workflow-run-elapsed">{{ elapsedText }}</b>
+            </span>
           </span>
         </div>
 
@@ -1485,6 +1611,73 @@ async function onRunChange(runId: string) {
 
 .run-viewer__progress-count {
   white-space: nowrap;
+}
+
+/*
+  Running strip — the gap between the progress bar and the first task box. Centered because
+  that empty middle is where the eye rests while waiting, and it is the same place no matter
+  how wide the graph is laid out.
+*/
+.run-viewer__running {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem 0.125rem;
+  font-size: 0.75rem;
+  color: #374151;
+}
+
+.run-viewer__running-spinner {
+  flex: 0 0 auto;
+  width: 0.875rem;
+  height: 0.875rem;
+  border: 2px solid #c7d4f7;
+  border-top-color: #2563eb;
+  border-radius: 9999px;
+  animation: run-viewer-spin 0.9s linear infinite;
+}
+
+@keyframes run-viewer-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/*
+  Wrap at spaces, and break inside a word only when that single word is itself too wide for
+  the column — a task name can be long. With break-all the sentence split mid-word
+  ("...has been goi / ng for"), which reads as a rendering fault.
+*/
+.run-viewer__running-text {
+  min-width: 0;
+  text-align: center;
+  overflow-wrap: anywhere;
+  word-break: normal;
+}
+
+.run-viewer__running-elapsed {
+  color: #6b7280;
+  white-space: nowrap;
+}
+
+.run-viewer__running-elapsed b {
+  /* the one number that keeps changing — it should be the thing you can find at a glance */
+  color: #2563eb;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/*
+  With motion turned off the ring stops, but the elapsed counter keeps ticking — the "this is
+  still alive" signal survives without anything spinning.
+*/
+@media (prefers-reduced-motion: reduce) {
+  .run-viewer__running-spinner,
+  .run-viewer__progress-dot {
+    animation: none;
+  }
 }
 
 @keyframes run-viewer-blink {

--- a/front/tests/e2e/pages/workflow.page.ts
+++ b/front/tests/e2e/pages/workflow.page.ts
@@ -223,6 +223,14 @@ export class WorkflowPage {
     return this.page.getByTestId('workflow-run-running');
   }
 
+  /**
+   * The layer shown from the moment Run is pressed until the new run can be drawn. It covers
+   * the graph, which still shows the *previous* run until then.
+   */
+  get runStarting(): Locator {
+    return this.page.getByTestId('workflow-run-starting');
+  }
+
   /** "Running: <task>" or "Waiting for the next task to start" */
   get runningTasksText(): Locator {
     return this.page.getByTestId('workflow-run-running-tasks');

--- a/front/tests/e2e/pages/workflow.page.ts
+++ b/front/tests/e2e/pages/workflow.page.ts
@@ -212,6 +212,35 @@ export class WorkflowPage {
     return this.page.getByTestId('workflow-run-progress-count');
   }
 
+  /**
+   * "Still running" indicators. The progress bar only moves when a task finishes, so during a
+   * long task these are the only things that keep moving — which task is being waited on, and
+   * how long it has been.
+   *
+   * Only present while the run is in flight, so assert on them *during* a run, not after.
+   */
+  get runningIndicator(): Locator {
+    return this.page.getByTestId('workflow-run-running');
+  }
+
+  /** "Running: <task>" or "Waiting for the next task to start" */
+  get runningTasksText(): Locator {
+    return this.page.getByTestId('workflow-run-running-tasks');
+  }
+
+  /** The elapsed counter. It must actually change — a frozen one proves nothing */
+  get runElapsed(): Locator {
+    return this.page.getByTestId('workflow-run-elapsed');
+  }
+
+  /**
+   * Spinners drawn on running task nodes. Count them rather than checking a style —
+   * the rotation is CSS, which tells you nothing about which task is running.
+   */
+  get runNodeSpinners(): Locator {
+    return this.page.getByTestId('workflow-run-node-spinner');
+  }
+
   /** Which run is currently being viewed */
   get runMeta() {
     return this.page.getByTestId('workflow-run-meta');

--- a/front/tests/e2e/specs/workflow-run-viewer.spec.ts
+++ b/front/tests/e2e/specs/workflow-run-viewer.spec.ts
@@ -158,6 +158,48 @@ test.describe('워크플로우 실행 상태 뷰어', () => {
   });
 
   /**
+   * Pressing Run used to leave the screen untouched for three to five seconds, because the
+   * code slept a fixed 3s before re-reading. Now it says what it is waiting for and asks the
+   * engine until the new run actually exists.
+   *
+   * The run list answers in well under a second, so the layer would be gone before it could be
+   * asserted. We delay *that one response* — timing only, not content — which is also what
+   * makes this test deterministic rather than a race.
+   */
+  test('실행을 누르면 준비 중임을 바로 말하고, 준비되면 그때 그린다', async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const workflow = new WorkflowPage(page);
+    await workflow.gotoWorkflows();
+    await workflow.openRunViewer(RUNNABLE_WORKFLOW);
+    await expect(workflow.runStarting).toBeHidden();
+    // An earlier test may have left a run in flight, and Run is locked while one is. Wait it
+    // out rather than clicking a disabled button and blaming the screen for not reacting.
+    await expect(workflow.runningIndicator).toBeHidden({ timeout: 120_000 });
+
+    let delayed = 0;
+    await page.route('**/api/cm-cicada/get-workflow-runs', async route => {
+      if (delayed < 3) {
+        delayed += 1;
+        await new Promise(resolve => setTimeout(resolve, 1500));
+      }
+      await route.continue();
+    });
+
+    await page.getByTestId('workflow-viewer-run-btn').click();
+    await page.getByTestId('workflow-run-confirm-ok').click();
+
+    // The screen must react to the click, not to the response
+    await expect(workflow.runStarting).toBeVisible({ timeout: 3000 });
+    await expect(workflow.runStarting).toContainText('Preparing run data');
+
+    // ...and it must not linger past readiness — a layer that never lifts is its own failure
+    await expect(workflow.runStarting).toBeHidden({ timeout: 60_000 });
+    await expect(workflow.runMeta).toContainText('Run ID');
+  });
+
+  /**
    * A long task leaves the progress bar at the same width and every number unchanged, so the
    * screen becomes indistinguishable from one that has died. What has to be proven is not
    * "an indicator exists" but that **something keeps changing while a task is running** —
@@ -174,8 +216,9 @@ test.describe('워크플로우 실행 상태 뷰어', () => {
     await workflow.gotoWorkflows();
     await workflow.openRunViewer(RUNNABLE_WORKFLOW);
 
-    // Nothing is running yet, so neither indicator may be present
-    await expect(workflow.runningIndicator).toBeHidden();
+    // Nothing is running yet, so neither indicator may be present. A run left over from an
+    // earlier test has to finish first — that is a stale screen, not this test's subject.
+    await expect(workflow.runningIndicator).toBeHidden({ timeout: 120_000 });
     expect(await workflow.runNodeSpinners.count()).toBe(0);
 
     await page.getByTestId('workflow-viewer-run-btn').click();
@@ -183,7 +226,16 @@ test.describe('워크플로우 실행 상태 뷰어', () => {
 
     const elapsedSeen = new Set<string>();
     let sawIndicator = false;
-    let sawNodeSpinner = false;
+    let sawRunningNode = false;
+    /*
+      The spinner's contract is *one spinner per running node* — checked on every sample, so a
+      spinner that stops appearing, or one left turning on a finished task, is caught either way.
+
+      We do not require "a running node was seen at least once": the screen re-reads status
+      every 3s while this sample workflow's tasks finish in one or two, so a task can start and
+      end between two reads. Demanding it would fail on timing, not on the product.
+    */
+    const mismatches: string[] = [];
 
     // Sample faster than the 1s tick so the change is actually observable
     for (let i = 0; i < 150; i++) {
@@ -194,22 +246,38 @@ test.describe('워크플로우 실행 상태 뷰어', () => {
         sawIndicator = true;
         const elapsed = await workflow.runElapsed.innerText().catch(() => '');
         if (elapsed) elapsedSeen.add(elapsed);
-        if ((await workflow.runNodeSpinners.count().catch(() => 0)) > 0) {
-          sawNodeSpinner = true;
-        }
       } else if (sawIndicator && i > 20) {
         break; // the run finished
       }
+
+      const runningNodes = await page
+        .locator('[data-testid="workflow-run-node"][data-state="running"]')
+        .count()
+        .catch(() => 0);
+      const spinners = await workflow.runNodeSpinners.count().catch(() => 0);
+      if (runningNodes > 0) sawRunningNode = true;
+      if (runningNodes !== spinners) {
+        mismatches.push(`t${i}: running=${runningNodes} spinner=${spinners}`);
+      }
+
       await page.waitForTimeout(600);
     }
+    console.log('running node observed during this run:', sawRunningNode);
 
     expect(sawIndicator, '실행 중 표시가 나타났다').toBe(true);
-    expect(sawNodeSpinner, '실행 중 태스크에 스피너가 붙었다').toBe(true);
+    expect(mismatches, '실행 중 노드마다 스피너가 정확히 하나씩').toEqual([]);
     expect(elapsedSeen.size, '경과 시간이 실제로 흘렀다').toBeGreaterThan(1);
+    // A queued run reports the engine's zero start time, and counting from it printed
+    // "17755691h 11m". A number that cannot be true discredits everything beside it.
+    expect(
+      [...elapsedSeen].filter(t => /\d{5,}h/.test(t)),
+      '말이 되는 경과 시간만 나왔다',
+    ).toEqual([]);
 
     // Once the run ends, the indicators must go away — a spinner left turning on a finished
     // run says "still working" when nothing is.
     await expect(workflow.runningIndicator).toBeHidden({ timeout: 30_000 });
     expect(await workflow.runNodeSpinners.count()).toBe(0);
+    expect(await workflow.runProgress.isVisible()).toBe(false);
   });
 });

--- a/front/tests/e2e/specs/workflow-run-viewer.spec.ts
+++ b/front/tests/e2e/specs/workflow-run-viewer.spec.ts
@@ -18,6 +18,16 @@ import { WorkflowPage } from '../pages/workflow.page';
 const WORKFLOW =
   process.env.E2E_RUN_VIEWER_WORKFLOW ?? 'demo-runviewer-parallel';
 
+/**
+ * A workflow this spec is allowed to actually *run*. The "still running" indicators only
+ * exist while a run is in flight, so they cannot be checked on history alone.
+ *
+ * It must be a workflow whose tasks touch nothing outside themselves (the sample example
+ * tasks). Pointing this at a migration workflow would create real cloud resources.
+ */
+const RUNNABLE_WORKFLOW =
+  process.env.E2E_RUN_VIEWER_RUNNABLE_WORKFLOW ?? 'e2e-sample-bash-workflow';
+
 test.describe('워크플로우 실행 상태 뷰어', () => {
   test.beforeEach(async ({ page }) => {
     const user = getUser('cmiguser');
@@ -145,5 +155,61 @@ test.describe('워크플로우 실행 상태 뷰어', () => {
     // The dropdown collapses once you pick. What you are viewing must remain on screen
     await expect(workflow.runMeta).toContainText('Run ID');
     await expect(page.getByTestId('workflow-run-meta-id')).not.toBeEmpty();
+  });
+
+  /**
+   * A long task leaves the progress bar at the same width and every number unchanged, so the
+   * screen becomes indistinguishable from one that has died. What has to be proven is not
+   * "an indicator exists" but that **something keeps changing while a task is running** —
+   * hence the assertion on the counter *ticking*, not merely on it being visible.
+   *
+   * This one actually starts a run, so it points at a workflow that touches nothing outside
+   * itself. Do not aim it at a migration workflow.
+   */
+  test('오래 걸리는 태스크에서도 지금 무엇이 도는지·얼마나 됐는지가 계속 움직인다', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const workflow = new WorkflowPage(page);
+    await workflow.gotoWorkflows();
+    await workflow.openRunViewer(RUNNABLE_WORKFLOW);
+
+    // Nothing is running yet, so neither indicator may be present
+    await expect(workflow.runningIndicator).toBeHidden();
+    expect(await workflow.runNodeSpinners.count()).toBe(0);
+
+    await page.getByTestId('workflow-viewer-run-btn').click();
+    await page.getByTestId('workflow-run-confirm-ok').click();
+
+    const elapsedSeen = new Set<string>();
+    let sawIndicator = false;
+    let sawNodeSpinner = false;
+
+    // Sample faster than the 1s tick so the change is actually observable
+    for (let i = 0; i < 150; i++) {
+      const visible = await workflow.runningIndicator
+        .isVisible()
+        .catch(() => false);
+      if (visible) {
+        sawIndicator = true;
+        const elapsed = await workflow.runElapsed.innerText().catch(() => '');
+        if (elapsed) elapsedSeen.add(elapsed);
+        if ((await workflow.runNodeSpinners.count().catch(() => 0)) > 0) {
+          sawNodeSpinner = true;
+        }
+      } else if (sawIndicator && i > 20) {
+        break; // the run finished
+      }
+      await page.waitForTimeout(600);
+    }
+
+    expect(sawIndicator, '실행 중 표시가 나타났다').toBe(true);
+    expect(sawNodeSpinner, '실행 중 태스크에 스피너가 붙었다').toBe(true);
+    expect(elapsedSeen.size, '경과 시간이 실제로 흘렀다').toBeGreaterThan(1);
+
+    // Once the run ends, the indicators must go away — a spinner left turning on a finished
+    // run says "still working" when nothing is.
+    await expect(workflow.runningIndicator).toBeHidden({ timeout: 30_000 });
+    expect(await workflow.runNodeSpinners.count()).toBe(0);
   });
 });


### PR DESCRIPTION
## 배경

Run Status 탭은 진행률 바·상태 배지·태스크 노드 색을 모두 **태스크가 끝날 때만** 갱신한다. 그래서 인프라 마이그레이션처럼 태스크 하나가 10분 걸리는 워크플로우에서는 그 10분 동안 화면의 어떤 픽셀도 바뀌지 않고, **폴링이 죽은 화면과 구별되지 않는다.**

실행 버튼을 눌렀을 때도 3~5초간 화면이 그대로였다. 기다린 게 아니라 코드가 고정 3초를 셌다 — 실행을 걸어도 새 실행이 이력에 곧바로 나타나지 않아, 바로 읽으면 직전 실행을 최신으로 잡기 때문에 둔 여유값이다. 고정 대기는 양방향으로 틀린다: 빨리 준비되면 남은 시간을 버리고, 3초로 모자라면 엉뚱한 실행을 그린다.

## 변경 내용

- **실행 중 태스크에 회전 표시**를 붙여 지금 어느 태스크에서 기다리는 중인지 짚는다. 표시 자리는 상태와 무관하게 모든 노드에서 예약해, 태스크가 시작·종료할 때 이름 폭이 흔들리지 않는다.
- **진행률 바와 그래프 사이 중앙**에 회전 표시·실행 중 태스크 이름·경과 시간을 둔다. "살아 있다"만으로는 이게 정상인지 판단할 수 없고, 매초 바뀌는 숫자가 그 판단 근거다. 도는 태스크가 없는 순간(태스크 사이)에는 기준을 실행 시작으로 바꾸고 문구도 구분한다.
- **실행 직후**: 고정 3초 대기를 없앴다. 클릭 즉시 그래프를 흐리게 덮고 무엇을 기다리는지 적은 뒤, **직전에 없던 실행 id가 이력에 생겼는지 1초 간격으로 확인**해 준비되면 그때 그린다. 새 실행을 시각이 아니라 *몰랐던 id*로 식별하는 것이 중요한데, 엔진과 브라우저는 서로 다른 시계라 시각 정렬은 두 시계가 어긋나는 순간 직전 실행을 집기 때문이다.

### 함께 고친 결함 2건 (검증 중 발견)

- **진행 중 판정이 상태 이름 목록**이라, 갓 시작한 실행이 보고하는 일부 상태 구간에서 표시가 통째로 사라졌다. 판정을 "끝났는가"로 바꿔 **상태 갱신을 멈추는 기준과 일치**시켰다 — 묻고 있는 동안에는 화면도 묻고 있다고 말한다.
- **경과 시간이 `17755691h 11m`으로 표시**됐다. 대기 중인 실행은 시작 시각을 빈 값으로 보고하는데 거기서부터 셌다. 시작으로 볼 수 없는 값이면 아무것도 표시하지 않는다 — 말이 안 되는 숫자 하나가 옆에 있는 정상 정보의 신뢰까지 깎는다.

## 검증

개발 서버 백엔드에 이 브랜치 화면을 붙여 **실제 워크플로우를 실행하며** 관측했다. 외부 자원을 만들지 않는 예제 워크플로우를 대상으로 삼았고, 응답을 가짜로 만들지 않았다.

| 항목 | 결과 |
|---|---|
| 실행 클릭 → 첫 화면 반응 | **0.18~0.20초** (종전 3~5초 무반응) |
| 실행 클릭 → 새 실행 렌더 | **0.42~0.50초** (종전 고정 3초 + 왕복) |
| 실행 중 표시·경과 시간 | 태스크 이름과 함께 0s→1s→2s→3s |
| 실행 종료 후 | 두 표시 모두 소멸 |

첫 조회에서 이미 새 실행이 보여, **종전 고정 3초가 통째로 불필요했음**이 실측으로 확인됐다.

e2e 2건을 새로 추가했다. 경과 시간 회귀 단언을 포함하며, 새 단언이 실제로 실패할 수 있는지 식별자를 일부러 깨뜨려 확인한 뒤 원복했다. 노드 표시 단언은 *실행 중 노드 수 = 표시 수* 불변식으로 두었다 — 화면이 3초마다 상태를 읽는데 예제 태스크는 1~2초에 끝나, "한 번은 봤다"를 요구하면 타이밍으로 흔들린다.

전 항목 통과.

---

- [BAR-1625](https://mzdevs.atlassian.net/browse/BAR-1625) 실행 상태 뷰어에 진행이 살아 있음을 드러내는 표시 — 실행 중 태스크 스피너·경과 시간과 Run 직후 준비 표시