### PR TITLE
Help that says how each screen is used, not just what it is

### DIFF
--- a/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
+++ b/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
@@ -75,8 +75,8 @@ const steps: Step[] = [
     no: 2,
     title: 'Create Source Model',
     detail: [
-      'Collect what is running on those servers and save it as a source model.',
-      'The rest of the flow is built on that inventory.',
+      'Collect from the servers you registered, on the same Source Services screen, and save the result as a source model.',
+      'Everything after this is built from that model.',
     ],
     routeName: MENU_ID.SOURCE_MODELS,
     testId: 'migration-guide-step-source-model',

--- a/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
+++ b/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
@@ -218,6 +218,47 @@ const guideUrl = guideUrlFor('quick-start-migration.md');
       </li>
     </ol>
 
+    <!--
+      The boxes give the order; this says what the order is made of. Someone
+      arriving here does not yet know what a model is or why there are two of
+      them, and that is the question the steps alone leave open.
+    -->
+    <section class="mt-8 flex flex-col gap-3 text-sm text-gray-700">
+      <h2 class="text-base font-semibold text-gray-900">
+        What the steps are made of
+      </h2>
+      <p>
+        A migration moves a workload from the servers you have to somewhere
+        else, usually a cloud. It does that through models - a machine or its
+        software written in the shape this system works with.
+      </p>
+      <p>
+        A <strong>source model</strong> describes the origin: the servers you
+        are migrating from. A <strong>target model</strong> describes the same
+        workload for the destination. Both are models; they differ only in which
+        side they describe. Change either one's values and save it under a new
+        name and you have a <strong>custom model</strong>, with the original
+        left as it was.
+      </p>
+      <p>
+        A <strong>workflow</strong> is generated from a target model and is what
+        actually carries the migration out. It is also the last place values can
+        be changed before anything is created, which is why adjusting there is
+        often easiest - the target model is already in the destination's shape,
+        and the workflow is the final word.
+      </p>
+      <p>
+        Target models and workflows can be exported to a file and imported back,
+        so one that works can be kept and reused like a template.
+      </p>
+      <p>
+        Infrastructure and software follow the same five steps. Infrastructure
+        recommendations come with an estimated cost to choose by; software
+        recommendations come with a list of what to install, and expect the
+        infrastructure to exist already.
+      </p>
+    </section>
+
     <footer class="mt-6 text-sm text-gray-600">
       <span>
         Looking for the full walkthrough, including software migration and load

--- a/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
+++ b/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
@@ -62,7 +62,7 @@ const steps: Step[] = [
     title: 'Register Source Service',
     detail: [
       'Register the servers you want to migrate.',
-      'Each connection is one source server, and the collection agent is installed when you add it.',
+      'Each connection is one source server, reached over SSH.',
     ],
     routeName: MENU_ID.SOURCE_SERVICES,
     testId: 'migration-guide-step-source-service',

--- a/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
+++ b/front/src/pages/migrationGuide/ui/MigrationGuidePage.vue
@@ -204,15 +204,30 @@ const guideUrl = guideUrlFor('quick-start-migration.md');
             :class="index < steps.length - 1 ? 'bg-gray-300' : 'bg-transparent'"
             aria-hidden="true"
           />
+          <!--
+            Say it is a document before it is clicked. On its own the title read
+            as a caption, and you only learned it was a link by pressing it.
+          -->
           <a
             v-if="step.guide"
             :href="guideUrlFor(step.guide.file)"
             target="_blank"
             rel="noopener noreferrer"
-            class="text-xs text-blue-600 underline"
+            class="inline-flex items-center gap-1 text-xs text-blue-600"
             :data-testid="`${step.testId}-guide`"
           >
-            {{ step.guide.title }}
+            <svg
+              class="h-3 w-3 shrink-0"
+              viewBox="0 0 16 16"
+              aria-hidden="true"
+            >
+              <path
+                fill="currentColor"
+                d="M4 1.5h5.2L13 5.3V14a.5.5 0 0 1-.5.5h-8A.5.5 0 0 1 4 14V1.5Zm1 1V13.5h7V6H8.7V2.5H5Zm4.7.7V5H12L9.7 3.2ZM6 7.5h5v1H6v-1Zm0 2.5h5v1H6v-1Z"
+              />
+            </svg>
+            <span class="underline">Guide: {{ step.guide.title }}</span>
+            <span class="text-gray-400">&#8599;</span>
           </a>
         </div>
       </li>
@@ -268,10 +283,18 @@ const guideUrl = guideUrlFor('quick-start-migration.md');
         :href="guideUrl"
         target="_blank"
         rel="noopener noreferrer"
-        class="text-blue-600 underline"
+        class="inline-flex items-center gap-1 text-blue-600"
         data-testid="migration-guide-full-doc"
-        >Read the Quick Start guide</a
       >
+        <svg class="h-3 w-3 shrink-0" viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            fill="currentColor"
+            d="M4 1.5h5.2L13 5.3V14a.5.5 0 0 1-.5.5h-8A.5.5 0 0 1 4 14V1.5Zm1 1V13.5h7V6H8.7V2.5H5Zm4.7.7V5H12L9.7 3.2ZM6 7.5h5v1H6v-1Zm0 2.5h5v1H6v-1Z"
+          />
+        </svg>
+        <span class="underline">Guide: Quick start</span>
+        <span class="text-gray-400">&#8599;</span>
+      </a>
     </footer>
   </div>
 </template>

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -13,9 +13,13 @@ import { computed, ref, onBeforeUnmount } from 'vue';
 import { useRoute } from 'vue-router/composables';
 import { DOC_LINKS, openDocLink } from '@/shared/constants/docLinks';
 
+type Section = { heading: string; steps: string[] };
+
 type Help = {
   title: string;
   paragraphs: string[];
+  /** How to actually use the screen, as the steps you take on it. */
+  sections?: Section[];
   guide?: { label: string; url: string };
 };
 
@@ -37,8 +41,32 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Source Services',
       paragraphs: [
-        'Register the servers you want to migrate. Each connection is one source server, and the collection agent is installed when you add it.',
-        'Several connections can be registered at once from a CSV or Excel file.',
+        'Register the servers you want to migrate, then collect what is running on them.',
+      ],
+      sections: [
+        {
+          heading: 'Register servers',
+          steps: [
+            'Create a Source Service.',
+            'On its Connections tab, add one connection per source server - name, IP address, SSH port, user, and a password or private key.',
+          ],
+        },
+        {
+          heading: 'Register many at once',
+          steps: [
+            'Download the connection template to see the file layout.',
+            'Fill in your servers. The template opens in Excel and saves back as either CSV or .xlsx.',
+            'Import the file. The rows to be registered are listed on screen - review them, then confirm.',
+          ],
+        },
+        {
+          heading: 'Collect',
+          steps: [
+            'Press Refresh first. It re-checks each connection and updates Agent Status and Connection Status on the Detail tab.',
+            'Once the status is healthy, run Collect Infra. The result opens in a viewer with the machine CPU, memory, disk and network.',
+            'For software, run Collect SW instead and press Convert in the viewer.',
+          ],
+        },
       ],
       guide: {
         label: 'Bulk import of source connections',
@@ -52,8 +80,25 @@ const HELP: Array<{ path: string; help: Help }> = [
       title: 'Source Models',
       paragraphs: [
         'What was collected from the registered servers, saved as a model. The rest of the flow is built on this inventory.',
-        'Open a model to review the collected values, and adjust them if the collection missed something.',
       ],
+      sections: [
+        {
+          heading: 'Create one',
+          steps: [
+            'From a collected result, save it as a Source Model. It appears in this list.',
+            'Saving under a new name gives you a copy to adjust before recommending.',
+          ],
+        },
+        {
+          heading: 'Get a target from it',
+          steps: [
+            'Select a source model and run Recommend Model.',
+            'Each candidate shows an estimated monthly cost.',
+            'Choose one and save it as a Target Model.',
+          ],
+        },
+      ],
+      guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
     },
   },
   {
@@ -62,8 +107,25 @@ const HELP: Array<{ path: string; help: Help }> = [
       title: 'Target Models',
       paragraphs: [
         'A target model is generated from a source model. Adjust the values you want and save it as a custom model.',
-        'Custom & View opens the model as JSON. The table view edits values and adds or removes list entries; the tree and text views are the same document in another shape.',
       ],
+      sections: [
+        {
+          heading: 'Adjust a model',
+          steps: [
+            'Open Custom & View to see the model as JSON.',
+            'The table view edits values and adds or removes list entries; the tree and text views are the same document in another shape.',
+            'Saving asks for a name and creates a custom model - the original is left as it was.',
+          ],
+        },
+        {
+          heading: 'Build the workflow',
+          steps: [
+            'Choose Make Workflow under Workflow Tool on the detail screen.',
+            'The workflow is generated from the target model, so its values are already filled in.',
+          ],
+        },
+      ],
+      guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
     },
   },
   {
@@ -72,7 +134,25 @@ const HELP: Array<{ path: string; help: Help }> = [
       title: 'Workflows',
       paragraphs: [
         'Create a workflow from a target model, or build one yourself in the editor.',
-        'Open a workflow to change any value it needs, then run it. The run status screen shows what is happening while it runs.',
+      ],
+      sections: [
+        {
+          heading: 'Check it before running',
+          steps: [
+            'Select the migration task on the canvas. Task Configuration opens on the right with the values carried over from the target model - path and query parameters and the request body.',
+            'Review them and edit anything that needs adjusting.',
+            'Drag components from the Toolbox on the left to extend what the workflow does.',
+            'Give the workflow a name and save it.',
+          ],
+        },
+        {
+          heading: 'Run and watch',
+          steps: [
+            'Saving takes you to the run view, where you run, edit, re-run and check results on one screen.',
+            'The graph shows live progress and where a run failed.',
+            'You can re-run one task, everything from a task onward, or only the tasks that failed.',
+          ],
+        },
       ],
       guide: {
         label: 'Reading the run status screen',
@@ -87,6 +167,15 @@ const HELP: Array<{ path: string; help: Help }> = [
       paragraphs: [
         'Workflows, the templates they can be built from, and the task components a workflow is made of.',
       ],
+      sections: [
+        {
+          heading: 'Working with tasks',
+          steps: [
+            'A task component is one step a workflow can take; a template is a workflow shape you can start from.',
+            'Tasks that do not depend on each other can be placed side by side to run together.',
+          ],
+        },
+      ],
       guide: {
         label: 'Running workflow tasks in parallel',
         url: DOC_LINKS.workflowParallelSteps,
@@ -98,8 +187,25 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Workloads',
       paragraphs: [
-        'What a migration produced, and where you go to check or remove it.',
+        'What a migration produced, and where you check, test or remove it.',
       ],
+      sections: [
+        {
+          heading: 'Check what was created',
+          steps: [
+            'Open Infra Workloads and select the workload.',
+            'The Detail tab shows the infrastructure; the Server tab lists its servers.',
+          ],
+        },
+        {
+          heading: 'Load-test it',
+          steps: [
+            'Start a load test on the selected workload.',
+            'Progress is shown live, and completion or failure is announced in the notification badge at the top right.',
+          ],
+        },
+      ],
+      guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
     },
   },
 ];
@@ -278,6 +384,16 @@ onBeforeUnmount(() => {
       </header>
       <div class="help-body">
         <p v-for="(line, i) in help.paragraphs" :key="i">{{ line }}</p>
+        <section
+          v-for="(section, s) in help.sections || []"
+          :key="`s${s}`"
+          class="help-section"
+        >
+          <h3 class="help-heading">{{ section.heading }}</h3>
+          <ol class="help-steps">
+            <li v-for="(step, t) in section.steps" :key="t">{{ step }}</li>
+          </ol>
+        </section>
         <button
           v-if="help.guide"
           class="help-guide"
@@ -413,6 +529,27 @@ onBeforeUnmount(() => {
   font-size: 13px;
   line-height: 1.7;
   color: #374151;
+}
+
+.help-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.help-heading {
+  font-size: 12px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.help-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-left: 18px;
+  margin: 0;
+  list-style: decimal;
 }
 
 .help-guide {

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -17,9 +17,12 @@ type Section = { heading: string; steps: string[] };
 
 type Help = {
   title: string;
+  /** What this menu is for, before any of the steps. */
   paragraphs: string[];
   /** How to actually use the screen, as the steps you take on it. */
   sections?: Section[];
+  /** Terms someone new to the console will not know yet. Kept last on purpose. */
+  terms?: Array<{ term: string; meaning: string }>;
   guide?: { label: string; url: string };
 };
 
@@ -34,6 +37,28 @@ const HELP: Array<{ path: string; help: Help }> = [
         'Infrastructure and software migration follow the same five steps; where they differ, the help on each screen says so.',
         'The help icon at the top right shows help for whichever screen you are on.',
       ],
+      terms: [
+        {
+          term: 'Source service',
+          meaning:
+            'A group of the servers you are migrating from - on-premises machines or ones already on a cloud. Each connection under it is one server.',
+        },
+        {
+          term: 'Source model',
+          meaning:
+            'What was found on those servers, written down. It stays close to the original machines.',
+        },
+        {
+          term: 'Target model',
+          meaning:
+            'The same workload described the way the destination expects it - usually a cloud. This is what a workflow is built from.',
+        },
+        {
+          term: 'Where to make changes',
+          meaning:
+            'You can adjust the source model, the target model, or the workflow. Later is usually easier: the target model is already in the destination shape, and the workflow is the last word before anything runs. Target models and workflows can also be exported and imported, so a good one can be kept and reused like a template.',
+        },
+      ],
       guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
     },
   },
@@ -42,54 +67,77 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Source Services',
       paragraphs: [
-        'A source service groups the servers you want to migrate. Each connection under it is one server.',
-        'A group can be created on its own and filled in later, or created with its connections in one go.',
+        'This menu does two things: it keeps the list of servers you are migrating from, and it turns what is collected from them into a source model.',
+        'A source service is a group of those servers - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
       ],
       sections: [
         {
-          heading: 'Create a group only',
+          heading: 'Managing the group - create it empty',
           steps: [
             'Create a source service with a name and description.',
             'It appears in the list with no connections. Add them whenever the server details are ready.',
           ],
         },
         {
-          heading: 'Create a group with its connections',
+          heading: 'Managing the group - create it with connections',
           steps: [
             'While creating the source service, add connections in the same form.',
             'Each connection needs a name, IP address, SSH port, user, and a password or private key.',
           ],
         },
         {
-          heading: 'Add connections to an existing group',
+          heading: 'Managing the group - add, edit or remove later',
           steps: [
-            'Select the group and open its Connections tab.',
-            'Add one connection per server, entering the details by hand.',
+            'Select the group and open its Connections tab to add a server by hand.',
+            'Connections can be edited or removed the same way as the group itself.',
           ],
         },
         {
-          heading: 'Register many from a file',
+          heading: 'Managing the group - from a file',
           steps: [
             'Download the connection template to see the layout.',
             'Fill it in. The template opens in Excel and saves back as either CSV or .xlsx.',
             'Import the file. The rows to be registered are listed on screen - review them, then confirm.',
+            'What is already registered can be exported in the same layout, so a group can be copied or kept as a starting point. Passwords and keys come out blank and have to be filled in again.',
           ],
         },
         {
-          heading: 'Export what is registered',
+          heading: 'Making a source model - choose what to migrate',
           steps: [
-            'Select a group, tick the connections you want, and export.',
-            'Choose CSV or Excel. The file uses the import layout, so it can be edited and imported back.',
-            'Passwords and keys are left blank - fill them in again before importing.',
+            'Decide whether you are migrating infrastructure or software - the collection differs.',
+            'Select a whole group to cover every server in it, or a single connection to cover one server.',
           ],
         },
         {
-          heading: 'Collect from the servers',
+          heading: 'Making a source model - collect and save',
           steps: [
-            'Press Refresh first. It re-checks each connection and updates Agent Status and Connection Status on the Detail tab.',
-            'Once the status is healthy, run Collect Infra for machines, or Collect SW for the software running on them.',
-            'The result opens in a viewer. For software, press Convert before saving.',
+            'Press Refresh first. Collection reaches the server over SSH, so it has to be reachable - Refresh re-checks that and updates Agent Status and Connection Status on the Detail tab.',
+            'Run Collect Infra for machines, or Collect SW for the software on them.',
+            'The result opens in a viewer. Check it, and for software press Convert.',
+            'Save it as a source model. It then appears under Models.',
           ],
+        },
+      ],
+      terms: [
+        {
+          term: 'Source service',
+          meaning:
+            'A group of the servers you are migrating from - on-premises machines or ones already on a cloud. Each connection under it is one server.',
+        },
+        {
+          term: 'Source model',
+          meaning:
+            'What was found on those servers, written down. It stays close to the original machines.',
+        },
+        {
+          term: 'Target model',
+          meaning:
+            'The same workload described the way the destination expects it - usually a cloud. This is what a workflow is built from.',
+        },
+        {
+          term: 'Where to make changes',
+          meaning:
+            'You can adjust the source model, the target model, or the workflow. Later is usually easier: the target model is already in the destination shape, and the workflow is the last word before anything runs. Target models and workflows can also be exported and imported, so a good one can be kept and reused like a template.',
         },
       ],
       guide: {
@@ -103,19 +151,20 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Source Models',
       paragraphs: [
-        'What was collected from the registered servers, saved as a model. The rest of the flow is built on it.',
-        'Infrastructure and software are separate models and take separate paths from here.',
+        'This menu does two things: it keeps your source models, and it produces a target model from one of them.',
+        'A source model stays close to the original servers - it is what was found on them.',
       ],
       sections: [
         {
-          heading: 'Save a model',
+          heading: 'Managing models',
           steps: [
-            'From a collected result, save it as a source model. It appears in this list.',
-            'Saving under a new name gives you a copy to adjust, leaving the original as it was.',
+            'Open a model to review what was collected, and adjust anything the collection got wrong.',
+            'Saving under a new name gives you a custom copy and leaves the original as it was.',
+            'Models can be renamed and removed here.',
           ],
         },
         {
-          heading: 'Infrastructure - get a target from it',
+          heading: 'Infrastructure - produce a target model',
           steps: [
             'Select an infrastructure source model and run Recommend Model.',
             'Each candidate shows an estimated monthly cost, so you can choose by cost.',
@@ -123,12 +172,34 @@ const HELP: Array<{ path: string; help: Help }> = [
           ],
         },
         {
-          heading: 'Software - get a target from it',
+          heading: 'Software - produce a target model',
           steps: [
             'Select a software source model and run Recommend Model.',
-            'On the recommendation screen, press Get Migration List. The recommended migration fills the panel on the right.',
-            'Save it as a software target model. There is no cost estimate here - software is matched to what is installed, not to a machine price.',
+            'Press Get Migration List. The recommended migration fills the panel on the right.',
+            'Save it as a software target model. There is no cost here - software is matched to what is installed, not to a machine price.',
           ],
+        },
+      ],
+      terms: [
+        {
+          term: 'Source service',
+          meaning:
+            'A group of the servers you are migrating from - on-premises machines or ones already on a cloud. Each connection under it is one server.',
+        },
+        {
+          term: 'Source model',
+          meaning:
+            'What was found on those servers, written down. It stays close to the original machines.',
+        },
+        {
+          term: 'Target model',
+          meaning:
+            'The same workload described the way the destination expects it - usually a cloud. This is what a workflow is built from.',
+        },
+        {
+          term: 'Where to make changes',
+          meaning:
+            'You can adjust the source model, the target model, or the workflow. Later is usually easier: the target model is already in the destination shape, and the workflow is the last word before anything runs. Target models and workflows can also be exported and imported, so a good one can be kept and reused like a template.',
         },
       ],
       guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
@@ -139,16 +210,17 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Target Models',
       paragraphs: [
-        'A target model is generated from a source model. Adjust the values you want and save it as a custom model.',
-        'The list marks each one as Basic or Custom, and as a CloudModel or a SoftwareModel.',
+        'This menu does two things: it keeps your target models, and it builds a workflow from one of them.',
+        'A target model describes the workload the way the destination expects it. The list marks each one as Basic or Custom, and as a CloudModel or a SoftwareModel.',
       ],
       sections: [
         {
-          heading: 'Adjust a model',
+          heading: 'Managing models',
           steps: [
             'Open Custom & View to see the model as JSON.',
             'The table view edits values and adds or removes list entries; the tree and text views are the same document in another shape.',
             'Saving asks for a name and creates a custom model - the original is left as it was.',
+            'A model can be exported to a file and imported back, so a good one can be kept and reused.',
           ],
         },
         {
@@ -167,6 +239,28 @@ const HELP: Array<{ path: string; help: Help }> = [
           ],
         },
       ],
+      terms: [
+        {
+          term: 'Source service',
+          meaning:
+            'A group of the servers you are migrating from - on-premises machines or ones already on a cloud. Each connection under it is one server.',
+        },
+        {
+          term: 'Source model',
+          meaning:
+            'What was found on those servers, written down. It stays close to the original machines.',
+        },
+        {
+          term: 'Target model',
+          meaning:
+            'The same workload described the way the destination expects it - usually a cloud. This is what a workflow is built from.',
+        },
+        {
+          term: 'Where to make changes',
+          meaning:
+            'You can adjust the source model, the target model, or the workflow. Later is usually easier: the target model is already in the destination shape, and the workflow is the last word before anything runs. Target models and workflows can also be exported and imported, so a good one can be kept and reused like a template.',
+        },
+      ],
       guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
     },
   },
@@ -175,9 +269,17 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Workflows',
       paragraphs: [
-        'Create a workflow from a target model, or build one yourself in the editor.',
+        'This menu keeps your workflows and runs them. A workflow is the last thing you can change before anything is actually created.',
+        'Most come from a target model, but one can be built in the editor or copied from an existing workflow and adjusted.',
       ],
       sections: [
+        {
+          heading: 'Managing workflows',
+          steps: [
+            'Create one from a target model, build it in the editor, or copy an existing workflow and change its values.',
+            'A workflow can be exported to a file and imported back, so a working one can be kept and reused like a template.',
+          ],
+        },
         {
           heading: 'Check it before running',
           steps: [
@@ -188,7 +290,7 @@ const HELP: Array<{ path: string; help: Help }> = [
           ],
         },
         {
-          heading: 'Run and watch',
+          heading: 'Run, watch and run again',
           steps: [
             'Saving takes you to the run view, where you run, edit, re-run and check results on one screen.',
             'The graph shows live progress and where a run failed.',
@@ -201,6 +303,28 @@ const HELP: Array<{ path: string; help: Help }> = [
             'Open the Run Status tab and select the run_software_migration task.',
             'Under Result, choose View installed software. It lists each piece of software with its version, install type, status, and the namespace, infra and node it landed on.',
           ],
+        },
+      ],
+      terms: [
+        {
+          term: 'Source service',
+          meaning:
+            'A group of the servers you are migrating from - on-premises machines or ones already on a cloud. Each connection under it is one server.',
+        },
+        {
+          term: 'Source model',
+          meaning:
+            'What was found on those servers, written down. It stays close to the original machines.',
+        },
+        {
+          term: 'Target model',
+          meaning:
+            'The same workload described the way the destination expects it - usually a cloud. This is what a workflow is built from.',
+        },
+        {
+          term: 'Where to make changes',
+          meaning:
+            'You can adjust the source model, the target model, or the workflow. Later is usually easier: the target model is already in the destination shape, and the workflow is the last word before anything runs. Target models and workflows can also be exported and imported, so a good one can be kept and reused like a template.',
         },
       ],
       guide: {
@@ -287,6 +411,10 @@ const width = ref(readWidth());
 */
 const docked = ref(localStorage.getItem(MODE_KEY) !== 'float');
 
+/* Where the detached panel sits. It opens on the right, which is also where the
+   screen keeps its buttons, so it has to be movable. Null means "as opened". */
+const offset = ref<{ x: number; y: number } | null>(null);
+
 /* Docking works by reserving the width on the application root, so every screen
    inside it reflows instead of being covered. */
 function applyDock() {
@@ -299,6 +427,7 @@ function applyDock() {
 
 function setDocked(next: boolean) {
   docked.value = next;
+  if (next) offset.value = null;
   localStorage.setItem(MODE_KEY, next ? 'dock' : 'float');
   applyDock();
 }
@@ -307,6 +436,18 @@ function readWidth(): number {
   const saved = Number(localStorage.getItem(WIDTH_KEY));
   return saved >= MIN_WIDTH && saved <= MAX_WIDTH ? saved : 380;
 }
+
+const panelStyle = computed(() => {
+  const style: Record<string, string> = { width: `${width.value}px` };
+  if (!docked.value && offset.value) {
+    style.left = `${offset.value.x}px`;
+    style.top = `${offset.value.y}px`;
+    style.right = 'auto';
+    style.bottom = 'auto';
+    style.height = '70vh';
+  }
+  return style;
+});
 
 const help = computed<Help>(() => {
   const path = route.path;
@@ -347,6 +488,39 @@ function startResize(event: MouseEvent) {
   document.addEventListener('mouseup', onUp);
 }
 
+/* Drag the header to move a detached panel out of the way. */
+function startMove(event: MouseEvent) {
+  if (docked.value) return;
+  if ((event.target as HTMLElement).closest('button')) return;
+  event.preventDefault();
+
+  const panel = (event.currentTarget as HTMLElement).closest(
+    '.help-panel',
+  ) as HTMLElement;
+  const box = panel.getBoundingClientRect();
+  const grabX = event.clientX - box.left;
+  const grabY = event.clientY - box.top;
+
+  const onMove = (e: MouseEvent) => {
+    offset.value = {
+      x: Math.max(
+        0,
+        Math.min(window.innerWidth - box.width, e.clientX - grabX),
+      ),
+      y: Math.max(
+        0,
+        Math.min(window.innerHeight - box.height, e.clientY - grabY),
+      ),
+    };
+  };
+  const onUp = () => {
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', onUp);
+  };
+  document.addEventListener('mousemove', onMove);
+  document.addEventListener('mouseup', onUp);
+}
+
 function onEscape(e: KeyboardEvent) {
   if (e.key === 'Escape') close();
 }
@@ -377,7 +551,7 @@ onBeforeUnmount(() => {
       v-if="open"
       class="help-panel"
       :class="docked ? 'is-docked' : 'is-float'"
-      :style="{ width: width + 'px' }"
+      :style="panelStyle"
       data-testid="help-panel"
     >
       <span
@@ -386,7 +560,12 @@ onBeforeUnmount(() => {
         title="Drag to resize"
         @mousedown="startResize"
       />
-      <header class="help-head">
+      <header
+        class="help-head"
+        :class="{ 'is-movable': !docked }"
+        data-testid="help-header"
+        @mousedown="startMove"
+      >
         <span class="help-title">{{ help.title }}</span>
         <span class="help-actions">
           <button
@@ -396,13 +575,15 @@ onBeforeUnmount(() => {
             title="Detach - float over the page instead of taking a column"
             @click="setDocked(false)"
           >
-            <!-- a small pane lifted off the edge: the shape used for "open in a
-                 floating window" across editors and browsers -->
+            <!-- two overlapping windows: the shape that means "come out of the
+                 full screen into a window of your own" -->
             <svg viewBox="0 0 16 16" class="help-mode-icon" aria-hidden="true">
               <path
-                d="M2.5 3.5h7a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1h-7a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1Zm0 1v7h7v-7h-7Z"
+                d="M2 5.5h7.5a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1Zm0 1v7h7.5v-7H2Z"
               />
-              <path d="M6.5 2.5h7a1 1 0 0 1 1 1v7h-1v-7h-7v-1Z" />
+              <path
+                d="M6.5 1.5H14a1 1 0 0 1 1 1V10a1 1 0 0 1-1 1h-2v-1h2V2.5H6.5v2h-1v-2a1 1 0 0 1 1-1Z"
+              />
             </svg>
           </button>
           <button
@@ -412,8 +593,8 @@ onBeforeUnmount(() => {
             title="Dock - give the panel a column of its own"
             @click="setDocked(true)"
           >
-            <!-- a pane split with the right column filled: the shape used for
-                 "dock to the side" in editors -->
+            <!-- one window with its right column filled: back into the screen,
+                 taking a side of it -->
             <svg viewBox="0 0 16 16" class="help-mode-icon" aria-hidden="true">
               <path
                 d="M2 3h12a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Zm0 1v8h12V4H2Z"
@@ -442,6 +623,15 @@ onBeforeUnmount(() => {
           <ol class="help-steps">
             <li v-for="(step, t) in section.steps" :key="t">{{ step }}</li>
           </ol>
+        </section>
+        <section v-if="help.terms" class="help-section">
+          <h3 class="help-heading">What these words mean</h3>
+          <dl class="help-terms">
+            <template v-for="(t, k) in help.terms">
+              <dt :key="`t${k}`">{{ t.term }}</dt>
+              <dd :key="`d${k}`">{{ t.meaning }}</dd>
+            </template>
+          </dl>
         </section>
         <button
           v-if="help.guide"
@@ -541,6 +731,10 @@ onBeforeUnmount(() => {
   }
 }
 
+.help-head.is-movable {
+  cursor: move;
+}
+
 .help-head {
   display: flex;
   align-items: center;
@@ -599,6 +793,22 @@ onBeforeUnmount(() => {
   padding-left: 18px;
   margin: 0;
   list-style: decimal;
+}
+
+.help-terms {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+}
+
+.help-terms dt {
+  font-weight: 600;
+  color: #111827;
+}
+
+.help-terms dd {
+  margin: 0 0 4px;
 }
 
 .help-guide {

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -36,8 +36,43 @@ type Help = {
   groups?: Group[];
   /** Terms someone new to the console will not know yet. Kept last on purpose. */
   terms?: Array<{ term: string; meaning: string }>;
-  guide?: { label: string; url: string };
+  /** The written guides worth reading for this screen. */
+  guides?: Array<{ label: string; url: string }>;
 };
+
+/** The same words on every screen - defined once, shown at the end of each entry. */
+const TERMS: Help['terms'] = [
+  {
+    term: 'Source service',
+    meaning:
+      'A group of the servers you are migrating from - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
+  },
+  {
+    term: 'Model',
+    meaning:
+      'What a machine or its software actually is, written in the shape this system works with. Collecting reads the raw facts; a model is those facts turned into something the migration can act on.',
+  },
+  {
+    term: 'Source model / target model',
+    meaning:
+      'Both are models - they differ in which side they describe. A source model describes the origin, the servers you are migrating from. A target model describes the same workload for the destination, usually a cloud. A workflow is built from a target model.',
+  },
+  {
+    term: 'Custom model',
+    meaning:
+      'Either kind, once you have changed its values and saved it under a new name. The original is left as it was.',
+  },
+  {
+    term: 'Workflow',
+    meaning:
+      'The steps that carry the migration out, generated from a target model. It is the last place values can be changed before anything is created, and it is what you run, watch and re-run.',
+  },
+  {
+    term: 'Where to make changes',
+    meaning:
+      'You can adjust the source model, the target model, or the workflow. Later is usually easier: the target model is already in the destination shape, and the workflow is the last word before anything runs. Target models and workflows can also be exported and imported, so a good one can be kept and reused like a template.',
+  },
+];
 
 /** Matched against the current path, longest match first. */
 const HELP: Array<{ path: string; help: Help }> = [
@@ -50,39 +85,22 @@ const HELP: Array<{ path: string; help: Help }> = [
         'Infrastructure and software migration follow the same five steps. Where they differ - a cost estimate for infrastructure, an install target for software - the help on each screen says so.',
         'The words below are the ones the steps use.',
       ],
-      terms: [
+      terms: TERMS,
+      guides: [
+        { label: 'Quick start', url: DOC_LINKS.quickStartMigration },
         {
-          term: 'Source service',
-          meaning:
-            'A group of the servers you are migrating from - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
+          label: 'Bulk import of source connections',
+          url: DOC_LINKS.sourceConnectionBulkImport,
         },
         {
-          term: 'Model',
-          meaning:
-            'What a machine or its software actually is, written in the shape this system works with. Collecting reads the raw facts; a model is those facts turned into something the migration can act on.',
+          label: 'Running workflow tasks in parallel',
+          url: DOC_LINKS.workflowParallelSteps,
         },
         {
-          term: 'Source model / target model',
-          meaning:
-            'Both are models - they differ in which side they describe. A source model describes the origin, the servers you are migrating from. A target model describes the same workload for the destination, usually a cloud. A workflow is built from a target model.',
-        },
-        {
-          term: 'Custom model',
-          meaning:
-            'Either kind, once you have changed its values and saved it under a new name. The original is left as it was.',
-        },
-        {
-          term: 'Workflow',
-          meaning:
-            'The steps that carry the migration out, generated from a target model. It is the last place values can be changed before anything is created, and it is what you run, watch and re-run.',
-        },
-        {
-          term: 'Where to make changes',
-          meaning:
-            'You can adjust the source model, the target model, or the workflow. Later is usually easier: the target model is already in the destination shape, and the workflow is the last word before anything runs. Target models and workflows can also be exported and imported, so a good one can be kept and reused like a template.',
+          label: 'Reading the run status screen',
+          url: DOC_LINKS.workflowRunStatus,
         },
       ],
-      guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
     },
   },
   {
@@ -156,42 +174,14 @@ const HELP: Array<{ path: string; help: Help }> = [
           ],
         },
       ],
-      terms: [
+      terms: TERMS,
+      guides: [
         {
-          term: 'Source service',
-          meaning:
-            'A group of the servers you are migrating from - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
+          label: 'Bulk import of source connections',
+          url: DOC_LINKS.sourceConnectionBulkImport,
         },
-        {
-          term: 'Model',
-          meaning:
-            'What a machine or its software actually is, written in the shape this system works with. Collecting reads the raw facts; a model is those facts turned into something the migration can act on.',
-        },
-        {
-          term: 'Source model / target model',
-          meaning:
-            'Both are models - they differ in which side they describe. A source model describes the origin, the servers you are migrating from. A target model describes the same workload for the destination, usually a cloud. A workflow is built from a target model.',
-        },
-        {
-          term: 'Custom model',
-          meaning:
-            'Either kind, once you have changed its values and saved it under a new name. The original is left as it was.',
-        },
-        {
-          term: 'Workflow',
-          meaning:
-            'The steps that carry the migration out, generated from a target model. It is the last place values can be changed before anything is created, and it is what you run, watch and re-run.',
-        },
-        {
-          term: 'Where to make changes',
-          meaning:
-            'You can adjust the source model, the target model, or the workflow. Later is usually easier: the target model is already in the destination shape, and the workflow is the last word before anything runs. Target models and workflows can also be exported and imported, so a good one can be kept and reused like a template.',
-        },
+        { label: 'Quick start', url: DOC_LINKS.quickStartMigration },
       ],
-      guide: {
-        label: 'Bulk import of source connections',
-        url: DOC_LINKS.sourceConnectionBulkImport,
-      },
     },
   },
   {
@@ -243,39 +233,8 @@ const HELP: Array<{ path: string; help: Help }> = [
           ],
         },
       ],
-      terms: [
-        {
-          term: 'Source service',
-          meaning:
-            'A group of the servers you are migrating from - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
-        },
-        {
-          term: 'Model',
-          meaning:
-            'What a machine or its software actually is, written in the shape this system works with. Collecting reads the raw facts; a model is those facts turned into something the migration can act on.',
-        },
-        {
-          term: 'Source model / target model',
-          meaning:
-            'Both are models - they differ in which side they describe. A source model describes the origin, the servers you are migrating from. A target model describes the same workload for the destination, usually a cloud. A workflow is built from a target model.',
-        },
-        {
-          term: 'Custom model',
-          meaning:
-            'Either kind, once you have changed its values and saved it under a new name. The original is left as it was.',
-        },
-        {
-          term: 'Workflow',
-          meaning:
-            'The steps that carry the migration out, generated from a target model. It is the last place values can be changed before anything is created, and it is what you run, watch and re-run.',
-        },
-        {
-          term: 'Where to make changes',
-          meaning:
-            'You can adjust the source model, the target model, or the workflow. Later is usually easier: the target model is already in the destination shape, and the workflow is the last word before anything runs. Target models and workflows can also be exported and imported, so a good one can be kept and reused like a template.',
-        },
-      ],
-      guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
+      terms: TERMS,
+      guides: [{ label: 'Quick start', url: DOC_LINKS.quickStartMigration }],
     },
   },
   {
@@ -326,39 +285,8 @@ const HELP: Array<{ path: string; help: Help }> = [
           ],
         },
       ],
-      terms: [
-        {
-          term: 'Source service',
-          meaning:
-            'A group of the servers you are migrating from - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
-        },
-        {
-          term: 'Model',
-          meaning:
-            'What a machine or its software actually is, written in the shape this system works with. Collecting reads the raw facts; a model is those facts turned into something the migration can act on.',
-        },
-        {
-          term: 'Source model / target model',
-          meaning:
-            'Both are models - they differ in which side they describe. A source model describes the origin, the servers you are migrating from. A target model describes the same workload for the destination, usually a cloud. A workflow is built from a target model.',
-        },
-        {
-          term: 'Custom model',
-          meaning:
-            'Either kind, once you have changed its values and saved it under a new name. The original is left as it was.',
-        },
-        {
-          term: 'Workflow',
-          meaning:
-            'The steps that carry the migration out, generated from a target model. It is the last place values can be changed before anything is created, and it is what you run, watch and re-run.',
-        },
-        {
-          term: 'Where to make changes',
-          meaning:
-            'You can adjust the source model, the target model, or the workflow. Later is usually easier: the target model is already in the destination shape, and the workflow is the last word before anything runs. Target models and workflows can also be exported and imported, so a good one can be kept and reused like a template.',
-        },
-      ],
-      guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
+      terms: TERMS,
+      guides: [{ label: 'Quick start', url: DOC_LINKS.quickStartMigration }],
     },
   },
   {
@@ -411,42 +339,93 @@ const HELP: Array<{ path: string; help: Help }> = [
           ],
         },
       ],
-      terms: [
+      terms: TERMS,
+      guides: [
         {
-          term: 'Source service',
-          meaning:
-            'A group of the servers you are migrating from - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
+          label: 'Reading the run status screen',
+          url: DOC_LINKS.workflowRunStatus,
         },
         {
-          term: 'Model',
-          meaning:
-            'What a machine or its software actually is, written in the shape this system works with. Collecting reads the raw facts; a model is those facts turned into something the migration can act on.',
+          label: 'Running workflow tasks in parallel',
+          url: DOC_LINKS.workflowParallelSteps,
         },
+        { label: 'Quick start', url: DOC_LINKS.quickStartMigration },
+      ],
+    },
+  },
+  {
+    path: '/main/workflow-management/workflow-templates',
+    help: {
+      title: 'Workflow Templates',
+      paragraphs: [
+        'A template is a workflow shape you can start from, so a migration you run often does not have to be assembled each time.',
+      ],
+      groups: [
         {
-          term: 'Source model / target model',
-          meaning:
-            'Both are models - they differ in which side they describe. A source model describes the origin, the servers you are migrating from. A target model describes the same workload for the destination, usually a cloud. A workflow is built from a target model.',
-        },
-        {
-          term: 'Custom model',
-          meaning:
-            'Either kind, once you have changed its values and saved it under a new name. The original is left as it was.',
-        },
-        {
-          term: 'Workflow',
-          meaning:
-            'The steps that carry the migration out, generated from a target model. It is the last place values can be changed before anything is created, and it is what you run, watch and re-run.',
-        },
-        {
-          term: 'Where to make changes',
-          meaning:
-            'You can adjust the source model, the target model, or the workflow. Later is usually easier: the target model is already in the destination shape, and the workflow is the last word before anything runs. Target models and workflows can also be exported and imported, so a good one can be kept and reused like a template.',
+          id: 'use-templates',
+          title: 'Using templates',
+          intro:
+            'Templates hold the same content a workflow does, minus the values that belong to one particular run. Start from one and fill in what is specific to this migration.',
+          sections: [
+            {
+              heading: 'Start from a template',
+              steps: [
+                'Open a template to see the tasks it contains and how they are ordered.',
+                'Create a workflow from it, then adjust the task values for this migration.',
+              ],
+            },
+          ],
         },
       ],
-      guide: {
-        label: 'Reading the run status screen',
-        url: DOC_LINKS.workflowRunStatus,
-      },
+      terms: TERMS,
+      guides: [
+        {
+          label: 'Running workflow tasks in parallel',
+          url: DOC_LINKS.workflowParallelSteps,
+        },
+        { label: 'Quick start', url: DOC_LINKS.quickStartMigration },
+      ],
+    },
+  },
+  {
+    path: '/main/workflow-management/task-components',
+    help: {
+      title: 'Task Components',
+      paragraphs: [
+        'A task component is one step a workflow can take - collect something, create infrastructure, install software, wait.',
+      ],
+      groups: [
+        {
+          id: 'use-tasks',
+          title: 'Working with task components',
+          intro:
+            'Components are the pieces a workflow is assembled from. Looking at one shows what it needs and what it returns, which is what the workflow editor asks you to fill in.',
+          sections: [
+            {
+              heading: 'Read a component',
+              steps: [
+                'Open a component to see the values it takes and the result it produces.',
+                'Its JSON can be viewed and edited the same way a model can.',
+              ],
+            },
+            {
+              heading: 'Use it in a workflow',
+              steps: [
+                'In the workflow editor, drag the component from the Toolbox onto the canvas.',
+                'Components that do not depend on each other can sit side by side and run together.',
+              ],
+            },
+          ],
+        },
+      ],
+      terms: TERMS,
+      guides: [
+        {
+          label: 'Running workflow tasks in parallel',
+          url: DOC_LINKS.workflowParallelSteps,
+        },
+        { label: 'Quick start', url: DOC_LINKS.quickStartMigration },
+      ],
     },
   },
   {
@@ -473,10 +452,69 @@ const HELP: Array<{ path: string; help: Help }> = [
           ],
         },
       ],
-      guide: {
-        label: 'Running workflow tasks in parallel',
-        url: DOC_LINKS.workflowParallelSteps,
-      },
+      guides: [
+        {
+          label: 'Running workflow tasks in parallel',
+          url: DOC_LINKS.workflowParallelSteps,
+        },
+        { label: 'Quick start', url: DOC_LINKS.quickStartMigration },
+      ],
+    },
+  },
+  {
+    path: '/main/cloud-resources/cloud-credentials',
+    help: {
+      title: 'Cloud Credentials',
+      paragraphs: [
+        'The accounts this system uses to create things on a cloud. A migration cannot reach a destination without one.',
+      ],
+      groups: [
+        {
+          id: 'manage-credentials',
+          title: 'Managing credentials',
+          intro:
+            'Each credential belongs to one cloud provider and is chosen when a target is decided. Registering it here is what lets a workflow act on that provider.',
+          sections: [
+            {
+              heading: 'Register and check',
+              steps: [
+                'Add a credential for the provider you are migrating to.',
+                'A migration that fails to reach its destination is often a credential that is missing, expired, or short of permissions - check here first.',
+              ],
+            },
+          ],
+        },
+      ],
+      terms: TERMS,
+      guides: [{ label: 'Quick start', url: DOC_LINKS.quickStartMigration }],
+    },
+  },
+  {
+    path: '/main/cloud-resources/apis',
+    help: {
+      title: 'APIs',
+      paragraphs: [
+        'The interfaces this console calls, listed so you can see what is available and try a call directly.',
+      ],
+      groups: [
+        {
+          id: 'browse-apis',
+          title: 'Looking up an API',
+          intro:
+            'Every screen here is built on these calls. Reading them is useful when you want to know exactly what a screen sends, or to do something the screens do not cover yet.',
+          sections: [
+            {
+              heading: 'Find and try',
+              steps: [
+                'Find the API by the framework it belongs to.',
+                'Its parameters and response shape are shown with it.',
+              ],
+            },
+          ],
+        },
+      ],
+      terms: TERMS,
+      guides: [{ label: 'Quick start', url: DOC_LINKS.quickStartMigration }],
     },
   },
   {
@@ -510,19 +548,36 @@ const HELP: Array<{ path: string; help: Help }> = [
           ],
         },
       ],
-      guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
+      guides: [{ label: 'Quick start', url: DOC_LINKS.quickStartMigration }],
     },
   },
 ];
 
-const FALLBACK: Help = {
-  title: 'Help',
-  paragraphs: [
-    'There is no help written for this screen yet.',
-    'The quick start guide walks through a migration from beginning to end.',
-  ],
-  guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
-};
+/*
+  No entry for this screen yet. Saying only "Help" left the reader unsure whether
+  the panel had failed or the screen simply has none, so the screen is named and
+  the gap is stated.
+*/
+function fallbackFor(title: string): Help {
+  return {
+    title,
+    paragraphs: [
+      'Help for this screen has not been written yet - it is on the way.',
+      'In the meantime, the quick start guide walks through a migration from beginning to end.',
+    ],
+    terms: TERMS,
+    guides: [{ label: 'Quick start', url: DOC_LINKS.quickStartMigration }],
+  };
+}
+
+/** Turns a path segment into a screen name, so the panel can title itself. */
+function screenNameFrom(path: string): string {
+  const last = path.split('/').filter(Boolean).pop() ?? 'this screen';
+  return last
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
 
 const WIDTH_KEY = 'cm.helpPanel.width';
 const MODE_KEY = 'cm.helpPanel.mode';
@@ -589,7 +644,7 @@ const help = computed<Help>(() => {
   const hit = HELP.filter(e => path.startsWith(e.path)).sort(
     (a, b) => b.path.length - a.path.length,
   )[0];
-  return hit ? hit.help : FALLBACK;
+  return hit ? hit.help : fallbackFor(screenNameFrom(path));
 });
 
 /* The index at the top scrolls to the job it names. */
@@ -800,20 +855,24 @@ onBeforeUnmount(() => {
           </dl>
         </section>
 
-        <button
-          v-if="help.guide"
-          class="help-guide"
-          data-testid="help-guide-link"
-          @click="openDocLink(help.guide.url)"
-        >
-          <svg class="help-doc-icon" viewBox="0 0 16 16" aria-hidden="true">
-            <path
-              d="M4 1.5h5.2L13 5.3V14a.5.5 0 0 1-.5.5h-8A.5.5 0 0 1 4 14V1.5Zm1 1V13.5h7V6H8.7V2.5H5Zm4.7.7V5H12L9.7 3.2ZM6 7.5h5v1H6v-1Zm0 2.5h5v1H6v-1Z"
-            />
-          </svg>
-          <span class="help-guide-text">Guide: {{ help.guide.label }}</span>
-          <span class="help-guide-out">&#8599;</span>
-        </button>
+        <section v-if="help.guides" class="help-docs">
+          <h2 class="help-group-title">Read more</h2>
+          <button
+            v-for="(doc, g) in help.guides"
+            :key="`g${g}`"
+            class="help-guide"
+            data-testid="help-guide-link"
+            @click="openDocLink(doc.url)"
+          >
+            <svg class="help-doc-icon" viewBox="0 0 16 16" aria-hidden="true">
+              <path
+                d="M4 1.5h5.2L13 5.3V14a.5.5 0 0 1-.5.5h-8A.5.5 0 0 1 4 14V1.5Zm1 1V13.5h7V6H8.7V2.5H5Zm4.7.7V5H12L9.7 3.2ZM6 7.5h5v1H6v-1Zm0 2.5h5v1H6v-1Z"
+              />
+            </svg>
+            <span class="help-guide-text">Guide: {{ doc.label }}</span>
+            <span class="help-guide-out">&#8599;</span>
+          </button>
+        </section>
       </div>
     </aside>
   </div>
@@ -955,10 +1014,13 @@ onBeforeUnmount(() => {
   border-bottom: 1px solid #f3f4f6;
 }
 
+/* Colour carries the level - the outline was hard to follow in grey alone. */
 .help-group-title {
+  padding-bottom: 4px;
   font-size: 14px;
   font-weight: 700;
-  color: #111827;
+  color: #1d4ed8;
+  border-bottom: 2px solid #dbeafe;
 }
 
 .help-group-intro {
@@ -1008,7 +1070,18 @@ onBeforeUnmount(() => {
 .help-heading {
   font-size: 12px;
   font-weight: 600;
-  color: #111827;
+  color: #1f2937;
+}
+
+.help-heading::before {
+  display: inline-block;
+  width: 3px;
+  height: 11px;
+  margin-right: 6px;
+  vertical-align: -1px;
+  content: '';
+  background: #60a5fa;
+  border-radius: 1px;
 }
 
 .help-steps {
@@ -1047,6 +1120,14 @@ onBeforeUnmount(() => {
   background: transparent;
   border: 0;
   cursor: pointer;
+}
+
+.help-docs {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 14px;
+  border-top: 1px solid #f3f4f6;
 }
 
 .help-doc-icon {

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -806,7 +806,13 @@ onBeforeUnmount(() => {
           data-testid="help-guide-link"
           @click="openDocLink(help.guide.url)"
         >
-          {{ help.guide.label }} &rsaquo;
+          <svg class="help-doc-icon" viewBox="0 0 16 16" aria-hidden="true">
+            <path
+              d="M4 1.5h5.2L13 5.3V14a.5.5 0 0 1-.5.5h-8A.5.5 0 0 1 4 14V1.5Zm1 1V13.5h7V6H8.7V2.5H5Zm4.7.7V5H12L9.7 3.2ZM6 7.5h5v1H6v-1Zm0 2.5h5v1H6v-1Z"
+            />
+          </svg>
+          <span class="help-guide-text">Guide: {{ help.guide.label }}</span>
+          <span class="help-guide-out">&#8599;</span>
         </button>
       </div>
     </aside>
@@ -1031,13 +1037,30 @@ onBeforeUnmount(() => {
 }
 
 .help-guide {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   align-self: flex-start;
   padding: 0;
   font-size: 13px;
   color: #2563eb;
-  text-decoration: underline;
   background: transparent;
   border: 0;
   cursor: pointer;
+}
+
+.help-doc-icon {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  fill: currentcolor;
+}
+
+.help-guide-text {
+  text-decoration: underline;
+}
+
+.help-guide-out {
+  color: #9ca3af;
 }
 </style>

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -31,6 +31,7 @@ const HELP: Array<{ path: string; help: Help }> = [
       title: 'Migration Guide',
       paragraphs: [
         'The five steps a migration runs through, in order. Selecting a step opens the screen where it happens.',
+        'Infrastructure and software migration follow the same five steps; where they differ, the help on each screen says so.',
         'The help icon at the top right shows help for whichever screen you are on.',
       ],
       guide: { label: 'Quick start guide', url: DOC_LINKS.quickStartMigration },
@@ -41,30 +42,53 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Source Services',
       paragraphs: [
-        'Register the servers you want to migrate, then collect what is running on them.',
+        'A source service groups the servers you want to migrate. Each connection under it is one server.',
+        'A group can be created on its own and filled in later, or created with its connections in one go.',
       ],
       sections: [
         {
-          heading: 'Register servers',
+          heading: 'Create a group only',
           steps: [
-            'Create a Source Service.',
-            'On its Connections tab, add one connection per source server - name, IP address, SSH port, user, and a password or private key.',
+            'Create a source service with a name and description.',
+            'It appears in the list with no connections. Add them whenever the server details are ready.',
           ],
         },
         {
-          heading: 'Register many at once',
+          heading: 'Create a group with its connections',
           steps: [
-            'Download the connection template to see the file layout.',
-            'Fill in your servers. The template opens in Excel and saves back as either CSV or .xlsx.',
+            'While creating the source service, add connections in the same form.',
+            'Each connection needs a name, IP address, SSH port, user, and a password or private key.',
+          ],
+        },
+        {
+          heading: 'Add connections to an existing group',
+          steps: [
+            'Select the group and open its Connections tab.',
+            'Add one connection per server, entering the details by hand.',
+          ],
+        },
+        {
+          heading: 'Register many from a file',
+          steps: [
+            'Download the connection template to see the layout.',
+            'Fill it in. The template opens in Excel and saves back as either CSV or .xlsx.',
             'Import the file. The rows to be registered are listed on screen - review them, then confirm.',
           ],
         },
         {
-          heading: 'Collect',
+          heading: 'Export what is registered',
+          steps: [
+            'Select a group, tick the connections you want, and export.',
+            'Choose CSV or Excel. The file uses the import layout, so it can be edited and imported back.',
+            'Passwords and keys are left blank - fill them in again before importing.',
+          ],
+        },
+        {
+          heading: 'Collect from the servers',
           steps: [
             'Press Refresh first. It re-checks each connection and updates Agent Status and Connection Status on the Detail tab.',
-            'Once the status is healthy, run Collect Infra. The result opens in a viewer with the machine CPU, memory, disk and network.',
-            'For software, run Collect SW instead and press Convert in the viewer.',
+            'Once the status is healthy, run Collect Infra for machines, or Collect SW for the software running on them.',
+            'The result opens in a viewer. For software, press Convert before saving.',
           ],
         },
       ],
@@ -79,22 +103,31 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Source Models',
       paragraphs: [
-        'What was collected from the registered servers, saved as a model. The rest of the flow is built on this inventory.',
+        'What was collected from the registered servers, saved as a model. The rest of the flow is built on it.',
+        'Infrastructure and software are separate models and take separate paths from here.',
       ],
       sections: [
         {
-          heading: 'Create one',
+          heading: 'Save a model',
           steps: [
-            'From a collected result, save it as a Source Model. It appears in this list.',
-            'Saving under a new name gives you a copy to adjust before recommending.',
+            'From a collected result, save it as a source model. It appears in this list.',
+            'Saving under a new name gives you a copy to adjust, leaving the original as it was.',
           ],
         },
         {
-          heading: 'Get a target from it',
+          heading: 'Infrastructure - get a target from it',
           steps: [
-            'Select a source model and run Recommend Model.',
-            'Each candidate shows an estimated monthly cost.',
-            'Choose one and save it as a Target Model.',
+            'Select an infrastructure source model and run Recommend Model.',
+            'Each candidate shows an estimated monthly cost, so you can choose by cost.',
+            'Choose one and save it as a target model.',
+          ],
+        },
+        {
+          heading: 'Software - get a target from it',
+          steps: [
+            'Select a software source model and run Recommend Model.',
+            'On the recommendation screen, press Get Migration List. The recommended migration fills the panel on the right.',
+            'Save it as a software target model. There is no cost estimate here - software is matched to what is installed, not to a machine price.',
           ],
         },
       ],
@@ -107,6 +140,7 @@ const HELP: Array<{ path: string; help: Help }> = [
       title: 'Target Models',
       paragraphs: [
         'A target model is generated from a source model. Adjust the values you want and save it as a custom model.',
+        'The list marks each one as Basic or Custom, and as a CloudModel or a SoftwareModel.',
       ],
       sections: [
         {
@@ -118,10 +152,18 @@ const HELP: Array<{ path: string; help: Help }> = [
           ],
         },
         {
-          heading: 'Build the workflow',
+          heading: 'Infrastructure - build the workflow',
           steps: [
             'Choose Make Workflow under Workflow Tool on the detail screen.',
-            'The workflow is generated from the target model, so its values are already filled in.',
+            'The workflow is generated from the target model, so the infra_migration task already carries its values.',
+          ],
+        },
+        {
+          heading: 'Software - build the workflow',
+          steps: [
+            'Choose Make Workflow on a software target model.',
+            'The run_software_migration task is filled in from the infrastructure you created - the install target namespace and infra are already set.',
+            'That means the infrastructure migration should have run first.',
           ],
         },
       ],
@@ -151,6 +193,13 @@ const HELP: Array<{ path: string; help: Help }> = [
             'Saving takes you to the run view, where you run, edit, re-run and check results on one screen.',
             'The graph shows live progress and where a run failed.',
             'You can re-run one task, everything from a task onward, or only the tasks that failed.',
+          ],
+        },
+        {
+          heading: 'After a software migration',
+          steps: [
+            'Open the Run Status tab and select the run_software_migration task.',
+            'Under Result, choose View installed software. It lists each piece of software with its version, install type, status, and the namespace, infra and node it landed on.',
           ],
         },
       ],

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -23,6 +23,8 @@ type Section = { heading: string; steps: string[] };
 type Group = {
   id: string;
   title: string;
+  /** The guide for this job, offered where it is being read rather than only at the end. */
+  guide?: { label: string; url: string };
   /** Why this job exists and what choices it offers, before the ways of doing it. */
   intro: string;
   sections: Section[];
@@ -113,6 +115,10 @@ const HELP: Array<{ path: string; help: Help }> = [
       groups: [
         {
           id: 'manage-sources',
+          guide: {
+            label: 'Bulk import of source connections',
+            url: DOC_LINKS.sourceConnectionBulkImport,
+          },
           title: 'Managing the servers you migrate from',
           intro:
             'A source service is a group of servers, and each connection under it is one server. There is no single order to build it in - create the group first and add servers when their details are ready, create both at once, add or change servers later, or bring them in from a file. Use whichever suits how you got the information.',
@@ -151,6 +157,7 @@ const HELP: Array<{ path: string; help: Help }> = [
         },
         {
           id: 'make-source-model',
+          guide: { label: 'Quick start', url: DOC_LINKS.quickStartMigration },
           title: 'Making a source model',
           intro:
             'Collecting reads what is actually on the servers; saving turns that into a source model the migration can work from. Two choices shape it - infrastructure or software, and a whole group or a single server. Collection reaches each server over SSH, so it has to be reachable at the time.',
@@ -210,6 +217,7 @@ const HELP: Array<{ path: string; help: Help }> = [
         },
         {
           id: 'make-target-model',
+          guide: { label: 'Quick start', url: DOC_LINKS.quickStartMigration },
           title: 'Producing a target model',
           intro:
             'This is where the origin turns into a destination. The two kinds part ways here: infrastructure gets candidate machines with a price to choose between, software gets a list of what to install and no price, since software is matched to what is there rather than to a machine.',
@@ -263,6 +271,7 @@ const HELP: Array<{ path: string; help: Help }> = [
         },
         {
           id: 'make-workflow',
+          guide: { label: 'Quick start', url: DOC_LINKS.quickStartMigration },
           title: 'Building the workflow',
           intro:
             'The workflow is generated from the model, so its values are already in place. What differs is the order: a software migration installs onto infrastructure, so that infrastructure has to exist first.',
@@ -299,6 +308,10 @@ const HELP: Array<{ path: string; help: Help }> = [
       groups: [
         {
           id: 'manage-workflows',
+          guide: {
+            label: 'Running workflow tasks in parallel',
+            url: DOC_LINKS.workflowParallelSteps,
+          },
           title: 'Managing workflows',
           intro:
             'Most workflows come from a target model, but one can also be built in the editor or copied from a workflow that already works. They can be exported and imported, so a good one can be kept and reused like a template.',
@@ -317,6 +330,10 @@ const HELP: Array<{ path: string; help: Help }> = [
         },
         {
           id: 'run-workflows',
+          guide: {
+            label: 'Reading the run status screen',
+            url: DOC_LINKS.workflowRunStatus,
+          },
           title: 'Running and checking results',
           intro:
             'Running, watching and re-running all happen on one screen. A failed run does not have to be started over - you can pick up from where it broke.',
@@ -363,6 +380,10 @@ const HELP: Array<{ path: string; help: Help }> = [
       groups: [
         {
           id: 'use-templates',
+          guide: {
+            label: 'Running workflow tasks in parallel',
+            url: DOC_LINKS.workflowParallelSteps,
+          },
           title: 'Using templates',
           intro:
             'Templates hold the same content a workflow does, minus the values that belong to one particular run. Start from one and fill in what is specific to this migration.',
@@ -397,6 +418,10 @@ const HELP: Array<{ path: string; help: Help }> = [
       groups: [
         {
           id: 'use-tasks',
+          guide: {
+            label: 'Running workflow tasks in parallel',
+            url: DOC_LINKS.workflowParallelSteps,
+          },
           title: 'Working with task components',
           intro:
             'Components are the pieces a workflow is assembled from. Looking at one shows what it needs and what it returns, which is what the workflow editor asks you to fill in.',
@@ -599,6 +624,8 @@ const width = ref(readWidth());
   Which one suits depends on the screen and on the person, so both are offered
   and the choice is remembered.
 */
+// Docked unless the reader has chosen otherwise before - taking a column is the
+// default because that is where the help sits without hiding anything.
 const docked = ref(localStorage.getItem(MODE_KEY) !== 'float');
 
 /* Where the detached panel sits. It opens on the right, which is also where the
@@ -842,6 +869,20 @@ onBeforeUnmount(() => {
               <li v-for="(step, t) in section.steps" :key="t">{{ step }}</li>
             </ol>
           </section>
+          <button
+            v-if="group.guide"
+            class="help-guide"
+            :data-testid="`help-group-guide-${group.id}`"
+            @click="openDocLink(group.guide.url)"
+          >
+            <svg class="help-doc-icon" viewBox="0 0 16 16" aria-hidden="true">
+              <path
+                d="M4 1.5h5.2L13 5.3V14a.5.5 0 0 1-.5.5h-8A.5.5 0 0 1 4 14V1.5Zm1 1V13.5h7V6H8.7V2.5H5Zm4.7.7V5H12L9.7 3.2ZM6 7.5h5v1H6v-1Zm0 2.5h5v1H6v-1Z"
+              />
+            </svg>
+            <span class="help-guide-text">Guide: {{ group.guide.label }}</span>
+            <span class="help-guide-out">&#8599;</span>
+          </button>
         </section>
 
         <!-- Set apart: the same words on every screen, for when one is unfamiliar. -->

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -33,25 +33,35 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Migration Guide',
       paragraphs: [
-        'The five steps a migration runs through, in order. Selecting a step opens the screen where it happens.',
-        'Infrastructure and software migration follow the same five steps; where they differ, the help on each screen says so.',
-        'The help icon at the top right shows help for whichever screen you are on.',
+        'A migration goes from the servers you have, through a model of them, to a workflow that creates the result.',
+        'Infrastructure and software migration follow the same five steps. Where they differ - a cost estimate for infrastructure, an install target for software - the help on each screen says so.',
+        'The words below are the ones the steps use.',
       ],
       terms: [
         {
           term: 'Source service',
           meaning:
-            'A group of the servers you are migrating from - on-premises machines or ones already on a cloud. Each connection under it is one server.',
+            'A group of the servers you are migrating from - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
         },
         {
-          term: 'Source model',
+          term: 'Model',
           meaning:
-            'What was found on those servers, written down. It stays close to the original machines.',
+            'What a machine or its software actually is, written in the shape this system works with. Collecting reads the raw facts; a model is those facts turned into something the migration can act on.',
         },
         {
-          term: 'Target model',
+          term: 'Source model / target model',
           meaning:
-            'The same workload described the way the destination expects it - usually a cloud. This is what a workflow is built from.',
+            'Both are models - they differ in which side they describe. A source model describes the origin, the servers you are migrating from. A target model describes the same workload for the destination, usually a cloud. A workflow is built from a target model.',
+        },
+        {
+          term: 'Custom model',
+          meaning:
+            'Either kind, once you have changed its values and saved it under a new name. The original is left as it was.',
+        },
+        {
+          term: 'Workflow',
+          meaning:
+            'The steps that carry the migration out, generated from a target model. It is the last place values can be changed before anything is created, and it is what you run, watch and re-run.',
         },
         {
           term: 'Where to make changes',
@@ -122,17 +132,27 @@ const HELP: Array<{ path: string; help: Help }> = [
         {
           term: 'Source service',
           meaning:
-            'A group of the servers you are migrating from - on-premises machines or ones already on a cloud. Each connection under it is one server.',
+            'A group of the servers you are migrating from - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
         },
         {
-          term: 'Source model',
+          term: 'Model',
           meaning:
-            'What was found on those servers, written down. It stays close to the original machines.',
+            'What a machine or its software actually is, written in the shape this system works with. Collecting reads the raw facts; a model is those facts turned into something the migration can act on.',
         },
         {
-          term: 'Target model',
+          term: 'Source model / target model',
           meaning:
-            'The same workload described the way the destination expects it - usually a cloud. This is what a workflow is built from.',
+            'Both are models - they differ in which side they describe. A source model describes the origin, the servers you are migrating from. A target model describes the same workload for the destination, usually a cloud. A workflow is built from a target model.',
+        },
+        {
+          term: 'Custom model',
+          meaning:
+            'Either kind, once you have changed its values and saved it under a new name. The original is left as it was.',
+        },
+        {
+          term: 'Workflow',
+          meaning:
+            'The steps that carry the migration out, generated from a target model. It is the last place values can be changed before anything is created, and it is what you run, watch and re-run.',
         },
         {
           term: 'Where to make changes',
@@ -184,17 +204,27 @@ const HELP: Array<{ path: string; help: Help }> = [
         {
           term: 'Source service',
           meaning:
-            'A group of the servers you are migrating from - on-premises machines or ones already on a cloud. Each connection under it is one server.',
+            'A group of the servers you are migrating from - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
         },
         {
-          term: 'Source model',
+          term: 'Model',
           meaning:
-            'What was found on those servers, written down. It stays close to the original machines.',
+            'What a machine or its software actually is, written in the shape this system works with. Collecting reads the raw facts; a model is those facts turned into something the migration can act on.',
         },
         {
-          term: 'Target model',
+          term: 'Source model / target model',
           meaning:
-            'The same workload described the way the destination expects it - usually a cloud. This is what a workflow is built from.',
+            'Both are models - they differ in which side they describe. A source model describes the origin, the servers you are migrating from. A target model describes the same workload for the destination, usually a cloud. A workflow is built from a target model.',
+        },
+        {
+          term: 'Custom model',
+          meaning:
+            'Either kind, once you have changed its values and saved it under a new name. The original is left as it was.',
+        },
+        {
+          term: 'Workflow',
+          meaning:
+            'The steps that carry the migration out, generated from a target model. It is the last place values can be changed before anything is created, and it is what you run, watch and re-run.',
         },
         {
           term: 'Where to make changes',
@@ -243,17 +273,27 @@ const HELP: Array<{ path: string; help: Help }> = [
         {
           term: 'Source service',
           meaning:
-            'A group of the servers you are migrating from - on-premises machines or ones already on a cloud. Each connection under it is one server.',
+            'A group of the servers you are migrating from - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
         },
         {
-          term: 'Source model',
+          term: 'Model',
           meaning:
-            'What was found on those servers, written down. It stays close to the original machines.',
+            'What a machine or its software actually is, written in the shape this system works with. Collecting reads the raw facts; a model is those facts turned into something the migration can act on.',
         },
         {
-          term: 'Target model',
+          term: 'Source model / target model',
           meaning:
-            'The same workload described the way the destination expects it - usually a cloud. This is what a workflow is built from.',
+            'Both are models - they differ in which side they describe. A source model describes the origin, the servers you are migrating from. A target model describes the same workload for the destination, usually a cloud. A workflow is built from a target model.',
+        },
+        {
+          term: 'Custom model',
+          meaning:
+            'Either kind, once you have changed its values and saved it under a new name. The original is left as it was.',
+        },
+        {
+          term: 'Workflow',
+          meaning:
+            'The steps that carry the migration out, generated from a target model. It is the last place values can be changed before anything is created, and it is what you run, watch and re-run.',
         },
         {
           term: 'Where to make changes',
@@ -309,17 +349,27 @@ const HELP: Array<{ path: string; help: Help }> = [
         {
           term: 'Source service',
           meaning:
-            'A group of the servers you are migrating from - on-premises machines or ones already on a cloud. Each connection under it is one server.',
+            'A group of the servers you are migrating from - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
         },
         {
-          term: 'Source model',
+          term: 'Model',
           meaning:
-            'What was found on those servers, written down. It stays close to the original machines.',
+            'What a machine or its software actually is, written in the shape this system works with. Collecting reads the raw facts; a model is those facts turned into something the migration can act on.',
         },
         {
-          term: 'Target model',
+          term: 'Source model / target model',
           meaning:
-            'The same workload described the way the destination expects it - usually a cloud. This is what a workflow is built from.',
+            'Both are models - they differ in which side they describe. A source model describes the origin, the servers you are migrating from. A target model describes the same workload for the destination, usually a cloud. A workflow is built from a target model.',
+        },
+        {
+          term: 'Custom model',
+          meaning:
+            'Either kind, once you have changed its values and saved it under a new name. The original is left as it was.',
+        },
+        {
+          term: 'Workflow',
+          meaning:
+            'The steps that carry the migration out, generated from a target model. It is the last place values can be changed before anything is created, and it is what you run, watch and re-run.',
         },
         {
           term: 'Where to make changes',

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -77,7 +77,7 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Source Services',
       paragraphs: [
-        'This menu does two things: it keeps the list of servers you are migrating from, and it turns what is collected from them into a source model.',
+        'This menu does two things: you register and manage the servers you are migrating from, and you turn what is collected from them into a source model.',
         'A source service is a group of those servers - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
       ],
       sections: [
@@ -171,7 +171,7 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Source Models',
       paragraphs: [
-        'This menu does two things: it keeps your source models, and it produces a target model from one of them.',
+        'This menu does two things: you manage your source models, and you produce a target model from one of them.',
         'A source model stays close to the original servers - it is what was found on them.',
       ],
       sections: [
@@ -240,7 +240,7 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Target Models',
       paragraphs: [
-        'This menu does two things: it keeps your target models, and it builds a workflow from one of them.',
+        'This menu does two things: you manage your target models, and you build a workflow from one of them.',
         'A target model describes the workload the way the destination expects it. The list marks each one as Basic or Custom, and as a CloudModel or a SoftwareModel.',
       ],
       sections: [
@@ -309,7 +309,7 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Workflows',
       paragraphs: [
-        'This menu keeps your workflows and runs them. A workflow is the last thing you can change before anything is actually created.',
+        'This menu is where you manage your workflows and run them. A workflow is the last thing you can change before anything is actually created.',
         'Most come from a target model, but one can be built in the editor or copied from an existing workflow and adjusted.',
       ],
       sections: [
@@ -388,7 +388,7 @@ const HELP: Array<{ path: string; help: Help }> = [
     help: {
       title: 'Workflow Management',
       paragraphs: [
-        'Workflows, the templates they can be built from, and the task components a workflow is made of.',
+        'Where you manage workflows, the templates they can be built from, and the task components a workflow is made of.',
       ],
       sections: [
         {

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -9,18 +9,31 @@
  * The text here is a short orientation. The written guides stay in the
  * repository as the single source, and each entry links to its own.
  */
-import { computed, ref, onBeforeUnmount } from 'vue';
+import { computed, ref, onBeforeUnmount, getCurrentInstance } from 'vue';
 import { useRoute } from 'vue-router/composables';
 import { DOC_LINKS, openDocLink } from '@/shared/constants/docLinks';
 
 type Section = { heading: string; steps: string[] };
 
+/**
+ * What this menu lets you do, as one job with its own explanation and the ways
+ * of doing it underneath. A menu usually does more than one job, and reading
+ * the ways without knowing which job they belong to is where it fell apart.
+ */
+type Group = {
+  id: string;
+  title: string;
+  /** Why this job exists and what choices it offers, before the ways of doing it. */
+  intro: string;
+  sections: Section[];
+};
+
 type Help = {
   title: string;
   /** What this menu is for, before any of the steps. */
   paragraphs: string[];
-  /** How to actually use the screen, as the steps you take on it. */
-  sections?: Section[];
+  /** The jobs this menu does. Listed at the top, each jumping to its part. */
+  groups?: Group[];
   /** Terms someone new to the console will not know yet. Kept last on purpose. */
   terms?: Array<{ term: string; meaning: string }>;
   guide?: { label: string; url: string };
@@ -78,53 +91,68 @@ const HELP: Array<{ path: string; help: Help }> = [
       title: 'Source Services',
       paragraphs: [
         'This menu does two things: you register and manage the servers you are migrating from, and you turn what is collected from them into a source model.',
-        'A source service is a group of those servers - on-premises machines or ones already running on a cloud. Each connection under it is one server.',
       ],
-      sections: [
+      groups: [
         {
-          heading: 'Managing the group - create it empty',
-          steps: [
-            'Create a source service with a name and description.',
-            'It appears in the list with no connections. Add them whenever the server details are ready.',
+          id: 'manage-sources',
+          title: 'Managing the servers you migrate from',
+          intro:
+            'A source service is a group of servers, and each connection under it is one server. There is no single order to build it in - create the group first and add servers when their details are ready, create both at once, add or change servers later, or bring them in from a file. Use whichever suits how you got the information.',
+          sections: [
+            {
+              heading: 'Create the group first',
+              steps: [
+                'Create a source service with a name and description.',
+                'It appears in the list with no connections. Add them whenever the server details are ready.',
+              ],
+            },
+            {
+              heading: 'Create the group with its servers',
+              steps: [
+                'While creating the source service, add connections in the same form.',
+                'Each connection needs a name, IP address, SSH port, user, and a password or private key.',
+              ],
+            },
+            {
+              heading: 'Add or change servers later',
+              steps: [
+                'Select the group and open its Connections tab to add a server by hand.',
+                'Connections can be edited or removed the same way as the group itself.',
+              ],
+            },
+            {
+              heading: 'Bring servers in from a file',
+              steps: [
+                'Download the connection template to see the layout.',
+                'Fill it in. The template opens in Excel and saves back as either CSV or .xlsx.',
+                'Import the file. The rows to be registered are listed on screen - review them, then confirm.',
+                'What is already registered can be exported in the same layout, so a group can be copied or kept as a starting point. Passwords and keys come out blank and have to be filled in again.',
+              ],
+            },
           ],
         },
         {
-          heading: 'Managing the group - create it with connections',
-          steps: [
-            'While creating the source service, add connections in the same form.',
-            'Each connection needs a name, IP address, SSH port, user, and a password or private key.',
-          ],
-        },
-        {
-          heading: 'Managing the group - add, edit or remove later',
-          steps: [
-            'Select the group and open its Connections tab to add a server by hand.',
-            'Connections can be edited or removed the same way as the group itself.',
-          ],
-        },
-        {
-          heading: 'Managing the group - from a file',
-          steps: [
-            'Download the connection template to see the layout.',
-            'Fill it in. The template opens in Excel and saves back as either CSV or .xlsx.',
-            'Import the file. The rows to be registered are listed on screen - review them, then confirm.',
-            'What is already registered can be exported in the same layout, so a group can be copied or kept as a starting point. Passwords and keys come out blank and have to be filled in again.',
-          ],
-        },
-        {
-          heading: 'Making a source model - choose what to migrate',
-          steps: [
-            'Decide whether you are migrating infrastructure or software - the collection differs.',
-            'Select a whole group to cover every server in it, or a single connection to cover one server.',
-          ],
-        },
-        {
-          heading: 'Making a source model - collect and save',
-          steps: [
-            'Press Refresh first. Collection reaches the server over SSH, so it has to be reachable - Refresh re-checks that and updates Agent Status and Connection Status on the Detail tab.',
-            'Run Collect Infra for machines, or Collect SW for the software on them.',
-            'The result opens in a viewer. Check it, and for software press Convert.',
-            'Save it as a source model. It then appears under Models.',
+          id: 'make-source-model',
+          title: 'Making a source model',
+          intro:
+            'Collecting reads what is actually on the servers; saving turns that into a source model the migration can work from. Two choices shape it - infrastructure or software, and a whole group or a single server. Collection reaches each server over SSH, so it has to be reachable at the time.',
+          sections: [
+            {
+              heading: 'Choose what to collect',
+              steps: [
+                'Decide whether you are migrating infrastructure or software - the collection differs.',
+                'Select a whole group to cover every server in it, or a single connection to cover one server.',
+              ],
+            },
+            {
+              heading: 'Collect and save',
+              steps: [
+                'Press Refresh first. It re-checks that each server can still be reached and updates Agent Status and Connection Status on the Detail tab.',
+                'Run Collect Infra for machines, or Collect SW for the software on them.',
+                'The result opens in a viewer. Check it, and for software press Convert.',
+                'Save it as a source model. It then appears under Models.',
+              ],
+            },
           ],
         },
       ],
@@ -172,31 +200,46 @@ const HELP: Array<{ path: string; help: Help }> = [
       title: 'Source Models',
       paragraphs: [
         'This menu does two things: you manage your source models, and you produce a target model from one of them.',
-        'A source model stays close to the original servers - it is what was found on them.',
       ],
-      sections: [
+      groups: [
         {
-          heading: 'Managing models',
-          steps: [
-            'Open a model to review what was collected, and adjust anything the collection got wrong.',
-            'Saving under a new name gives you a custom copy and leaves the original as it was.',
-            'Models can be renamed and removed here.',
+          id: 'manage-source-models',
+          title: 'Managing source models',
+          intro:
+            'A source model describes the servers you are migrating from. If collection got something wrong, or you want to try a variation, change it here - saving under a new name gives you a custom copy and leaves the original alone.',
+          sections: [
+            {
+              heading: 'Review and adjust',
+              steps: [
+                'Open a model to review what was collected, and adjust anything that is wrong.',
+                'Saving under a new name gives you a custom copy.',
+                'Models can be renamed and removed here.',
+              ],
+            },
           ],
         },
         {
-          heading: 'Infrastructure - produce a target model',
-          steps: [
-            'Select an infrastructure source model and run Recommend Model.',
-            'Each candidate shows an estimated monthly cost, so you can choose by cost.',
-            'Choose one and save it as a target model.',
-          ],
-        },
-        {
-          heading: 'Software - produce a target model',
-          steps: [
-            'Select a software source model and run Recommend Model.',
-            'Press Get Migration List. The recommended migration fills the panel on the right.',
-            'Save it as a software target model. There is no cost here - software is matched to what is installed, not to a machine price.',
+          id: 'make-target-model',
+          title: 'Producing a target model',
+          intro:
+            'This is where the origin turns into a destination. The two kinds part ways here: infrastructure gets candidate machines with a price to choose between, software gets a list of what to install and no price, since software is matched to what is there rather than to a machine.',
+          sections: [
+            {
+              heading: 'Infrastructure',
+              steps: [
+                'Select an infrastructure source model and run Recommend Model.',
+                'Each candidate shows an estimated monthly cost, so you can choose by cost.',
+                'Choose one and save it as a target model.',
+              ],
+            },
+            {
+              heading: 'Software',
+              steps: [
+                'Select a software source model and run Recommend Model.',
+                'Press Get Migration List. The recommended migration fills the panel on the right.',
+                'Save it as a software target model.',
+              ],
+            },
           ],
         },
       ],
@@ -241,31 +284,45 @@ const HELP: Array<{ path: string; help: Help }> = [
       title: 'Target Models',
       paragraphs: [
         'This menu does two things: you manage your target models, and you build a workflow from one of them.',
-        'A target model describes the workload the way the destination expects it. The list marks each one as Basic or Custom, and as a CloudModel or a SoftwareModel.',
       ],
-      sections: [
+      groups: [
         {
-          heading: 'Managing models',
-          steps: [
-            'Open Custom & View to see the model as JSON.',
-            'The table view edits values and adds or removes list entries; the tree and text views are the same document in another shape.',
-            'Saving asks for a name and creates a custom model - the original is left as it was.',
-            'A model can be exported to a file and imported back, so a good one can be kept and reused.',
+          id: 'manage-target-models',
+          title: 'Managing target models',
+          intro:
+            'A target model describes the workload the way the destination expects it, which makes this a good place to adjust values. The list marks each one as Basic or Custom, and as a CloudModel or a SoftwareModel. A model can be exported and imported, so one that works can be kept and reused.',
+          sections: [
+            {
+              heading: 'Adjust and save',
+              steps: [
+                'Open Custom & View to see the model as JSON.',
+                'The table view edits values and adds or removes list entries; the tree and text views are the same document in another shape.',
+                'Saving asks for a name and creates a custom model - the original is left as it was.',
+              ],
+            },
           ],
         },
         {
-          heading: 'Infrastructure - build the workflow',
-          steps: [
-            'Choose Make Workflow under Workflow Tool on the detail screen.',
-            'The workflow is generated from the target model, so the infra_migration task already carries its values.',
-          ],
-        },
-        {
-          heading: 'Software - build the workflow',
-          steps: [
-            'Choose Make Workflow on a software target model.',
-            'The run_software_migration task is filled in from the infrastructure you created - the install target namespace and infra are already set.',
-            'That means the infrastructure migration should have run first.',
+          id: 'make-workflow',
+          title: 'Building the workflow',
+          intro:
+            'The workflow is generated from the model, so its values are already in place. What differs is the order: a software migration installs onto infrastructure, so that infrastructure has to exist first.',
+          sections: [
+            {
+              heading: 'Infrastructure',
+              steps: [
+                'Choose Make Workflow under Workflow Tool on the detail screen.',
+                'The infra_migration task already carries the model values.',
+              ],
+            },
+            {
+              heading: 'Software',
+              steps: [
+                'Choose Make Workflow on a software target model.',
+                'The run_software_migration task is filled in from the infrastructure you created - the install target namespace and infra are already set.',
+                'That means the infrastructure migration should have run first.',
+              ],
+            },
           ],
         },
       ],
@@ -310,38 +367,47 @@ const HELP: Array<{ path: string; help: Help }> = [
       title: 'Workflows',
       paragraphs: [
         'This menu is where you manage your workflows and run them. A workflow is the last thing you can change before anything is actually created.',
-        'Most come from a target model, but one can be built in the editor or copied from an existing workflow and adjusted.',
       ],
-      sections: [
+      groups: [
         {
-          heading: 'Managing workflows',
-          steps: [
-            'Create one from a target model, build it in the editor, or copy an existing workflow and change its values.',
-            'A workflow can be exported to a file and imported back, so a working one can be kept and reused like a template.',
+          id: 'manage-workflows',
+          title: 'Managing workflows',
+          intro:
+            'Most workflows come from a target model, but one can also be built in the editor or copied from a workflow that already works. They can be exported and imported, so a good one can be kept and reused like a template.',
+          sections: [
+            {
+              heading: 'Create, copy and check',
+              steps: [
+                'Create one from a target model, build it in the editor, or copy an existing workflow and change its values.',
+                'Select the migration task on the canvas. Task Configuration opens on the right with the values carried over from the target model - path and query parameters and the request body.',
+                'Review them and edit anything that needs adjusting.',
+                'Drag components from the Toolbox on the left to extend what the workflow does.',
+                'Give the workflow a name and save it.',
+              ],
+            },
           ],
         },
         {
-          heading: 'Check it before running',
-          steps: [
-            'Select the migration task on the canvas. Task Configuration opens on the right with the values carried over from the target model - path and query parameters and the request body.',
-            'Review them and edit anything that needs adjusting.',
-            'Drag components from the Toolbox on the left to extend what the workflow does.',
-            'Give the workflow a name and save it.',
-          ],
-        },
-        {
-          heading: 'Run, watch and run again',
-          steps: [
-            'Saving takes you to the run view, where you run, edit, re-run and check results on one screen.',
-            'The graph shows live progress and where a run failed.',
-            'You can re-run one task, everything from a task onward, or only the tasks that failed.',
-          ],
-        },
-        {
-          heading: 'After a software migration',
-          steps: [
-            'Open the Run Status tab and select the run_software_migration task.',
-            'Under Result, choose View installed software. It lists each piece of software with its version, install type, status, and the namespace, infra and node it landed on.',
+          id: 'run-workflows',
+          title: 'Running and checking results',
+          intro:
+            'Running, watching and re-running all happen on one screen. A failed run does not have to be started over - you can pick up from where it broke.',
+          sections: [
+            {
+              heading: 'Run and watch',
+              steps: [
+                'Saving takes you to the run view.',
+                'The graph shows live progress and where a run failed.',
+                'You can re-run one task, everything from a task onward, or only the tasks that failed.',
+              ],
+            },
+            {
+              heading: 'After a software migration',
+              steps: [
+                'Open the Run Status tab and select the run_software_migration task.',
+                'Under Result, choose View installed software. It lists each piece of software with its version, install type, status, and the namespace, infra and node it landed on.',
+              ],
+            },
           ],
         },
       ],
@@ -390,12 +456,20 @@ const HELP: Array<{ path: string; help: Help }> = [
       paragraphs: [
         'Where you manage workflows, the templates they can be built from, and the task components a workflow is made of.',
       ],
-      sections: [
+      groups: [
         {
-          heading: 'Working with tasks',
-          steps: [
-            'A task component is one step a workflow can take; a template is a workflow shape you can start from.',
-            'Tasks that do not depend on each other can be placed side by side to run together.',
+          id: 'workflow-parts',
+          title: 'What the parts are',
+          intro:
+            'A workflow is assembled from smaller pieces, and those pieces are managed here rather than inside a single workflow.',
+          sections: [
+            {
+              heading: 'Tasks and templates',
+              steps: [
+                'A task component is one step a workflow can take; a template is a workflow shape you can start from.',
+                'Tasks that do not depend on each other can be placed side by side to run together.',
+              ],
+            },
           ],
         },
       ],
@@ -412,19 +486,27 @@ const HELP: Array<{ path: string; help: Help }> = [
       paragraphs: [
         'What a migration produced, and where you check, test or remove it.',
       ],
-      sections: [
+      groups: [
         {
-          heading: 'Check what was created',
-          steps: [
-            'Open Infra Workloads and select the workload.',
-            'The Detail tab shows the infrastructure; the Server tab lists its servers.',
-          ],
-        },
-        {
-          heading: 'Load-test it',
-          steps: [
-            'Start a load test on the selected workload.',
-            'Progress is shown live, and completion or failure is announced in the notification badge at the top right.',
+          id: 'check-workloads',
+          title: 'Checking and testing what was created',
+          intro:
+            'A finished migration leaves real infrastructure behind. This is where you look at it, put load on it, and remove it when it is no longer needed.',
+          sections: [
+            {
+              heading: 'Check what was created',
+              steps: [
+                'Open Infra Workloads and select the workload.',
+                'The Detail tab shows the infrastructure; the Server tab lists its servers.',
+              ],
+            },
+            {
+              heading: 'Load-test it',
+              steps: [
+                'Start a load test on the selected workload.',
+                'Progress is shown live, and completion or failure is announced in the notification badge at the top right.',
+              ],
+            },
           ],
         },
       ],
@@ -448,6 +530,9 @@ const MIN_WIDTH = 280;
 const MAX_WIDTH = 720;
 
 const route = useRoute();
+const { $refs } = getCurrentInstance()!.proxy as unknown as {
+  $refs: Record<string, unknown>;
+};
 const open = ref(false);
 const width = ref(readWidth());
 
@@ -506,6 +591,12 @@ const help = computed<Help>(() => {
   )[0];
   return hit ? hit.help : FALLBACK;
 });
+
+/* The index at the top scrolls to the job it names. */
+function jumpTo(id: string) {
+  const target = ($refs[`group-${id}`] as HTMLElement[] | undefined)?.[0];
+  target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
 
 function toggle() {
   open.value = !open.value;
@@ -664,18 +755,43 @@ onBeforeUnmount(() => {
       </header>
       <div class="help-body">
         <p v-for="(line, i) in help.paragraphs" :key="i">{{ line }}</p>
+
+        <!-- What this menu does, as a list you can jump from. -->
+        <nav v-if="(help.groups || []).length > 1" class="help-index">
+          <button
+            v-for="group in help.groups"
+            :key="`i-${group.id}`"
+            class="help-index-item"
+            :data-testid="`help-index-${group.id}`"
+            @click="jumpTo(group.id)"
+          >
+            {{ group.title }}
+          </button>
+        </nav>
+
         <section
-          v-for="(section, s) in help.sections || []"
-          :key="`s${s}`"
-          class="help-section"
+          v-for="group in help.groups || []"
+          :key="group.id"
+          :ref="`group-${group.id}`"
+          class="help-group"
         >
-          <h3 class="help-heading">{{ section.heading }}</h3>
-          <ol class="help-steps">
-            <li v-for="(step, t) in section.steps" :key="t">{{ step }}</li>
-          </ol>
+          <h2 class="help-group-title">{{ group.title }}</h2>
+          <p class="help-group-intro">{{ group.intro }}</p>
+          <section
+            v-for="(section, x) in group.sections"
+            :key="`s${x}`"
+            class="help-section"
+          >
+            <h3 class="help-heading">{{ section.heading }}</h3>
+            <ol class="help-steps">
+              <li v-for="(step, t) in section.steps" :key="t">{{ step }}</li>
+            </ol>
+          </section>
         </section>
-        <section v-if="help.terms" class="help-section">
-          <h3 class="help-heading">What these words mean</h3>
+
+        <!-- Set apart: the same words on every screen, for when one is unfamiliar. -->
+        <section v-if="help.terms" class="help-glossary">
+          <h2 class="help-group-title">Words used here</h2>
           <dl class="help-terms">
             <template v-for="(t, k) in help.terms">
               <dt :key="`t${k}`">{{ t.term }}</dt>
@@ -683,6 +799,7 @@ onBeforeUnmount(() => {
             </template>
           </dl>
         </section>
+
         <button
           v-if="help.guide"
           class="help-guide"
@@ -822,6 +939,58 @@ onBeforeUnmount(() => {
   font-size: 13px;
   line-height: 1.7;
   color: #374151;
+}
+
+.help-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.help-group-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.help-group-intro {
+  color: #4b5563;
+}
+
+.help-index {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  background: #f9fafb;
+  border-radius: 4px;
+}
+
+.help-index-item {
+  padding: 0;
+  font-size: 12px;
+  color: #2563eb;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+/* A gap and a rule, so the shared words read as a footnote rather than one more
+   thing this screen does. */
+.help-glossary {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 18px;
+  margin-top: 8px;
+  border-top: 2px solid #e5e7eb;
 }
 
 .help-section {


### PR DESCRIPTION
도움말을 여는 사람은 대개 **어딘가에서 막혀 있습니다.** 그런데 지금 도움말은 "이 화면은 무엇이다"까지만 말하고, 실제로 무엇을 어떤 순서로 하는지는 다른 탭의 문서에 맡기고 있었습니다.

## 하는 일을 먼저 말하고, 그 아래에 방식을 둡니다

한 메뉴가 하는 일이 여럿인데 방식만 나열하면 서로 무관한 항목처럼 읽힙니다. 소스 서비스 화면은 **대상 서버를 등록·관리하는 일**과 **수집해서 소스 모델을 만드는 일** 두 가지를 하고, 그룹을 만드는 방식만 해도 네 가지입니다.

이제 각 메뉴의 도움말이 하는 일을 이름 짓고 맨 위에 목록으로 보여줍니다. 누르면 그 자리로 스크롤합니다. 일마다 **왜 있고 어떤 선택지가 있는지** 설명이 먼저 오고 그 아래에 방식별 절차가 옵니다 — 그룹을 먼저 만들고 나중에 채우거나, 한 번에 만들거나, 나중에 추가하거나, 파일로 가져오거나, 정보를 어떻게 얻었는지에 따라 고르면 된다는 식으로. 제목 계층은 색으로 구분합니다.

## 도움말이 없던 화면들

워크플로우 템플릿·태스크 컴포넌트·워크로드·클라우드 크리덴셜·API 는 항목이 없어 상위 메뉴 설명이나 제목이 `Help` 인 화면으로 떨어지고 있었습니다. 고장으로 보입니다. 각각 채웠고, 아직 없는 화면은 **화면 이름을 제목으로 보여주고 준비 중임을 알립니다.**

## 만들어 둔 가이드를 화면에 잇습니다

문서 4종이 있는데 링크가 거의 걸려 있지 않았습니다. 화면마다 관련 문서를 걸고, **읽고 있는 자리에서** 바로 갈 수 있게 각 일의 설명 끝에도 링크를 둡니다. 하단 목록만 있으면 용어 설명 아래라 한 번 보고 다시 보지 않습니다. 링크는 문서 아이콘과 `Guide:` 접두어, 새 창 표시를 달아 누르기 전에 문서임을 알 수 있게 했습니다.

## 함께 정리한 것

- 모델의 정의를 바로잡았습니다 — *수집한 것* 이 아니라 **수집한 사실을 이 시스템이 다루는 형태로 적은 것**. 소스와 타깃은 어느 쪽을 기술하느냐만 다릅니다
- 용어(소스 서비스·모델·커스텀 모델·워크플로우·어디서 고치는 게 편한지)를 가로선 아래로 떼어 각주처럼 읽히게 했습니다
- 마이그레이션 가이드 화면에는 같은 설명을 단계 박스 아래 문단으로 풀어 넣었습니다. 박스는 순서만 말할 뿐 모델이 무엇인지는 답하지 않습니다
- 1단계의 수집 에이전트 언급을 뺐습니다. 그 단계에서 할 일과 무관하고 화면이 답하지 않는 질문을 만듭니다
- 마이그레이션 가이드 도움말이 *우측 상단 도움말을 누르라* 고 안내하고 있었습니다 — 이미 눌러서 열린 화면에서
- 패널 모드 아이콘을 창 두 개/한 개로 바꾸고(자물쇠처럼 보였습니다), 분리 상태에서 제목 줄을 끌어 옮길 수 있게 했습니다. 오른쪽에 떠서 버튼을 가리기 때문입니다

## 확인

개발 서버에서 구동해 14개 항목을 확인했습니다 — 화면별 그룹 구분, 목차 이동, 용어 분리, 그룹별·하단 문서 링크, 채워진 다섯 화면, 패널 기본 모드와 드래그, 브라우저 오류 없음.

---

- [BAR-1658](https://mzdevs.atlassian.net/browse/BAR-1658) 화면별 도움말 내용 보강 — 사용 절차·용어·문서 링크
- [BAR-1645](https://mzdevs.atlassian.net/browse/BAR-1645) cm-butterfly v0.5.4 pre-release (취합)

테스트 결과서: `notion/cm-bf-ep-전환워크플로우웹플래닝고도화/018_도움말진입점/ST3_단위테스트/TR-BAR-1658.md`