### PR TITLE
fix(workload): cap the load test progress bar at the width of the step list

### DIFF
--- a/front/src/widgets/workload/vm/loadTestProgress/ui/LoadTestProgress.vue
+++ b/front/src/widgets/workload/vm/loadTestProgress/ui/LoadTestProgress.vue
@@ -393,7 +393,7 @@ const hasSteps = computed(() => steps.value.length > 0);
       >
         {{ primaryLine }}
       </p>
-      <div class="lt-bar-row">
+      <div class="lt-bar-row" :class="{ 'is-full': variant === 'full' }">
         <div class="lt-bar" data-testid="load-test-progress-bar">
           <div
             class="lt-fill"
@@ -525,6 +525,16 @@ const hasSteps = computed(() => steps.value.length > 0);
   align-items: center;
   gap: 8px;
   height: 16px;
+}
+
+/* Full panel: cap the row at roughly the width of the step lines below it, so the percentage
+   and the polling spinner sit next to the bar instead of against the right edge of a wide
+   panel — far from the left-aligned step text the eye is already on. Only the full variant is
+   capped; the compact cell in the Information tab keeps filling its column. It is a cap, not a
+   fixed width, so a narrower browser shrinks the whole row with the panel. */
+.lt-bar-row.is-full {
+  width: 100%;
+  max-width: 480px;
 }
 
 .lt-bar {


### PR DESCRIPTION
## 무엇을 고쳤나

부하테스트가 도는 동안 Evaluate Perf 탭 상단 진행률 바가 **패널 전체 폭으로 늘어나** 진행률 숫자와 폴링 스피너가 화면 오른쪽 끝에 놓였습니다. 정작 단계 목록은 왼쪽 정렬이라 "지금 돌고 있는가"를 확인하려면 시선을 화면 반대편까지 옮겨야 했습니다. 1920px 화면에서 바 한 줄이 1,255px인데 그 아래 단계 글자가 차지하는 폭은 약 405px — 나머지가 빈 여백이고 그 끝에서 12px 스피너가 혼자 돌고 있었습니다.

## 원인

되돌림이 아닙니다. 최초 구현의 바는 `width: 60%` · `max-width: 420px`로 짧고 가운데 정렬이었는데, 진행 표시를 세 화면(Evaluate Perf · Information · Load Config)이 공유하도록 공통 컴포넌트로 추출하면서 그 폭 제한이 삭제되고 `flex: 1`(부모 폭을 그대로 채움)로 바뀌었습니다. 폭 제한이 필요한 곳과 필요 없는 곳을 구분하지 않은 것이 원인입니다.

## 변경

한 파일 두 곳입니다.

```
<div class="lt-bar-row" :class="{ 'is-full': variant === 'full' }">

.lt-bar-row.is-full { width: 100%; max-width: 480px; }
```

- 고정 폭이 아니라 **상한**입니다. 패널이 상한보다 넓으면 480px에서 멈추고, 좁으면 패널을 따라 함께 줄어듭니다.
- `full` 변형은 Evaluate Perf 진행 패널 한 곳에서만 쓰므로 **다른 화면은 규칙이 적용되지 않습니다.** Information 탭 Load Status 칸(compact)은 종전대로 칸을 채웁니다.
- 단계 글자 폭에 CSS를 직접 묶는 방식(`fit-content`)은 쓰지 않았습니다. 단계 메시지가 폴링마다 바뀌어 바 폭이 매번 흔들립니다.
- 폴링 스피너는 크기·회전 그대로이고 위치만 진행률 옆으로 옵니다.

## 검증

원격 개발 서버의 브랜치 검증용 front-dev(포트 5174)에 브랜치 CI 이미지를 올려 실화면에서 계측했습니다. 브라우저 폭 7종 · 실행 상태 4종 **전 항목 PASS(7/7), FAIL 없음.**

| 브라우저 폭 | 변경 전 | 변경 후 |
|---:|---:|---:|
| 1920 | 1,255px | **480px** |
| 1280 | 615px | **480px** |
| 1024 이하 | 패널 폭 | 패널 폭 (**차이 없음**) |

- 500~1920px 전 구간에서 **가로 스크롤이 생기지 않습니다.**
- 패널이 이미 상한보다 좁은 구간에서는 변경 전과 측정값이 동일해 **좁은 화면에서 나빠지는 구간이 없습니다.**
- 하위 단계가 없는 단계의 좌우 이동(sweep) 바, 실패 패널·단계 목록, 완료 시 결과 영역 전환 모두 정상.
- Information 탭 compact 표시에 새 클래스가 붙지 않는 것을 확인했습니다.

검증 시점의 개발 서버에는 인프라가 없어 실제 부하테스트를 돌릴 수 없었고, 기존 방식대로 상태 응답을 주입해 표시만 확인했습니다. 이번 변경이 CSS 레이아웃 한정이라 데이터 출처가 측정값에 영향을 주지 않습니다.

이미지 빌드: https://github.com/MZC-CSC/onecloud-ci/actions/runs/30091629424

---

- [BAR-1626](https://mzdevs.atlassian.net/browse/BAR-1626) [cm-butterfly] 부하테스트 진행률 바 폭 제한 (진행 표시 가독성)