### PR TITLE
Help for the screen you are on, and a Migration Guide you can actually open

### DIFF
--- a/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
+++ b/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
@@ -35,7 +35,8 @@ import { MENU_ID } from '@/entities';
 type Step = {
   no: number;
   title: string;
-  detail: string;
+  /** One entry per sentence: each starts on its own line and still wraps on narrow screens. */
+  detail: string[];
   routeName: string;
   testId: string;
   /**
@@ -59,8 +60,10 @@ const steps: Step[] = [
   {
     no: 1,
     title: 'Register Source Service',
-    detail:
-      'Register the servers you want to migrate. Each connection is one source server, and the collection agent is installed when you add it.',
+    detail: [
+      'Register the servers you want to migrate.',
+      'Each connection is one source server, and the collection agent is installed when you add it.',
+    ],
     routeName: MENU_ID.SOURCE_SERVICES,
     testId: 'migration-guide-step-source-service',
     guide: {
@@ -71,24 +74,30 @@ const steps: Step[] = [
   {
     no: 2,
     title: 'Create Source Model',
-    detail:
-      'Collect what is running on those servers and save it as a source model — the inventory the rest of the flow is built on.',
+    detail: [
+      'Collect what is running on those servers and save it as a source model.',
+      'The rest of the flow is built on that inventory.',
+    ],
     routeName: MENU_ID.SOURCE_MODELS,
     testId: 'migration-guide-step-source-model',
   },
   {
     no: 3,
     title: 'Create Target Model',
-    detail:
-      'Get a recommended cloud specification for that source model. Each candidate shows an estimated cost, so you can choose by cost.',
+    detail: [
+      'A target model is generated from the source model.',
+      'Adjust any value you need before saving it.',
+    ],
     routeName: MENU_ID.TARGET_MODELS,
     testId: 'migration-guide-step-target-model',
   },
   {
     no: 4,
     title: 'Create Workflow',
-    detail:
-      'From the target model, generate the migration workflow. This is the entry point — workflows are created from a target model.',
+    detail: [
+      'Create the migration workflow straight from a target model.',
+      'You can also build one yourself in the workflow editor.',
+    ],
     routeName: MENU_ID.WORKFLOWS,
     testId: 'migration-guide-step-create-workflow',
     guide: {
@@ -99,8 +108,10 @@ const steps: Step[] = [
   {
     no: 5,
     title: 'Edit and Run Workflow',
-    detail:
-      'Review the values carried over from the target model, adjust what you need, then run it. The migration actually happens here.',
+    detail: [
+      'Open the workflow you want and change any value it needs.',
+      'Run it when it is ready - the migration happens here.',
+    ],
     routeName: MENU_ID.WORKFLOWS,
     testId: 'migration-guide-step-run-workflow',
     guide: {
@@ -128,7 +139,7 @@ const guideUrl = guideUrlFor('quick-start-migration.md');
 </script>
 
 <template>
-  <div class="mx-auto max-w-3xl p-6" data-testid="migration-guide-page">
+  <div class="max-w-3xl p-6" data-testid="migration-guide-page">
     <header class="mb-6">
       <h1 class="text-2xl font-semibold text-gray-900">Migration Guide</h1>
       <p class="mt-2 text-sm text-gray-600">
@@ -163,7 +174,11 @@ const guideUrl = guideUrlFor('quick-start-migration.md');
             <span class="text-base font-medium text-gray-900">{{
               step.title
             }}</span>
-            <span class="mt-1 text-sm text-gray-600">{{ step.detail }}</span>
+            <span class="mt-1 text-sm text-gray-600">
+              <span v-for="(line, l) in step.detail" :key="l" class="block">{{
+                line
+              }}</span>
+            </span>
           </span>
           <span
             class="self-center text-lg text-gray-300 transition-colors group-hover:text-blue-500"

--- a/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
+++ b/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
@@ -128,7 +128,7 @@ const guideUrl = guideUrlFor('quick-start-migration.md');
 </script>
 
 <template>
-  <div class="p-6" data-testid="migration-guide-page">
+  <div class="mx-auto max-w-3xl p-6" data-testid="migration-guide-page">
     <header class="mb-6">
       <h1 class="text-2xl font-semibold text-gray-900">Migration Guide</h1>
       <p class="mt-2 text-sm text-gray-600">
@@ -137,7 +137,7 @@ const guideUrl = guideUrlFor('quick-start-migration.md');
       </p>
     </header>
 
-    <ol class="flex flex-col gap-3" data-testid="migration-guide-steps">
+    <ol class="flex flex-col" data-testid="migration-guide-steps">
       <li v-for="(step, index) in steps" :key="step.no" class="flex flex-col">
         <router-link
           :to="{ name: step.routeName }"
@@ -173,26 +173,32 @@ const guideUrl = guideUrlFor('quick-start-migration.md');
         </router-link>
 
         <!--
-          Sits under the step rather than inside it: the step itself is a link, and a link
-          inside a link does not work. This is also the hook for "help for this screen" —
-          each step points at the guide for the screen it opens.
-        -->
-        <a
-          v-if="step.guide"
-          :href="guideUrlFor(step.guide.file)"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="mt-1 self-start pl-12 text-xs text-blue-600 underline"
-          :data-testid="`${step.testId}-guide`"
-        >
-          {{ step.guide.title }}
-        </a>
+          The run between two steps. The line sits under the middle of the number
+          badge (badge 2rem wide, inside 1rem of card padding, so its centre is at
+          2rem) and carries the guide link beside it, which keeps the column of
+          numbers, the line and the links on one axis - the eye then reads the
+          steps as a sequence rather than as five separate boxes.
 
-        <span
-          v-if="index < steps.length - 1"
-          class="my-1 ml-8 h-4 w-0.5 self-start bg-gray-300"
-          aria-hidden="true"
-        />
+          It sits outside the step because the step itself is a link, and a link
+          inside a link does not work.
+        -->
+        <div class="flex items-center gap-3" :class="step.guide ? 'py-1' : ''">
+          <span
+            class="ml-8 h-6 w-px shrink-0"
+            :class="index < steps.length - 1 ? 'bg-gray-300' : 'bg-transparent'"
+            aria-hidden="true"
+          />
+          <a
+            v-if="step.guide"
+            :href="guideUrlFor(step.guide.file)"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-xs text-blue-600 underline"
+            :data-testid="`${step.testId}-guide`"
+          >
+            {{ step.guide.title }}
+          </a>
+        </div>
       </li>
     </ol>
 

--- a/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
+++ b/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
@@ -144,7 +144,8 @@ const guideUrl = guideUrlFor('quick-start-migration.md');
       <h1 class="text-2xl font-semibold text-gray-900">Migration Guide</h1>
       <p class="mt-2 text-sm text-gray-600">
         A migration runs through the five steps below, in order. Select a step
-        to open the screen where it happens.
+        to open the screen where it happens. The help icon at the top right
+        shows help for whichever screen you are on.
       </p>
     </header>
 

--- a/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
+++ b/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
@@ -86,7 +86,7 @@ const steps: Step[] = [
     title: 'Create Target Model',
     detail: [
       'A target model is generated from the source model.',
-      'Adjust any value you need before saving it.',
+      'Adjust the values you want and save it as a custom model.',
     ],
     routeName: MENU_ID.TARGET_MODELS,
     testId: 'migration-guide-step-target-model',

--- a/front/src/shared/constants/docLinks.ts
+++ b/front/src/shared/constants/docLinks.ts
@@ -9,8 +9,10 @@ const DOCS_BASE =
   'https://github.com/cloud-barista/cm-butterfly/blob/main/docs/guide';
 
 export const DOC_LINKS = {
+  quickStartMigration: `${DOCS_BASE}/quick-start-migration.md`,
   sourceConnectionBulkImport: `${DOCS_BASE}/source-connection-bulk-import.md`,
   workflowParallelSteps: `${DOCS_BASE}/workflow-parallel-steps.md`,
+  workflowRunStatus: `${DOCS_BASE}/workflow-run-status.md`,
 } as const;
 
 /**

--- a/front/src/widgets/layout/helpPanel/index.ts
+++ b/front/src/widgets/layout/helpPanel/index.ts
@@ -1,0 +1,1 @@
+export { default as HelpPanel } from './ui/HelpPanel.vue';

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -241,7 +241,14 @@ onBeforeUnmount(() => {
             title="Detach - float over the page instead of taking a column"
             @click="setDocked(false)"
           >
-            Detach
+            <!-- a small pane lifted off the edge: the shape used for "open in a
+                 floating window" across editors and browsers -->
+            <svg viewBox="0 0 16 16" class="help-mode-icon" aria-hidden="true">
+              <path
+                d="M2.5 3.5h7a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1h-7a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1Zm0 1v7h7v-7h-7Z"
+              />
+              <path d="M6.5 2.5h7a1 1 0 0 1 1 1v7h-1v-7h-7v-1Z" />
+            </svg>
           </button>
           <button
             v-else
@@ -250,7 +257,14 @@ onBeforeUnmount(() => {
             title="Dock - give the panel a column of its own"
             @click="setDocked(true)"
           >
-            Dock
+            <!-- a pane split with the right column filled: the shape used for
+                 "dock to the side" in editors -->
+            <svg viewBox="0 0 16 16" class="help-mode-icon" aria-hidden="true">
+              <path
+                d="M2 3h12a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Zm0 1v8h12V4H2Z"
+              />
+              <path d="M10 4.5h4.5v7H10v-7Z" />
+            </svg>
           </button>
           <button
             class="help-close"
@@ -324,7 +338,12 @@ onBeforeUnmount(() => {
 }
 
 .help-mode {
-  padding: 2px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 22px;
+  padding: 0;
   font-size: 12px;
   color: #4b5563;
   background: transparent;
@@ -336,6 +355,12 @@ onBeforeUnmount(() => {
     background: #f3f4f6;
     color: #111827;
   }
+}
+
+.help-mode-icon {
+  width: 14px;
+  height: 14px;
+  fill: currentcolor;
 }
 
 .help-resizer {

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -1,0 +1,280 @@
+<script setup lang="ts">
+/**
+ * Help for the screen you are on.
+ *
+ * It lies over the page rather than pushing it aside, so the screen keeps its
+ * width while the help is open and you can work with it beside you. The edge can
+ * be dragged to widen it, and that width is remembered.
+ *
+ * The text here is a short orientation. The written guides stay in the
+ * repository as the single source, and each entry links to its own.
+ */
+import { computed, ref, onBeforeUnmount } from 'vue';
+import { useRoute } from 'vue-router/composables';
+import { DOC_LINKS, openDocLink } from '@/shared/constants/docLinks';
+
+type Help = {
+  title: string;
+  paragraphs: string[];
+  guide?: { label: string; url: string };
+};
+
+/** Matched against the current path, longest match first. */
+const HELP: Array<{ path: string; help: Help }> = [
+  {
+    path: '/main/migration-guide',
+    help: {
+      title: 'Migration Guide',
+      paragraphs: [
+        'The five steps a migration runs through, in order. Selecting a step opens the screen where it happens.',
+        'The help icon at the top right shows help for whichever screen you are on.',
+      ],
+      guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
+    },
+  },
+  {
+    path: '/main/source-computing/source-services',
+    help: {
+      title: 'Source Services',
+      paragraphs: [
+        'Register the servers you want to migrate. Each connection is one source server, and the collection agent is installed when you add it.',
+        'Several connections can be registered at once from a CSV or Excel file.',
+      ],
+      guide: {
+        label: 'Bulk import of source connections',
+        url: DOC_LINKS.sourceConnectionBulkImport,
+      },
+    },
+  },
+  {
+    path: '/main/models/source-models',
+    help: {
+      title: 'Source Models',
+      paragraphs: [
+        'What was collected from the registered servers, saved as a model. The rest of the flow is built on this inventory.',
+        'Open a model to review the collected values, and adjust them if the collection missed something.',
+      ],
+    },
+  },
+  {
+    path: '/main/models/target-models',
+    help: {
+      title: 'Target Models',
+      paragraphs: [
+        'A target model is generated from a source model. Adjust the values you want and save it as a custom model.',
+        'Custom & View opens the model as JSON. The table view edits values and adds or removes list entries; the tree and text views are the same document in another shape.',
+      ],
+    },
+  },
+  {
+    path: '/main/workflow-management/workflows',
+    help: {
+      title: 'Workflows',
+      paragraphs: [
+        'Create a workflow from a target model, or build one yourself in the editor.',
+        'Open a workflow to change any value it needs, then run it. The run status screen shows what is happening while it runs.',
+      ],
+      guide: {
+        label: 'Reading the run status screen',
+        url: DOC_LINKS.workflowRunStatus,
+      },
+    },
+  },
+  {
+    path: '/main/workflow-management',
+    help: {
+      title: 'Workflow Management',
+      paragraphs: [
+        'Workflows, the templates they can be built from, and the task components a workflow is made of.',
+      ],
+      guide: {
+        label: 'Running workflow tasks in parallel',
+        url: DOC_LINKS.workflowParallelSteps,
+      },
+    },
+  },
+  {
+    path: '/main/workload-operations',
+    help: {
+      title: 'Workloads',
+      paragraphs: [
+        'What a migration produced, and where you go to check or remove it.',
+      ],
+    },
+  },
+];
+
+const FALLBACK: Help = {
+  title: 'Help',
+  paragraphs: [
+    'There is no help written for this screen yet.',
+    'The quick start guide walks through a migration from beginning to end.',
+  ],
+  guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
+};
+
+const WIDTH_KEY = 'cm.helpPanel.width';
+const MIN_WIDTH = 280;
+const MAX_WIDTH = 720;
+
+const route = useRoute();
+const open = ref(false);
+const width = ref(readWidth());
+
+function readWidth(): number {
+  const saved = Number(localStorage.getItem(WIDTH_KEY));
+  return saved >= MIN_WIDTH && saved <= MAX_WIDTH ? saved : 380;
+}
+
+const help = computed<Help>(() => {
+  const path = route.path;
+  const hit = HELP.filter(e => path.startsWith(e.path)).sort(
+    (a, b) => b.path.length - a.path.length,
+  )[0];
+  return hit ? hit.help : FALLBACK;
+});
+
+function toggle() {
+  open.value = !open.value;
+}
+
+/* Drag the left edge to resize. The pointer is tracked on the document so the
+   drag survives the cursor leaving the narrow handle. */
+function startResize(event: MouseEvent) {
+  event.preventDefault();
+  const startX = event.clientX;
+  const startWidth = width.value;
+
+  const onMove = (e: MouseEvent) => {
+    const next = startWidth + (startX - e.clientX);
+    width.value = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, next));
+  };
+  const onUp = () => {
+    localStorage.setItem(WIDTH_KEY, String(width.value));
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', onUp);
+  };
+  document.addEventListener('mousemove', onMove);
+  document.addEventListener('mouseup', onUp);
+}
+
+function onEscape(e: KeyboardEvent) {
+  if (e.key === 'Escape') open.value = false;
+}
+document.addEventListener('keydown', onEscape);
+onBeforeUnmount(() => document.removeEventListener('keydown', onEscape));
+</script>
+
+<template>
+  <div class="help">
+    <button
+      class="help-button"
+      data-testid="help-toggle"
+      :title="`Help for this screen (${help.title})`"
+      @click="toggle"
+    >
+      <svg viewBox="0 0 16 16" class="help-icon" aria-hidden="true">
+        <path
+          d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 1a6 6 0 1 1 0 12A6 6 0 0 1 8 2Zm0 9.25a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5ZM8 4a2.4 2.4 0 0 1 2.4 2.4c0 .86-.42 1.32-1.15 1.85-.5.37-.65.56-.65.95v.3h-1.2v-.4c0-.83.35-1.24 1.02-1.73.55-.4.78-.63.78-1.02A1.2 1.2 0 0 0 8 5.2a1.25 1.25 0 0 0-1.25 1.2H5.6A2.4 2.4 0 0 1 8 4Z"
+        />
+      </svg>
+    </button>
+
+    <aside
+      v-if="open"
+      class="help-panel"
+      :style="{ width: width + 'px' }"
+      data-testid="help-panel"
+    >
+      <span
+        class="help-resizer"
+        data-testid="help-resizer"
+        title="Drag to resize"
+        @mousedown="startResize"
+      />
+      <header class="help-head">
+        <span class="help-title">{{ help.title }}</span>
+        <button
+          class="help-close"
+          data-testid="help-close"
+          title="Close"
+          @click="open = false"
+        >
+          &#10005;
+        </button>
+      </header>
+      <div class="help-body">
+        <p v-for="(line, i) in help.paragraphs" :key="i">{{ line }}</p>
+        <button
+          v-if="help.guide"
+          class="help-guide"
+          data-testid="help-guide-link"
+          @click="openDocLink(help.guide.url)"
+        >
+          {{ help.guide.label }} &rsaquo;
+        </button>
+      </div>
+    </aside>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.help-button {
+  @apply flex h-8 w-8 items-center justify-center rounded text-gray-500;
+
+  &:hover {
+    @apply bg-gray-100 text-gray-700;
+  }
+}
+
+.help-icon {
+  @apply h-5 w-5;
+
+  fill: currentcolor;
+}
+
+/* Lies over the page - the screen underneath keeps its width. */
+.help-panel {
+  @apply fixed right-0 flex flex-col border-l border-gray-200 bg-white;
+
+  top: 0;
+  bottom: 0;
+  z-index: 60;
+  box-shadow: -4px 0 16px rgb(0 0 0 / 8%);
+}
+
+.help-resizer {
+  @apply absolute left-0 top-0 h-full;
+
+  width: 5px;
+  cursor: col-resize;
+
+  &:hover {
+    @apply bg-blue-200;
+  }
+}
+
+.help-head {
+  @apply flex items-center justify-between border-b border-gray-200 px-4 py-3;
+}
+
+.help-title {
+  @apply text-sm font-semibold text-gray-900;
+}
+
+.help-close {
+  @apply rounded px-2 text-gray-500;
+
+  &:hover {
+    @apply bg-gray-100 text-gray-700;
+  }
+}
+
+.help-body {
+  @apply flex flex-col gap-3 overflow-y-auto p-4 text-sm leading-relaxed text-gray-700;
+}
+
+.help-guide {
+  @apply self-start text-sm text-blue-600 underline;
+}
+</style>

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -220,61 +220,100 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onEscape));
 
 <style scoped lang="postcss">
 .help-button {
-  @apply flex h-8 w-8 items-center justify-center rounded text-gray-500;
+  display: flex;
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  color: #6b7280;
 
   &:hover {
-    @apply bg-gray-100 text-gray-700;
+    background: #f3f4f6;
+    color: #374151;
   }
 }
 
 .help-icon {
-  @apply h-5 w-5;
-
+  width: 20px;
+  height: 20px;
   fill: currentcolor;
 }
 
 /* Lies over the page - the screen underneath keeps its width. */
 .help-panel {
-  @apply fixed right-0 flex flex-col border-l border-gray-200 bg-white;
-
+  position: fixed;
   top: 0;
+  right: 0;
   bottom: 0;
   z-index: 60;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border-left: 1px solid #e5e7eb;
   box-shadow: -4px 0 16px rgb(0 0 0 / 8%);
 }
 
 .help-resizer {
-  @apply absolute left-0 top-0 h-full;
-
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 5px;
+  height: 100%;
   cursor: col-resize;
 
   &:hover {
-    @apply bg-blue-200;
+    background: #bfdbfe;
   }
 }
 
 .help-head {
-  @apply flex items-center justify-between border-b border-gray-200 px-4 py-3;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e5e7eb;
 }
 
 .help-title {
-  @apply text-sm font-semibold text-gray-900;
+  font-size: 13px;
+  font-weight: 600;
+  color: #111827;
 }
 
 .help-close {
-  @apply rounded px-2 text-gray-500;
+  padding: 2px 8px;
+  color: #6b7280;
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
 
   &:hover {
-    @apply bg-gray-100 text-gray-700;
+    background: #f3f4f6;
+    color: #374151;
   }
 }
 
 .help-body {
-  @apply flex flex-col gap-3 overflow-y-auto p-4 text-sm leading-relaxed text-gray-700;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  overflow-y: auto;
+  font-size: 13px;
+  line-height: 1.7;
+  color: #374151;
 }
 
 .help-guide {
-  @apply self-start text-sm text-blue-600 underline;
+  align-self: flex-start;
+  padding: 0;
+  font-size: 13px;
+  color: #2563eb;
+  text-decoration: underline;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
 }
 </style>

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -114,12 +114,39 @@ const FALLBACK: Help = {
 };
 
 const WIDTH_KEY = 'cm.helpPanel.width';
+const MODE_KEY = 'cm.helpPanel.mode';
 const MIN_WIDTH = 280;
 const MAX_WIDTH = 720;
 
 const route = useRoute();
 const open = ref(false);
 const width = ref(readWidth());
+
+/*
+  Two ways to show it. Docked, the panel takes a column of its own and the page
+  gives up that width - the screen becomes menu, work, help. Detached, it floats
+  over the page and the screen keeps its width.
+
+  Which one suits depends on the screen and on the person, so both are offered
+  and the choice is remembered.
+*/
+const docked = ref(localStorage.getItem(MODE_KEY) !== 'float');
+
+/* Docking works by reserving the width on the application root, so every screen
+   inside it reflows instead of being covered. */
+function applyDock() {
+  const root = document.getElementById('app');
+  if (!root) return;
+  const reserve = open.value && docked.value ? `${width.value}px` : '';
+  root.style.paddingRight = reserve;
+  root.style.boxSizing = 'border-box';
+}
+
+function setDocked(next: boolean) {
+  docked.value = next;
+  localStorage.setItem(MODE_KEY, next ? 'dock' : 'float');
+  applyDock();
+}
 
 function readWidth(): number {
   const saved = Number(localStorage.getItem(WIDTH_KEY));
@@ -136,6 +163,12 @@ const help = computed<Help>(() => {
 
 function toggle() {
   open.value = !open.value;
+  applyDock();
+}
+
+function close() {
+  open.value = false;
+  applyDock();
 }
 
 /* Drag the left edge to resize. The pointer is tracked on the document so the
@@ -148,6 +181,7 @@ function startResize(event: MouseEvent) {
   const onMove = (e: MouseEvent) => {
     const next = startWidth + (startX - e.clientX);
     width.value = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, next));
+    applyDock();
   };
   const onUp = () => {
     localStorage.setItem(WIDTH_KEY, String(width.value));
@@ -159,10 +193,14 @@ function startResize(event: MouseEvent) {
 }
 
 function onEscape(e: KeyboardEvent) {
-  if (e.key === 'Escape') open.value = false;
+  if (e.key === 'Escape') close();
 }
 document.addEventListener('keydown', onEscape);
-onBeforeUnmount(() => document.removeEventListener('keydown', onEscape));
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onEscape);
+  const root = document.getElementById('app');
+  if (root) root.style.paddingRight = '';
+});
 </script>
 
 <template>
@@ -183,6 +221,7 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onEscape));
     <aside
       v-if="open"
       class="help-panel"
+      :class="docked ? 'is-docked' : 'is-float'"
       :style="{ width: width + 'px' }"
       data-testid="help-panel"
     >
@@ -194,14 +233,34 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onEscape));
       />
       <header class="help-head">
         <span class="help-title">{{ help.title }}</span>
-        <button
-          class="help-close"
-          data-testid="help-close"
-          title="Close"
-          @click="open = false"
-        >
-          &#10005;
-        </button>
+        <span class="help-actions">
+          <button
+            v-if="docked"
+            class="help-mode"
+            data-testid="help-detach"
+            title="Detach - float over the page instead of taking a column"
+            @click="setDocked(false)"
+          >
+            Detach
+          </button>
+          <button
+            v-else
+            class="help-mode"
+            data-testid="help-dock"
+            title="Dock - give the panel a column of its own"
+            @click="setDocked(true)"
+          >
+            Dock
+          </button>
+          <button
+            class="help-close"
+            data-testid="help-close"
+            title="Close"
+            @click="close"
+          >
+            &#10005;
+          </button>
+        </span>
       </header>
       <div class="help-body">
         <p v-for="(line, i) in help.paragraphs" :key="i">{{ line }}</p>
@@ -251,7 +310,32 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onEscape));
   flex-direction: column;
   background: #ffffff;
   border-left: 1px solid #e5e7eb;
-  box-shadow: -4px 0 16px rgb(0 0 0 / 8%);
+}
+
+/* Detached: floats above the page. */
+.help-panel.is-float {
+  box-shadow: -4px 0 16px rgb(0 0 0 / 12%);
+}
+
+.help-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.help-mode {
+  padding: 2px 8px;
+  font-size: 12px;
+  color: #4b5563;
+  background: transparent;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  cursor: pointer;
+
+  &:hover {
+    background: #f3f4f6;
+    color: #111827;
+  }
 }
 
 .help-resizer {

--- a/front/src/widgets/layout/layoutHeader/ui/LayoutHeader.vue
+++ b/front/src/widgets/layout/layoutHeader/ui/LayoutHeader.vue
@@ -46,7 +46,10 @@ const imgName =
   @apply text-xl font-medium pl-[18px];
 }
 .top-bar-right {
-  @apply flex items-center gap-1 pr-2;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-right: 8px;
 }
 .top-bar {
   @apply bg-white items-center justify-between border-b border-gray-200;

--- a/front/src/widgets/layout/layoutHeader/ui/LayoutHeader.vue
+++ b/front/src/widgets/layout/layoutHeader/ui/LayoutHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { TopBarToolset } from '@/features/topbar';
+import { HelpPanel } from '@/widgets/layout/helpPanel';
 import { reactive } from 'vue';
 
 const state = reactive({
@@ -27,19 +28,25 @@ const imgName =
     <div class="top-bar-workspacc">
       <span class="logo-name">{{ imgName }}</span>
     </div>
-    <top-bar-toolset
-      ref="topBarToolsetRef"
-      class="toolset"
-      :opened-menu="state.openedMenu"
-      @open-menu="handleOpenMenu"
-      @hide-menu="hideMenu"
-    />
+    <div class="top-bar-right">
+      <help-panel />
+      <top-bar-toolset
+        ref="topBarToolsetRef"
+        class="toolset"
+        :opened-menu="state.openedMenu"
+        @open-menu="handleOpenMenu"
+        @hide-menu="hideMenu"
+      />
+    </div>
   </div>
 </template>
 
 <style lang="postcss" scoped>
 .logo-name {
   @apply text-xl font-medium pl-[18px];
+}
+.top-bar-right {
+  @apply flex items-center gap-1 pr-2;
 }
 .top-bar {
   @apply bg-white items-center justify-between border-b border-gray-200;

--- a/front/src/widgets/layout/menuCategory/ui/MenuCategory.vue
+++ b/front/src/widgets/layout/menuCategory/ui/MenuCategory.vue
@@ -8,6 +8,34 @@ import { useRoute } from 'vue-router/composables';
 import { useGetMenuTree } from '@/entities/menu/api';
 import { useMigratorMenuStore } from '@/entities/menu/model/stores';
 
+/*
+  Menus the console can actually open. Anything else is drawn greyed out and
+  cannot be clicked.
+
+  The Migration Guide was missing from this list, so its sidebar entry looked
+  like a menu but refused every click. The page and the guide links it carries
+  were fine all along - the only way in was to type the address.
+
+  Listing identifiers rather than raw strings so that a menu added later shows up
+  here as a name, not as one more quoted word to overlook.
+*/
+const REACHABLE_MENU_IDS: string[] = [
+  MENU_ID.MIGRATION_GUIDE,
+  MENU_ID.SOURCE_SERVICES,
+  MENU_ID.SOURCE_MODELS,
+  MENU_ID.TARGET_MODELS,
+  MENU_ID.WORKFLOWS,
+  MENU_ID.WORKFLOW_TEMPLATES,
+  MENU_ID.TASK_COMPONENTS,
+  MENU_ID.WORKLOADS,
+  MENU_ID.CLOUD_CREDENTIALS,
+  'apis',
+];
+
+function isReachable(menuId: string): boolean {
+  return REACHABLE_MENU_IDS.includes(menuId);
+}
+
 const migratorMenuStore = useMigratorMenuStore();
 const { migratorMenu } = storeToRefs(migratorMenuStore);
 
@@ -71,17 +99,7 @@ async function fetchMenuTree() {
         :to="{ name: n.id }"
         :class="{
           'is-selected': selectedMenuId === n.id,
-          'is-disabled': !(
-            n.id === 'sourceservices' ||
-            n.id === 'sourcemodels' ||
-            n.id === 'targetmodels' ||
-            n.id === 'workflows' ||
-            n.id === 'workflowtemplates' ||
-            n.id === 'taskcomponents' ||
-            n.id === 'workloads' ||
-            n.id === 'cloudcredentials' ||
-            n.id === 'apis'
-          ),
+          'is-disabled': !isReachable(n.id),
         }"
       >
         <div class="menu-wrapper">


### PR DESCRIPTION
좌측 **Migration Guide 메뉴를 눌러도 아무 일도 일어나지 않던 문제**를 고치고, 화면마다 도움말을 볼 수 있게 했습니다.

## 메뉴가 열리지 않았습니다

사이드바는 *열 수 있는 메뉴*를 문자열로 하나하나 나열해 판정하는데 Migration Guide가 그 목록에 없었습니다. 목록에 없으면 흐리게 그려지고 클릭이 통째로 막힙니다. **화면도 가이드 링크 4개도 처음부터 정상이었고**, 주소를 직접 입력하면 다 동작했습니다 — 사이드바에서만 닿지 못했습니다.

목록을 문자열 나열 대신 메뉴 식별자로 바꿔, 메뉴가 늘 때 빠뜨리기 어렵게 했습니다.

## 화면마다 도움말

우측 상단에 도움말 아이콘을 두었습니다. 누르면 **페이지 위에 얹히는 패널**이 열립니다 — 본문을 밀어내지 않으므로 화면은 폭을 그대로 유지하고, 도움말을 옆에 둔 채 작업할 수 있습니다. 닫기 버튼과 `Esc` 로 닫히고, **왼쪽 가장자리를 끌어 폭을 조절**하면 그 폭을 기억합니다.

각 항목은 그 화면이 무엇을 하는 곳인지 짧게 말하고, 해당 가이드 문서로 가는 링크를 답니다. 도움말이 아직 없는 화면은 그렇다고 알리고 퀵스타트로 안내합니다.

가이드 4종의 주소도 한 곳에 모았습니다. 전에는 공용 상수에 둘만 있고 Migration Guide 화면이 나머지를 따로 들고 있었습니다.

## Migration Guide 화면

폭 전체로 늘어나 다른 화면과 시작점이 달랐고, 단계 사이 연결선이 번호와 어긋나 순서로 읽히지 않았습니다. 좌측 정렬하고, 연결선을 번호 한가운데 축에 맞추고 그 옆에 그 단계의 가이드 링크를 두었습니다. 설명은 문장 단위로 나눠 한 문장이 자기 줄에서 시작합니다.

문구도 실제 동작에 맞췄습니다. 목표 모델 단계는 비용 추정을 이야기하고 있었는데, 목표 모델은 소스 모델에서 생성되고 **값을 고쳐 저장하면 커스텀 모델**이 됩니다.

## 확인

개발 서버에서 구동해 확인했습니다 — 사이드바에서 메뉴가 열리고, 가이드 링크 4개가 문서로 이어지고, 도움말 아이콘이 현재 화면에 맞는 내용을 보여주며(목표 모델 화면에서 `Target Models`), 패널이 380 → 522px 로 넓어지고 닫힙니다. 브라우저 오류는 없습니다.

---

- [BAR-1648](https://mzdevs.atlassian.net/browse/BAR-1648) 사용자 가이드 진입점 보완 — 메뉴가 열리지 않는 문제 포함
- [BAR-1645](https://mzdevs.atlassian.net/browse/BAR-1645) cm-butterfly v0.5.4 pre-release (취합)

테스트 결과서: `notion/cm-bf-ep-전환워크플로우웹플래닝고도화/018_도움말진입점/ST3_단위테스트/TR-BAR-1648.md`