### PR TITLE
fix(workload): make Stop work on a running load test

### DIFF
--- a/front/src/entities/vm/api/api.ts
+++ b/front/src/entities/vm/api/api.ts
@@ -54,19 +54,28 @@ export function useRunLoadTest(requestPayload: IRunLoadTestRequest | null) {
   >(RUN_LOAD_TEST, requestBodyWrapper);
 }
 
-// Stop a running load test (StopLoadTest). Identified by loadTestKey.
-export function useStopLoadTest(loadTestKey: string | null) {
+// Stop a running load test (StopLoadTest).
+//
+// cm-ant identifies the run by its key *and* by the node it belongs to, and rejects the request
+// before looking anything up unless nsId, infraId and nodeId are all present. Sending the key
+// alone always comes back 400 "load test stop info is not correct."
+export interface IStopLoadTestRequest {
+  loadTestKey: string;
+  nsId: string;
+  infraId: string;
+  nodeId: string;
+}
+
+export function useStopLoadTest(request: IStopLoadTestRequest | null) {
   const requestBodyWrapper: Required<
-    Pick<RequestBodyWrapper<{ loadTestKey: string } | null>, 'request'>
+    Pick<RequestBodyWrapper<IStopLoadTestRequest | null>, 'request'>
   > = {
-    request: loadTestKey ? { loadTestKey } : null,
+    request,
   };
 
   return useAxiosPost<
     IAxiosResponse<unknown>,
-    Required<
-      Pick<RequestBodyWrapper<{ loadTestKey: string } | null>, 'request'>
-    >
+    Required<Pick<RequestBodyWrapper<IStopLoadTestRequest | null>, 'request'>>
   >(STOP_LOAD_TEST, requestBodyWrapper);
 }
 

--- a/front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue
+++ b/front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue
@@ -49,6 +49,26 @@ function handleOpenLoadconfig() {
 const isLoadTestRunning = computed(() =>
   ['Running', 'Collecting results'].includes(props.loadTestStatus ?? ''),
 );
+
+// Stopping a run means killing the JMeter process on the load generator, so there is nothing to
+// stop until the generator is installed — cm-ant answers a stop request before that point with
+// "load install info: record not found". The phases before it (pre-check, generator install) are
+// short and end on their own, so the button waits for the generator instead of failing.
+//
+// An older cm-ant reports no steps at all; there is nothing to base the decision on, so the
+// button stays available rather than being permanently disabled.
+const canStopLoadTest = computed(() => {
+  const steps = props.loadTestSteps ?? [];
+  if (!steps.length) return true;
+  return steps.some(s => s.name === 'generator_install' && s.status === 'ok');
+});
+
+// Same guard as Load Config: mirinae's disabled is a class only and the click still reaches the
+// element (DESIGN-MIRINAE §1.6), so the handler has to hold the rule too.
+function handleStopLoadTest() {
+  if (!canStopLoadTest.value) return;
+  emit('stopLoadTest');
+}
 const hasLoadTest = computed(() => !!props.loadTestStatus);
 const isLoadTestFailed = computed(() => props.loadTestStatus === 'Failed');
 // Results (charts / aggregation) show only on success. Nothing is fetched while running/failed.
@@ -97,7 +117,13 @@ const isLoadTestCompleted = computed(() => props.loadTestStatus === 'Completed')
           data-testid="vm-load-stop"
           style-type="negative-secondary"
           icon-left="ic_close"
-          @click="emit('stopLoadTest')"
+          :disabled="!canStopLoadTest"
+          :title="
+            canStopLoadTest
+              ? undefined
+              : 'Available once the load generator is installed'
+          "
+          @click="handleStopLoadTest"
         >
           Stop
         </p-button>

--- a/front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue
+++ b/front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue
@@ -50,17 +50,19 @@ const isLoadTestRunning = computed(() =>
   ['Running', 'Collecting results'].includes(props.loadTestStatus ?? ''),
 );
 
-// Stopping a run means killing the JMeter process on the load generator, so there is nothing to
-// stop until the generator is installed — cm-ant answers a stop request before that point with
-// "load install info: record not found". The phases before it (pre-check, generator install) are
-// short and end on their own, so the button waits for the generator instead of failing.
+// Stopping a run kills the JMeter process on the load generator, so it only means anything while
+// JMeter is actually running. Asked earlier, cm-ant fails in two different ways and both reached
+// the screen as a bare 400: before the generator exists it cannot find the install record, and
+// once it exists but the load has not started the kill command matches no process and comes back
+// with a non-zero exit. The phases before the load run — pre-check, generator install, agent
+// install, test plan — are short and end on their own, so the button waits for the load run.
 //
 // An older cm-ant reports no steps at all; there is nothing to base the decision on, so the
 // button stays available rather than being permanently disabled.
 const canStopLoadTest = computed(() => {
   const steps = props.loadTestSteps ?? [];
   if (!steps.length) return true;
-  return steps.some(s => s.name === 'generator_install' && s.status === 'ok');
+  return steps.some(s => s.name === 'jmeter_run' && s.status === 'running');
 });
 
 // Same guard as Load Config: mirinae's disabled is a class only and the click still reaches the
@@ -121,7 +123,7 @@ const isLoadTestCompleted = computed(() => props.loadTestStatus === 'Completed')
           :title="
             canStopLoadTest
               ? undefined
-              : 'Available once the load generator is installed'
+              : 'Available once the load run has started'
           "
           @click="handleStopLoadTest"
         >

--- a/front/src/widgets/workload/vm/vmList/ui/VmList.vue
+++ b/front/src/widgets/workload/vm/vmList/ui/VmList.vue
@@ -154,9 +154,19 @@ async function handleReRun() {
 }
 function handleStopLoadTest() {
   const key = currentLoadTestKey.value;
-  if (!key) return;
+  const nodeId = selectedVm.value?.id;
+  if (!key || !nodeId) return;
+  // cm-ant needs the node the run belongs to, not just the key — without nsId/infraId/nodeId it
+  // rejects the request with 400 before it looks the run up.
   resStopLoadTest
-    .execute({ request: { loadTestKey: key } })
+    .execute({
+      request: {
+        loadTestKey: key,
+        nsId: props.nsId,
+        infraId: props.mciId,
+        nodeId,
+      },
+    })
     .then(() => setVmLoadTestResult())
     .catch(e => showErrorMessage('error', e.errorMsg?.value ?? 'Stop failed'));
 }


### PR DESCRIPTION
## 무엇을 고쳤나

부하테스트 실행 중 **Stop 버튼을 누르면 항상 400**이 나고 실행이 멈추지 않았습니다. 화면에는 `error 400 Bad Request`만 떴습니다.

원인이 **누른 시점에 따라 셋**이었고, 화면에는 전부 같은 문구로 보여 하나의 문제처럼 보였습니다. 개발 서버에서 단계별로 실제로 눌러 확인했습니다.

| 누른 시점 | cm-ant 응답 | 원인 |
|---|---|---|
| 언제든 | `load test stop info is not correct.` | 콘솔이 `loadTestKey`만 보냄. cm-ant는 `nsId`·`infraId`·`nodeId`까지 요구 |
| 발생기 설치 전 | `retrieve load install info: record not found` | 죽일 대상이 아직 없음 |
| 발생기는 있으나 부하 시작 전 | `command execution failed …: Process exited with status 2` | JMeter 미기동이라 kill이 잡을 프로세스가 없음 |

cm-ant의 Stop은 발생기에서 JMeter 프로세스를 kill 하는 것 하나뿐이라 **죽일 것이 있어야만 성립**합니다. 세 번째 경우엔 400을 받고도 **실행이 그대로 완주**합니다 — 눌러도 아무 일이 없습니다.

## 변경

1. **요청에 노드 정보를 함께 보냅니다** — `loadTestKey`와 함께 `nsId`·`infraId`·`nodeId`. 화면이 이미 가진 값들입니다.
2. **Load run이 시작된 뒤에만 Stop을 활성화합니다.** 그 앞 단계(Pre-check · 발생기 설치 · 에이전트 설치 · 테스트 플랜)는 짧고 스스로 끝나므로, 실패하는 버튼을 열어 두는 대신 안내 툴팁과 함께 비활성으로 둡니다.
3. 미리내는 `disabled`를 클래스로만 렌더하고 클릭이 요소까지 도달하므로 **핸들러에도 같은 가드**를 뒀습니다.
4. `steps[]`를 주지 않는 구버전 cm-ant에서는 판단 근거가 없으므로 **종전대로 활성**을 유지합니다.

서버(cm-ant)는 변경하지 않았습니다. 발생기도 뜨지 않은 실행을 중단하는 것 자체가 의미가 없고, 콘솔은 `steps[]`로 지금 어느 단계인지 정확히 알고 있습니다.

## 검증 — 실제 부하테스트로 6/6 PASS

상태 주입이 아니라 개발 서버에서 **실제 실행**했습니다.

| 경과 | 화면 단계 | Stop |
|---:|---|---|
| t+0s | Running | 비활성 |
| t+5s | Load generator install | 비활성 |
| t+15s | Metric agent install | 비활성 |
| **t+20s** | **Load run** | **활성** |

Load run 중 클릭 → 요청에 4개 필드 모두 실림 → **200** `Successfully stop load generator` → **5초 안에 실행 종료**(진행 패널·Stop 버튼 사라짐, 폴링 종료).

판정은 `isEnabled()`가 아니라 클래스로 했습니다 — 미리내의 disabled는 클래스뿐이라 표준 API가 항상 "활성"으로 답합니다.

## 남는 것 (서버 쪽 후속)

중단이 성립하지 않는 구간을 화면에서 가린 것이라 영구 해법은 아닙니다. cm-ant가 단계별 중단 로직과 중단 상태값을 갖추면 이 버튼 제한은 해제할 수 있습니다. 사용자가 중단한 실행이 지금은 실패로 기록되는 것도 같은 이유입니다.

---

- [BAR-1628](https://mzdevs.atlassian.net/browse/BAR-1628) [cm-butterfly] 부하테스트 Stop 버튼이 항상 400 — 요청 필드 누락
- [BAR-1629](https://mzdevs.atlassian.net/browse/BAR-1629) [cm-ant] 부하테스트 단계별 중단(Stop) 대응 로직