### PR TITLE
docs(guide): keep the overview diagram nodes to the step name only

### DIFF
--- a/docs/guide/quick-start-migration.md
+++ b/docs/guide/quick-start-migration.md
@@ -10,11 +10,11 @@ A migration runs through five steps, in order. Each one is a screen in the conso
 
 ```mermaid
 flowchart TD
-    A["<b>1 · Register Source Service</b><br/><small>connect to your source servers</small>"]
-    B["<b>2 · Create Source Model</b><br/><small>collect what is running there</small>"]
-    C["<b>3 · Create Target Model</b><br/><small>get a cloud spec recommendation, with cost</small>"]
-    D["<b>4 · Create Workflow</b><br/><small>generated from the target model</small>"]
-    E["<b>5 · Edit and Run Workflow</b><br/><small>the migration actually happens here</small>"]
+    A["1 · Register Source Service"]
+    B["2 · Create Source Model"]
+    C["3 · Create Target Model"]
+    D["4 · Create Workflow"]
+    E["5 · Edit and Run Workflow"]
 
     A --> B --> C --> D --> E
 


### PR DESCRIPTION
## 배경

퀵 스타트 가이드 상단 5단계 흐름도가 GitHub에서 **노드 안 글자가 잘린다.** GitHub mermaid 렌더러는 노드를 텍스트에 맞춰 크기 계산하는데, 노드가 볼드 제목·작은 글씨 설명·줄바꿈을 섞은 두 줄 이상이라 긴 문장이 하단에서 잘렸다. (mermaid.ink 최신 버전에서는 원본도 안 잘려, GitHub 자체 렌더러 특성이다.)

## 변경 내용

흐름도 노드를 **단계 이름만**으로 단순화한다. 각 단계 설명과 위치(어느 메뉴)는 흐름도 바로 아래 표에 이미 그대로 있으므로 정보 손실이 없고, 다이어그램↔표가 설명을 중복하던 것도 정리된다.

## 검증

수정한 흐름도를 렌더해 노드가 한 줄이 되어 잘릴 여지가 없음을 확인했다.

이 문서는 방금 게시한 v0.5.3에 포함되며, 릴리스 노트 링크가 `main`을 가리키므로 업스트림 반영 후 릴리스에서도 최신본이 보인다(태그 재발행 불필요).

---

- [BAR-1640](https://mzdevs.atlassian.net/browse/BAR-1640) 퀵 스타트 가이드 상단 흐름도 글자 잘림 수정 — 노드는 단계 이름만