### PR TITLE
docs(guide): point each migration step at the guide for the screen it opens

### DIFF
--- a/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
+++ b/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
@@ -38,7 +38,22 @@ type Step = {
   detail: string;
   routeName: string;
   testId: string;
+  /**
+   * A written guide that goes deeper than this step's one line, when one exists.
+   *
+   * Rendered *outside* the step's link — a link inside a link is not valid markup and the
+   * inner one stops working.
+   */
+  guide?: { title: string; file: string };
 };
+
+/** The guides live with the source, so they move with it and cannot drift into a stale copy */
+const GUIDE_BASE =
+  'https://github.com/cloud-barista/cm-butterfly/blob/main/docs/guide/';
+
+function guideUrlFor(file: string): string {
+  return GUIDE_BASE + file;
+}
 
 const steps: Step[] = [
   {
@@ -48,6 +63,10 @@ const steps: Step[] = [
       'Register the servers you want to migrate. Each connection is one source server, and the collection agent is installed when you add it.',
     routeName: MENU_ID.SOURCE_SERVICES,
     testId: 'migration-guide-step-source-service',
+    guide: {
+      title: 'Bulk import of source connections',
+      file: 'source-connection-bulk-import.md',
+    },
   },
   {
     no: 2,
@@ -72,6 +91,10 @@ const steps: Step[] = [
       'From the target model, generate the migration workflow. This is the entry point — workflows are created from a target model.',
     routeName: MENU_ID.WORKFLOWS,
     testId: 'migration-guide-step-create-workflow',
+    guide: {
+      title: 'Running workflow tasks in parallel',
+      file: 'workflow-parallel-steps.md',
+    },
   },
   {
     no: 5,
@@ -80,6 +103,10 @@ const steps: Step[] = [
       'Review the values carried over from the target model, adjust what you need, then run it. The migration actually happens here.',
     routeName: MENU_ID.WORKFLOWS,
     testId: 'migration-guide-step-run-workflow',
+    guide: {
+      title: 'Reading the run status screen',
+      file: 'workflow-run-status.md',
+    },
   },
 ];
 
@@ -97,8 +124,7 @@ function isActive(step: Step): boolean {
   );
 }
 
-const guideUrl =
-  'https://github.com/cloud-barista/cm-butterfly/blob/main/docs/guide/quick-start-migration.md';
+const guideUrl = guideUrlFor('quick-start-migration.md');
 </script>
 
 <template>
@@ -145,6 +171,22 @@ const guideUrl =
             >&rsaquo;</span
           >
         </router-link>
+
+        <!--
+          Sits under the step rather than inside it: the step itself is a link, and a link
+          inside a link does not work. This is also the hook for "help for this screen" —
+          each step points at the guide for the screen it opens.
+        -->
+        <a
+          v-if="step.guide"
+          :href="guideUrlFor(step.guide.file)"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="mt-1 self-start pl-12 text-xs text-blue-600 underline"
+          :data-testid="`${step.testId}-guide`"
+        >
+          {{ step.guide.title }}
+        </a>
 
         <span
           v-if="index < steps.length - 1"


### PR DESCRIPTION
## 배경

콘솔의 `Migration Guide` 화면은 **문서 하나(퀵 스타트)만** 페이지 맨 아래에서 링크하고 있었다. 상세 가이드는 있는데 제품 어디에서도 가리키지 않아, **이미 있다는 걸 아는 사람만** 찾아갈 수 있었다.

## 변경 내용

각 단계가 **그 단계가 여는 화면의 상세 가이드**를 가리킨다.

| 단계 | 연결한 가이드 |
|---|---|
| 1 Register Source Service | Bulk import of source connections |
| 4 Create Workflow | Running workflow tasks in parallel |
| 5 Edit and Run Workflow | **Reading the run status screen** |

링크를 페이지가 아니라 **단계에 매달았기 때문에**, 앞으로 화면별 도움말을 붙일 때 그대로 거치대가 된다.

> 링크는 단계 **바깥**에 둔다. 단계 자체가 링크라, 그 안에 링크를 넣으면 안쪽 링크가 동작하지 않는다.

## 검증

- 링크 3건이 모두 의도한 문서를 가리킨다
- **단계 자체의 화면 이동이 그대로 동작한다** (링크 중첩으로 깨지지 않았는지 확인)

---

- [BAR-1638](https://mzdevs.atlassian.net/browse/BAR-1638) 실행 상태 화면 사용 가이드 신설 — 상황별 화면 설명과 도움말 링크용 문서