### PR TITLE
fix(workflow): make the timeout message readable and keep it from being clipped

### DIFF
--- a/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
@@ -214,7 +214,7 @@ export function useWorkflowRunViewerModel() {
       // red error we show an empty state that invites the user to run it.
       // We do not clear the list here: `open()` clears it before calling, and the run-wait loop
       // must not wipe the run it is still showing just because one query failed.
-      return e?.message ?? 'Failed to load the run history.';
+      return e?.message ?? 'Failed to load the run information.';
     }
   }
 

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -680,6 +680,7 @@ async function onRunChange(runId: string) {
         <div
           v-if="runStarting"
           class="run-viewer__starting"
+          :class="{ 'run-viewer__starting--inflow': runStartTimedOut }"
           data-testid="workflow-run-starting"
         >
           <!--
@@ -705,13 +706,19 @@ async function onRunChange(runId: string) {
               class="run-viewer__starting-title run-viewer__starting-title--warn"
               data-testid="workflow-run-start-timeout"
             >
-              The new run still cannot be found
+              Cannot find the run information yet
+            </p>
+            <!--
+              One sentence per line. Run together as a single paragraph, the three things this
+              says — what happened, what it might mean, what we are asking — blur into one.
+            -->
+            <p class="run-viewer__starting-hint">
+              It has been a while, but the run you started has not appeared yet.
             </p>
             <p class="run-viewer__starting-hint">
-              It has been a while, and the run you started has still not
-              appeared in the run history. Something may be wrong with the
-              server. What would you like to do?
+              Something may be wrong with the server.
             </p>
+            <p class="run-viewer__starting-hint">What would you like to do?</p>
             <p
               v-if="runStartError"
               class="run-viewer__starting-error"
@@ -741,7 +748,12 @@ async function onRunChange(runId: string) {
               "Cancel" is about *this wait*, not about the run. Nothing here stops a run, and a
               user who reads it the other way would walk away believing they had stopped it.
             -->
-            <p class="run-viewer__starting-hint">
+            <!--
+              Sits apart from the buttons on purpose. Pressed up against them it reads as a
+              label *on* the buttons, and the error box above starts to look as though it
+              contained them too.
+            -->
+            <p class="run-viewer__starting-hint run-viewer__starting-note">
               Cancelling stops waiting only — it does not stop the run, which
               may still be going. The screen is refreshed so it shows where
               things actually stand.
@@ -1428,6 +1440,18 @@ async function onRunChange(runId: string) {
   text-align: center;
 }
 
+/*
+  While waiting it floats over the graph — it is two short lines and the graph underneath is
+  worth keeping in view. Once it turns into a message with buttons it no longer fits inside a
+  small graph box, and an overlay would simply clip the title off the top. So that state takes
+  its place in the flow and the box grows with it (the graph beneath stays dimmed either way).
+*/
+.run-viewer__starting--inflow {
+  position: static;
+  background: transparent;
+  padding: 1rem 0.75rem 0.5rem;
+}
+
 .run-viewer__starting-title {
   font-weight: 600;
   font-size: 0.8125rem;
@@ -1446,6 +1470,7 @@ async function onRunChange(runId: string) {
 
 .run-viewer__starting-error {
   max-width: 22rem;
+  margin-top: 0.5rem;
   padding: 0.375rem 0.5rem;
   border-radius: 0.25rem;
   background: #fdf3f3;
@@ -1457,7 +1482,12 @@ async function onRunChange(runId: string) {
 .run-viewer__starting-actions {
   display: flex;
   gap: 0.5rem;
-  margin: 0.25rem 0;
+  margin: 0.875rem 0 0;
+}
+
+/* keep the caveat off the buttons — see the template comment */
+.run-viewer__starting-note {
+  margin-top: 0.875rem;
 }
 
 .run-viewer__graph {


### PR DESCRIPTION
[PR #127](https://github.com/MZC-CSC/cm-butterfly/pull/127) 머지 후 실화면 검토에서 나온 지적을 반영한다.

| 지적 | 반영 |
|---|---|
| "실행 이력"이 아니라 **실행 정보**다 | 제목 `Cannot find the run information yet`, 실패 사유 `Failed to load the run information.` |
| 전부 한 줄로 붙어 있다 | *무슨 일이 있었는지 / 무엇을 뜻할 수 있는지 / 무엇을 묻는지* 를 **한 문장씩 줄을 나눠** 표시 |
| 버튼 바로 밑에 설명이 붙어 있다 | 실패 사유 · 버튼 · 설명 사이에 각각 여백 |
| 실패 사유 박스 안에 버튼이 있는 것 아닌가 | 아니다 — 별개 요소인데 간격이 없어 그렇게 보였고, 위 여백으로 해소 |

## 함께 잡은 렌더 결함

안내가 길어지자 **그래프 박스 높이를 넘어 제목이 위로 잘려 나갔다.** 안내를 그래프 위에 띄우지 않고 흐름 안에 두어 박스가 함께 늘어나도록 바꿨다(그래프는 그대로 흐리게 유지). 기다리는 동안 뜨는 짧은 안내는 종전대로 그래프 위에 뜬다 — 두 줄뿐이라 잘릴 일이 없고 아래 그래프를 가리지 않는 편이 낫다.

## 검증

조회를 실패시켜 해당 화면을 다시 띄워 확인했다. 제목부터 설명까지 잘림 없이 표시되고, 문장별 줄바꿈과 요소 간 여백이 의도대로 적용된다.

고치는 과정에서 CSS 규칙 순서 때문에 한 번 적용되지 않았다 — 같은 특이도의 기본 규칙이 뒤에 있어 이겼다. 화면으로 확인하지 않았으면 넘어갔을 자리다.

---

- [BAR-1633](https://mzdevs.atlassian.net/browse/BAR-1633) 실행 요청 후 실행이 나타나지 않을 때 조용히 넘어가지 않고 알린다