### PR TITLE
fix(workflow): say so when a requested run never appears, instead of quietly redrawing

### DIFF
--- a/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
@@ -194,16 +194,27 @@ export function useWorkflowRunViewerModel() {
     }
   }
 
-  async function loadRuns(wfId: string) {
+  /**
+   * Returns the reason it failed, or null on success.
+   *
+   * The caller decides what a failure means. Opening a workflow treats it as "has never run"
+   * (see below), but while we are waiting for a run we just started, the same failure means
+   * *we could not check* — and the user has to be told that rather than left watching a
+   * spinner forever.
+   */
+  async function loadRuns(wfId: string): Promise<string | null> {
     try {
       const { data, execute } = useGetWorkflowRuns(wfId);
       await execute();
       runs.value = data.value?.responseData ?? [];
-    } catch {
+      return null;
+    } catch (e: any) {
       // A workflow that has never run fails to load from the engine — before Airflow has read the
       // new DAG, it appears not to exist. **This is not a failure but "not yet"**, so instead of a
       // red error we show an empty state that invites the user to run it.
-      runs.value = [];
+      // We do not clear the list here: `open()` clears it before calling, and the run-wait loop
+      // must not wipe the run it is still showing just because one query failed.
+      return e?.message ?? 'Failed to load the run history.';
     }
   }
 
@@ -488,6 +499,78 @@ export function useWorkflowRunViewerModel() {
 
   /** A run has been requested and we are waiting for it to appear — drives the screen's lock */
   const runStarting = ref(false);
+  /**
+   * The wait ran out without the run showing up. **This is not "the run failed"** — the engine
+   * accepted the request and may well be running it. What we know is only that we could not
+   * confirm it, so the screen says exactly that and lets the user decide whether to keep
+   * waiting or stop looking.
+   */
+  const runStartTimedOut = ref(false);
+  /** Why the last check failed, when it failed. Empty when the run simply did not appear. */
+  const runStartError = ref<string | null>(null);
+
+  /** What the pending wait is about, so "keep waiting" can resume it */
+  let pendingRunWfId: string | null = null;
+  let pendingKnownRunIds = new Set<string>();
+
+  /**
+   * Wait for the run we just requested to appear in the run history.
+   *
+   * On the way out this used to reopen the whole screen, which threw away what the user was
+   * looking at and *said nothing* — the screen came back looking normal while the run was
+   * nowhere to be seen. Now we stop, keep the screen as it is, and say what happened.
+   */
+  async function waitForNewRun(wfId: string): Promise<void> {
+    runStarting.value = true;
+    runStartTimedOut.value = false;
+    runStartError.value = null;
+
+    const deadline = Date.now() + NEW_RUN_TIMEOUT_MS;
+    let lastError: string | null = null;
+
+    for (;;) {
+      lastError = await loadRuns(wfId);
+      // Identify it by "a run id we had not seen", not by time — the engine's clock and
+      // ours are different clocks, and sorting by start_date would pick the previous run
+      // whenever they disagree.
+      const started = runs.value.find(
+        r => !pendingKnownRunIds.has(r.workflow_run_id),
+      );
+      if (started) {
+        await selectRun(wfId, started.workflow_run_id);
+        runStarting.value = false;
+        return;
+      }
+      if (Date.now() + NEW_RUN_INTERVAL_MS > deadline) break;
+      await new Promise(resolve => setTimeout(resolve, NEW_RUN_INTERVAL_MS));
+    }
+
+    /*
+      A single failed query is not reported: right after a workflow is created the engine
+      answers 404 until it has registered the DAG, and calling that an error would cry wolf on
+      a perfectly normal first run. What matters is whether it was *still* failing when the
+      wait ran out — that is the case where the user needs the reason, not just "not yet".
+    */
+    runStartError.value = lastError;
+    runStartTimedOut.value = true;
+  }
+
+  /** The user chose to wait longer — same wait again, from now */
+  async function keepWaitingForRun(): Promise<void> {
+    if (!pendingRunWfId) return;
+    await waitForNewRun(pendingRunWfId);
+  }
+
+  /**
+   * The user chose to stop waiting. We leave the screen exactly as it is — the run may still
+   * be going, and reopening would hide that by redrawing as if nothing had been asked.
+   */
+  function stopWaitingForRun(): void {
+    runStarting.value = false;
+    runStartTimedOut.value = false;
+    runStartError.value = null;
+    pendingRunWfId = null;
+  }
 
   /** Run directly from the viewer — no need to go to the list screen */
   async function runWorkflow() {
@@ -497,39 +580,33 @@ export function useWorkflowRunViewerModel() {
     // Turn this on *before* the request. What the user is waiting on starts at the click,
     // not at the response.
     runStarting.value = true;
+    runStartTimedOut.value = false;
+    runStartError.value = null;
     loadError.value = null;
+
+    pendingRunWfId = wfId;
+    pendingKnownRunIds = new Set(runs.value.map(r => r.workflow_run_id));
+
     try {
-      const known = new Set(runs.value.map(r => r.workflow_run_id));
       const { execute } = useRunWorkflow(wfId);
       await execute();
-      // Hand it to the app-wide checker so the outcome is caught after leaving this screen.
-      // The name has to be captured here — at completion there is only the run id.
-      void trackWorkflow({
-        wfId,
-        label: workflow.value?.name || wfId,
-        action: 'run',
-      });
-
-      const deadline = Date.now() + NEW_RUN_TIMEOUT_MS;
-      let started: IWorkflowRun | undefined;
-      for (;;) {
-        await loadRuns(wfId);
-        // Identify it by "a run id we had not seen", not by time — the engine's clock and
-        // ours are different clocks, and sorting by start_date would pick the previous run
-        // whenever they disagree.
-        started = runs.value.find(r => !known.has(r.workflow_run_id));
-        if (started) break;
-        if (Date.now() + NEW_RUN_INTERVAL_MS > deadline) break;
-        await new Promise(resolve => setTimeout(resolve, NEW_RUN_INTERVAL_MS));
-      }
-
-      // If it never showed up, do not leave the screen on the old run pretending nothing
-      // happened — reopen so at least what *is* readable is drawn, and the run list is fresh.
-      if (started) await selectRun(wfId, started.workflow_run_id);
-      else await open(wfId);
-    } finally {
-      runStarting.value = false;
+    } catch (e: any) {
+      // The request itself was refused — that *is* a failure, and it is a different one from
+      // "we cannot find the run". Say so and stop; there is nothing to wait for.
+      runStartError.value = e?.message ?? 'Failed to start this workflow.';
+      runStartTimedOut.value = true;
+      return;
     }
+
+    // Hand it to the app-wide checker so the outcome is caught after leaving this screen.
+    // The name has to be captured here — at completion there is only the run id.
+    void trackWorkflow({
+      wfId,
+      label: workflow.value?.name || wfId,
+      action: 'run',
+    });
+
+    await waitForNewRun(wfId);
   }
 
   // Ensure polling does not linger after leaving the screen
@@ -573,6 +650,10 @@ export function useWorkflowRunViewerModel() {
     cloneForEdit,
     progress,
     runStarting,
+    runStartTimedOut,
+    runStartError,
+    keepWaitingForRun,
+    stopWaitingForRun,
     runWorkflow,
     stopPolling,
   };

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
@@ -562,14 +562,24 @@ export function useWorkflowRunViewerModel() {
   }
 
   /**
-   * The user chose to stop waiting. We leave the screen exactly as it is — the run may still
-   * be going, and reopening would hide that by redrawing as if nothing had been asked.
+   * The user chose to stop waiting.
+   *
+   * **This does not cancel the run** — there is no path from here that stops it, and the engine
+   * may well be running it. It only stops us looking for it.
+   *
+   * We do refresh once on the way out, because after all that waiting the screen may no longer
+   * match reality. Reopening is safe in both directions: with no history at all the screen falls
+   * back to the un-run state, and after a re-run the latest run is picked up again. What was
+   * wrong before was reopening *silently at the timeout*, as if nothing had been asked — doing
+   * it because the user asked to stop is a different thing.
    */
-  function stopWaitingForRun(): void {
+  async function stopWaitingForRun(): Promise<void> {
+    const wfId = pendingRunWfId;
     runStarting.value = false;
     runStartTimedOut.value = false;
     runStartError.value = null;
     pendingRunWfId = null;
+    if (wfId) await open(wfId);
   }
 
   /** Run directly from the viewer — no need to go to the list screen */

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -705,11 +705,12 @@ async function onRunChange(runId: string) {
               class="run-viewer__starting-title run-viewer__starting-title--warn"
               data-testid="workflow-run-start-timeout"
             >
-              The run has not shown up yet
+              The new run still cannot be found
             </p>
             <p class="run-viewer__starting-hint">
-              The run was requested, but it has not appeared in the run history.
-              It may still be starting, or the server may not be answering.
+              It has been a while, and the run you started has still not
+              appeared in the run history. Something may be wrong with the
+              server. What would you like to do?
             </p>
             <p
               v-if="runStartError"
@@ -733,12 +734,17 @@ async function onRunChange(runId: string) {
                 style-type="tertiary"
                 @click="stopWaitingForRun"
               >
-                Stop waiting
+                Cancel
               </p-button>
             </div>
+            <!--
+              "Cancel" is about *this wait*, not about the run. Nothing here stops a run, and a
+              user who reads it the other way would walk away believing they had stopped it.
+            -->
             <p class="run-viewer__starting-hint">
-              Stopping only stops looking. It does not cancel the run, and the
-              graph below stays on the run you were viewing.
+              Cancelling stops waiting only — it does not stop the run, which
+              may still be going. The screen is refreshed so it shows where
+              things actually stand.
             </p>
           </template>
         </div>

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -57,6 +57,10 @@ const {
   progress,
   isPolling,
   runStarting,
+  runStartTimedOut,
+  runStartError,
+  keepWaitingForRun,
+  stopWaitingForRun,
   cloning,
   loadError,
   logText,
@@ -678,12 +682,65 @@ async function onRunChange(runId: string) {
           class="run-viewer__starting"
           data-testid="workflow-run-starting"
         >
-          <span class="run-viewer__running-spinner" aria-hidden="true" />
-          <p class="run-viewer__starting-title">Preparing run data…</p>
-          <p class="run-viewer__starting-hint">
-            The run has been requested. Waiting until it appears in the run
-            history — the graph below still shows the previous run until then.
-          </p>
+          <!--
+            Still waiting. Nothing is wrong yet, so this says only what it is waiting for.
+          -->
+          <template v-if="!runStartTimedOut">
+            <span class="run-viewer__running-spinner" aria-hidden="true" />
+            <p class="run-viewer__starting-title">Preparing run data…</p>
+            <p class="run-viewer__starting-hint">
+              The run has been requested. Waiting until it appears in the run
+              history — the graph below still shows the previous run until then.
+            </p>
+          </template>
+
+          <!--
+            The wait ran out. **Do not say the run failed** — the engine took the request and
+            may be running it right now; what we know is that we could not confirm it. Saying
+            nothing and quietly redrawing (what this used to do) is worse: the screen comes
+            back looking normal while the run is nowhere to be seen.
+          -->
+          <template v-else>
+            <p
+              class="run-viewer__starting-title run-viewer__starting-title--warn"
+              data-testid="workflow-run-start-timeout"
+            >
+              The run has not shown up yet
+            </p>
+            <p class="run-viewer__starting-hint">
+              The run was requested, but it has not appeared in the run history.
+              It may still be starting, or the server may not be answering.
+            </p>
+            <p
+              v-if="runStartError"
+              class="run-viewer__starting-error"
+              data-testid="workflow-run-start-error"
+            >
+              {{ runStartError }}
+            </p>
+            <div class="run-viewer__starting-actions">
+              <p-button
+                data-testid="workflow-run-start-keep-waiting"
+                size="sm"
+                style-type="primary"
+                @click="keepWaitingForRun"
+              >
+                Keep waiting
+              </p-button>
+              <p-button
+                data-testid="workflow-run-start-stop-waiting"
+                size="sm"
+                style-type="tertiary"
+                @click="stopWaitingForRun"
+              >
+                Stop waiting
+              </p-button>
+            </div>
+            <p class="run-viewer__starting-hint">
+              Stopping only stops looking. It does not cancel the run, and the
+              graph below stays on the run you were viewing.
+            </p>
+          </template>
         </div>
 
         <!--
@@ -1374,7 +1431,27 @@ async function onRunChange(runId: string) {
 .run-viewer__starting-hint {
   font-size: 0.75rem;
   color: #6b6e78;
-  max-width: 20rem;
+  max-width: 22rem;
+}
+
+.run-viewer__starting-title--warn {
+  color: #8a5a17;
+}
+
+.run-viewer__starting-error {
+  max-width: 22rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.25rem;
+  background: #fdf3f3;
+  color: #b93c3c;
+  font-size: 0.75rem;
+  word-break: break-all;
+}
+
+.run-viewer__starting-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.25rem 0;
 }
 
 .run-viewer__graph {


### PR DESCRIPTION
## 배경

실행을 요청하면 화면은 새 실행이 이력에 나타날 때까지 기다린다. 30초가 지나도 나타나지 않으면 **화면을 그냥 다시 열었다.** 두 가지가 잘못됐다.

- **아무 말도 하지 않는다.** 화면이 정상처럼 다시 그려지는데 방금 요청한 실행은 어디에도 없다. 사용자는 실행이 걸렸는지조차 모른다.
- **보고 있던 것을 버린다.** 열어 두었던 실행 화면이 통째로 초기화된다.

## 변경 내용

- 30초가 지나도 실행이 보이지 않으면 **사실대로 알리고 계속 기다릴지 취소할지 고르게** 한다.
- 실행 요청 자체가 거부되면 그 에러를 바로 보여주고 기다리지 않는다 — 기다릴 대상이 없다.
- 대기가 끝난 시점에도 조회가 실패 중이었다면 **그 사유를 함께** 보여준다.
- **취소는 기다리기만 멈춘다.** 실행을 중단시키지 않으며, 그 점을 화면에 적었다. 취소 시 화면을 한 번 갱신해 현재 상태를 다시 반영한다.

**"실행이 실패했다"고 단정하지 않는다.** 엔진은 요청을 받아들였고 지금 돌고 있을 수도 있다. 아는 것은 *확인하지 못했다*는 것뿐이라 딱 그만큼만 말한다.

**조회가 한 번 실패한 것은 알리지 않는다.** 워크플로우를 갓 만들면 엔진이 DAG를 등록할 때까지 없는 것으로 응답하므로, 한 번 실패했다고 에러를 띄우면 정상적인 첫 실행에서 헛경보가 난다. 대기가 끝나는 시점에도 여전히 실패 중이었는지만 본다.

> 실행 자체를 중단시키는 기능은 별도 미구현 항목이다. 여기서 말하는 취소는 화면이 기다리기를 멈추는 것이다.

## 검증

실행 이력 조회만 503으로 실패시켜 30초 대기가 끝나는 경로를 실제로 지나가게 하고 화면을 관측했다. **응답 내용을 지어낸 것이 아니라 그 조회를 실패시킨 것**이며, 30초를 채워야만 도달하는 경로라 다른 방법이 없다.

| 확인 | 결과 |
|---|---|
| 대기가 끝나면 사실대로 말한다 | PASS |
| 조회 실패 사유를 함께 보여준다 | PASS |
| 보고 있던 실행 화면을 버리지 않는다 | PASS — 실행 ID가 클릭 전과 동일 |
| 계속 기다리기 → 조회 정상화되면 그때 그린다 | PASS |
| 취소하면 기다리기만 멈추고 화면을 갱신한다 | PASS |
| 취소가 실행을 중단시키지 않음을 화면이 밝힌다 | PASS |

**주목할 만한 결과** — 타임아웃 후 취소했더니 갱신된 화면이 **실제로는 시작돼 있던 실행**을 잡았다. 종전처럼 말없이 넘어갔다면 사용자는 그 실행의 존재를 몰랐을 것이다.

**이 경로에는 자동 검증을 두지 않았다.** 30초를 채워야 도달하므로 시나리오 테스트에 넣으면 매 실행이 그 시간을 문다. 실행 결과는 나중에 확인하면 되는 것이지 과정을 실시간으로 지켜볼 이유가 없다는 판단에 따른다.

---

- [BAR-1633](https://mzdevs.atlassian.net/browse/BAR-1633) 실행 요청 후 실행이 나타나지 않을 때 조용히 넘어가지 않고 알린다