### PR TITLE
feat(front): unify the JSON editor toolbars and give the table view a filter

### DIFF
--- a/front/src/shared/ui/EnhancedJsonEditor/EnhancedJsonEditor.vue
+++ b/front/src/shared/ui/EnhancedJsonEditor/EnhancedJsonEditor.vue
@@ -13,6 +13,7 @@ import {
   type Content,
   type OnChangeStatus,
   type JSONEditorPropsOptional,
+  type MenuItem,
 } from 'vanilla-jsoneditor';
 import JsonPropertyGrid from './JsonPropertyGrid.vue';
 
@@ -304,11 +305,19 @@ function initEditor() {
     /*
       The grid used to carry its own row of controls under the editor's, which
       read as two toolbars for one document. The editor offers this hook to put
-      items in its menu, so the grid's controls go there and only while the grid
-      is the view being shown.
+      items in its own menu, so the grid's controls go there - in the same place
+      the tree view keeps expand and collapse, so the row does not rearrange
+      itself when you change view.
 
-      Icons are given as the shape the menu expects; drawing our own keeps the
-      icon set out of this project's dependencies.
+      Three of the editor's own items are dropped while the grid is showing.
+      Search reaches the view the editor is drawing, which is hidden here, so it
+      would be a second magnifier that finds nothing. Sort and transform act on
+      whatever the editor has selected, and the grid makes no selection in it -
+      there is no way to say which array to sort, which is why a nested one like
+      the network interfaces never appears as a choice.
+
+      Icons are given as the shape the menu expects; drawing our own keeps
+      another icon set out of this project's dependencies.
     */
     onRenderMenu: (items, context) => {
       if (context.mode !== Mode.table) return items;
@@ -319,9 +328,16 @@ function initEditor() {
         icon: [16, 16, [], '', path],
       });
 
-      return [
-        ...items,
-        { type: 'separator' },
+      const titleOf = (item: MenuItem) =>
+        'title' in item ? (item.title ?? '') : '';
+      const isMode = (item: MenuItem) => /current mode/i.test(titleOf(item));
+      const unusableHere = (item: MenuItem) =>
+        /^(Search|Sort|Transform)/i.test(titleOf(item));
+
+      const kept = items.filter(item => !unusableHere(item));
+      const lastMode = kept.map(isMode).lastIndexOf(true);
+
+      const ours: MenuItem[] = [
         {
           type: 'button',
           title: 'Expand all',
@@ -336,7 +352,7 @@ function initEditor() {
           icon: icon(
             'M2 7.25h12v1.5H2v-1.5ZM2 11.5h12V13H2v-1.5ZM8 1l3 3.5H5L8 1Z',
           ),
-          onClick: () => gridRef.value?.collapseAll(),
+          onClick: () => gridRef.value?.expandToDepth(1),
         },
         {
           type: 'button',
@@ -364,6 +380,13 @@ function initEditor() {
           ),
           onClick: () => gridRef.value?.openSearch(),
         },
+      ];
+
+      return [
+        ...kept.slice(0, lastMode + 1),
+        { type: 'separator' },
+        ...ours,
+        ...kept.slice(lastMode + 1),
       ];
     },
     onChangeMode: (mode: Mode) => {

--- a/front/src/shared/ui/EnhancedJsonEditor/EnhancedJsonEditor.vue
+++ b/front/src/shared/ui/EnhancedJsonEditor/EnhancedJsonEditor.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
-import { computed, ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue';
+import {
+  computed,
+  ref,
+  watch,
+  onMounted,
+  onBeforeUnmount,
+  nextTick,
+} from 'vue';
 import {
   JSONEditor,
   Mode,
@@ -59,7 +66,14 @@ const emit = defineEmits<{
   */
   (e: 'update:model-value', value: string): void;
   (e: 'update:mode', value: string): void;
-  (e: 'change', value: { content: Content; previousContent: Content; changeStatus: OnChangeStatus }): void;
+  (
+    e: 'change',
+    value: {
+      content: Content;
+      previousContent: Content;
+      changeStatus: OnChangeStatus;
+    },
+  ): void;
   (e: 'error', value: Error): void;
   (e: 'import', value: { fileName: string; json: unknown }): void;
   (e: 'export', value: { fileName: string }): void;
@@ -77,6 +91,12 @@ const currentMode = ref<Mode>(props.mode as Mode);
   and the grid, which flattens any document to key/value rows, takes its place.
 */
 const showPropertyGrid = ref(props.mode === 'table');
+const gridRef = ref<{
+  expandAll: () => void;
+  collapseAll: () => void;
+  expandToDepth: (depth: number) => void;
+  openSearch: () => void;
+} | null>(null);
 const hasError = ref(false);
 const errorMessage = ref('');
 
@@ -99,12 +119,18 @@ function toContent(value: string | object | undefined): Content {
 function contentToString(content: Content): string {
   if ('json' in content && content.json !== undefined) {
     const result = JSON.stringify(content.json, null, 2);
-    console.log('[EnhancedJsonEditor] contentToString (JSON mode):', result.substring(0, 50));
+    console.log(
+      '[EnhancedJsonEditor] contentToString (JSON mode):',
+      result.substring(0, 50),
+    );
     return result;
   }
   if ('text' in content && content.text !== undefined) {
     const trimmed = content.text.trim();
-    console.log('[EnhancedJsonEditor] contentToString (Text mode), trimmed:', JSON.stringify(trimmed).substring(0, 50));
+    console.log(
+      '[EnhancedJsonEditor] contentToString (Text mode), trimmed:',
+      JSON.stringify(trimmed).substring(0, 50),
+    );
     // For an empty string, return the JSON of an empty object
     if (!trimmed || trimmed === '') {
       console.log('[EnhancedJsonEditor] Empty text detected, returning "{}"');
@@ -113,7 +139,7 @@ function contentToString(content: Content): string {
     return content.text;
   }
   console.log('[EnhancedJsonEditor] contentToString fallback, returning "{}"');
-  return '{}';  // default to '{}' instead of an empty string
+  return '{}'; // default to '{}' instead of an empty string
 }
 
 /* ── Import / Export ───────────────────────────────────────── */
@@ -250,18 +276,95 @@ function initEditor() {
     mainMenuBar: props.mainMenuBar,
     navigationBar: props.navigationBar,
     statusBar: props.statusBar,
-    onChange: (content: Content, previousContent: Content, changeStatus: OnChangeStatus) => {
+    onChange: (
+      content: Content,
+      previousContent: Content,
+      changeStatus: OnChangeStatus,
+    ) => {
       if (props.readOnly) {
         console.log('[EnhancedJsonEditor] onChange skipped - readOnly mode');
         return;
       }
-      console.log('[EnhancedJsonEditor] onChange triggered, readOnly:', props.readOnly);
+      console.log(
+        '[EnhancedJsonEditor] onChange triggered, readOnly:',
+        props.readOnly,
+      );
       hasError.value = false;
       errorMessage.value = '';
       const strValue = contentToString(content);
-      console.log('[EnhancedJsonEditor] Emitting update:modelValue:', JSON.stringify(strValue).substring(0, 100), 'type:', typeof strValue);
+      console.log(
+        '[EnhancedJsonEditor] Emitting update:modelValue:',
+        JSON.stringify(strValue).substring(0, 100),
+        'type:',
+        typeof strValue,
+      );
       emitModelValue(strValue);
       emit('change', { content, previousContent, changeStatus });
+    },
+    /*
+      The grid used to carry its own row of controls under the editor's, which
+      read as two toolbars for one document. The editor offers this hook to put
+      items in its menu, so the grid's controls go there and only while the grid
+      is the view being shown.
+
+      Icons are given as the shape the menu expects; drawing our own keeps the
+      icon set out of this project's dependencies.
+    */
+    onRenderMenu: (items, context) => {
+      if (context.mode !== Mode.table) return items;
+
+      const icon = (path: string) => ({
+        prefix: 'cm',
+        iconName: 'grid',
+        icon: [16, 16, [], '', path],
+      });
+
+      return [
+        ...items,
+        { type: 'separator' },
+        {
+          type: 'button',
+          title: 'Expand all',
+          icon: icon(
+            'M2 3h12v1.5H2V3Zm0 4.25h12v1.5H2v-1.5ZM8 15l-3-3.5h6L8 15Z',
+          ),
+          onClick: () => gridRef.value?.expandAll(),
+        },
+        {
+          type: 'button',
+          title: 'Collapse all',
+          icon: icon(
+            'M2 7.25h12v1.5H2v-1.5ZM2 11.5h12V13H2v-1.5ZM8 1l3 3.5H5L8 1Z',
+          ),
+          onClick: () => gridRef.value?.collapseAll(),
+        },
+        {
+          type: 'button',
+          text: 'D3',
+          title: 'Expand 3 levels',
+          onClick: () => gridRef.value?.expandToDepth(3),
+        },
+        {
+          type: 'button',
+          text: 'D5',
+          title: 'Expand 5 levels',
+          onClick: () => gridRef.value?.expandToDepth(5),
+        },
+        {
+          type: 'button',
+          text: 'D7',
+          title: 'Expand 7 levels',
+          onClick: () => gridRef.value?.expandToDepth(7),
+        },
+        {
+          type: 'button',
+          title: 'Search (Ctrl+F)',
+          icon: icon(
+            'M6.75 1.5a5.25 5.25 0 0 1 4.14 8.48l3.57 3.56-1.06 1.06-3.56-3.57A5.25 5.25 0 1 1 6.75 1.5Zm0 1.5a3.75 3.75 0 1 0 0 7.5 3.75 3.75 0 0 0 0-7.5Z',
+          ),
+          onClick: () => gridRef.value?.openSearch(),
+        },
+      ];
     },
     onChangeMode: (mode: Mode) => {
       currentMode.value = mode;
@@ -309,19 +412,29 @@ onBeforeUnmount(() => {
 // Watch for external modelValue changes
 watch(
   () => props.modelValue,
-  (newValue) => {
-    console.log('[EnhancedJsonEditor] modelValue changed:', typeof newValue, newValue?.length || Object.keys(newValue || {}).length);
+  newValue => {
+    console.log(
+      '[EnhancedJsonEditor] modelValue changed:',
+      typeof newValue,
+      newValue?.length || Object.keys(newValue || {}).length,
+    );
     if (!editorInstance) {
       console.warn('[EnhancedJsonEditor] Editor instance not ready');
       return;
     }
     try {
       const newContent = toContent(newValue);
-      console.log('[EnhancedJsonEditor] Updating editor with content:', 'json' in newContent ? 'JSON mode' : 'Text mode');
+      console.log(
+        '[EnhancedJsonEditor] Updating editor with content:',
+        'json' in newContent ? 'JSON mode' : 'Text mode',
+      );
       editorInstance.update(newContent);
       console.log('[EnhancedJsonEditor] Editor updated successfully');
     } catch (err) {
-      console.error('[EnhancedJsonEditor] Failed to update editor content:', err);
+      console.error(
+        '[EnhancedJsonEditor] Failed to update editor content:',
+        err,
+      );
     }
   },
 );
@@ -329,7 +442,7 @@ watch(
 // Watch for readOnly changes
 watch(
   () => props.readOnly,
-  (newReadOnly) => {
+  newReadOnly => {
     if (!editorInstance) return;
     editorInstance.updateProps({ readOnly: newReadOnly });
     // Force menu to show after readOnly change if mainMenuBar is true
@@ -360,7 +473,8 @@ function handlePropertyGridUpdate(value: string) {
 defineExpose({
   getEditor: () => editorInstance,
   exportJson: handleExport,
-  importJson: (text: string) => applyImportedText(text, `${props.fileName}.json`),
+  importJson: (text: string) =>
+    applyImportedText(text, `${props.fileName}.json`),
   refresh: () => {
     if (!editorInstance) return;
     editorInstance.update(toContent(props.modelValue));
@@ -394,7 +508,10 @@ defineExpose({
 
       // Expand is only possible in tree mode
       if (currentMode.value !== Mode.tree) {
-        console.log('expandAll: Skipping - not in tree mode, current mode:', currentMode.value);
+        console.log(
+          'expandAll: Skipping - not in tree mode, current mode:',
+          currentMode.value,
+        );
         return;
       }
 
@@ -414,7 +531,10 @@ defineExpose({
       }
 
       if (currentMode.value !== Mode.tree) {
-        console.log('collapseAll: Skipping - not in tree mode, current mode:', currentMode.value);
+        console.log(
+          'collapseAll: Skipping - not in tree mode, current mode:',
+          currentMode.value,
+        );
         return;
       }
 
@@ -472,6 +592,7 @@ defineExpose({
     -->
     <div v-show="showPropertyGrid" class="property-grid-wrapper">
       <JsonPropertyGrid
+        ref="gridRef"
         :data="modelValue"
         :read-only="readOnly"
         :active="showPropertyGrid"

--- a/front/src/shared/ui/EnhancedJsonEditor/JsonPropertyGrid.vue
+++ b/front/src/shared/ui/EnhancedJsonEditor/JsonPropertyGrid.vue
@@ -135,40 +135,144 @@ const flatRows = computed(() => {
 });
 
 /*
-  Search moves through the rows rather than hiding the others, the way the tree
-  does. Filtering left people unsure whether a value was missing or merely out
-  of view, and the surrounding keys are what make a value readable.
+  Every row in the document, whether or not its parent is open. Search reads
+  this, so a value buried under a closed branch is still found and counted.
 */
-const filteredRows = computed(() => flatRows.value);
+const allRows = computed(() =>
+  flattenAll(parsedData.value, '$', 0, Array.isArray(parsedData.value)),
+);
+
+function flattenAll(
+  data: any,
+  parentPath: string,
+  depth: number,
+  isArrayParent: boolean,
+  parentKeys: string[] = [],
+): FlatRow[] {
+  const rows: FlatRow[] = [];
+  if (data === null || data === undefined || typeof data !== 'object')
+    return rows;
+
+  const entries: [string, any][] = Array.isArray(data)
+    ? data.map((v, i) => [String(i), v])
+    : Object.entries(data);
+
+  for (const [key, value] of entries) {
+    const path = `${parentPath}.${key}`;
+    const keys = [...parentKeys, key];
+    const isExpandable = value !== null && typeof value === 'object';
+
+    rows.push({
+      key,
+      displayKey: isArrayParent ? `[${key}]` : key,
+      value,
+      depth,
+      path,
+      keys,
+      isExpandable,
+      isExpanded: expandedPaths.value.has(path),
+      valueType: getValueType(value),
+      childCount: isExpandable
+        ? Array.isArray(value)
+          ? value.length
+          : Object.keys(value).length
+        : undefined,
+      isArrayItem: isArrayParent,
+    });
+
+    if (isExpandable)
+      rows.push(
+        ...flattenAll(value, path, depth + 1, Array.isArray(value), keys),
+      );
+  }
+
+  return rows;
+}
 
 const searchOpen = ref(false);
 const matchIndex = ref(0);
 
+/*
+  Two ways to use a search, and both have their place.
+
+  Stepping through the matches keeps the neighbouring keys in view, and those
+  keys are often what make a value readable. Filtering throws them away but
+  answers a different question - when the same name runs through a hundred rows
+  and every one of them has to change, seeing only those rows is the shorter
+  road.
+*/
+const filterMode = ref(false);
+
+function matchesQuery(row: FlatRow, q: string): boolean {
+  return (
+    row.displayKey.toLowerCase().includes(q) ||
+    (!row.isExpandable && getValueDisplay(row).toLowerCase().includes(q))
+  );
+}
+
 const matches = computed(() => {
   const q = searchQuery.value.trim().toLowerCase();
   if (!q) return [] as string[];
-  return flatRows.value
-    .filter(
-      row =>
-        row.displayKey.toLowerCase().includes(q) ||
-        (!row.isExpandable && getValueDisplay(row).toLowerCase().includes(q)),
-    )
-    .map(row => row.path);
+  return allRows.value.filter(row => matchesQuery(row, q)).map(row => row.path);
 });
+
+/** Path of every branch above a row, so a match can be shown in place. */
+function ancestorsOf(path: string): string[] {
+  const parts = path.split('.');
+  const out: string[] = [];
+  for (let i = 2; i < parts.length; i += 1)
+    out.push(parts.slice(0, i).join('.'));
+  return out;
+}
+
+const filteredRows = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase();
+  if (!filterMode.value || !q) return flatRows.value;
+
+  const keep = new Set<string>();
+  for (const path of matches.value) {
+    keep.add(path);
+    for (const a of ancestorsOf(path)) keep.add(a);
+  }
+  // Branches are shown open, since what is under them is the reason they are here.
+  return allRows.value
+    .filter(row => keep.has(row.path))
+    .map(row => (row.isExpandable ? { ...row, isExpanded: true } : row));
+});
+
+/** True only while the filter is actually narrowing the rows down. */
+const isFiltering = computed(
+  () => filterMode.value && !!searchQuery.value.trim(),
+);
+
+function toggleFilterMode() {
+  filterMode.value = !filterMode.value;
+  if (!filterMode.value && currentMatch.value) revealPath(currentMatch.value);
+}
 
 const matchLabel = computed(() => {
   if (!searchQuery.value.trim()) return '';
   if (!matches.value.length) return 'no match';
+  if (filterMode.value) return `${matches.value.length} rows`;
   return `${matchIndex.value + 1} / ${matches.value.length}`;
 });
 
 const currentMatch = computed(() => matches.value[matchIndex.value] ?? null);
+
+/** Open every branch above a path so the row itself can be seen. */
+function revealPath(path: string) {
+  const next = new Set(expandedPaths.value);
+  for (const a of ancestorsOf(path)) next.add(a);
+  expandedPaths.value = next;
+}
 
 /** Step to the next or previous match and bring it into view. */
 function goToMatch(step: number) {
   if (!matches.value.length) return;
   matchIndex.value =
     (matchIndex.value + step + matches.value.length) % matches.value.length;
+  const target = matches.value[matchIndex.value];
+  if (target) revealPath(target);
   scrollToCurrent();
 }
 
@@ -181,7 +285,10 @@ function scrollToCurrent() {
 
 watch(searchQuery, () => {
   matchIndex.value = 0;
-  if (matches.value.length) scrollToCurrent();
+  const first = matches.value[0];
+  if (!first) return;
+  if (!filterMode.value) revealPath(first);
+  scrollToCurrent();
 });
 
 function openSearch() {
@@ -505,21 +612,36 @@ function cancelEdit() {
       />
       <span class="pg-search-count">{{ matchLabel }}</span>
       <button
-        class="pg-search-btn"
-        title="Previous match"
-        data-testid="json-grid-search-prev"
-        @click="goToMatch(-1)"
+        :class="['pg-search-toggle', { 'is-on': filterMode }]"
+        data-testid="json-grid-search-filter"
+        title="Filter - leave only the rows that match, instead of stepping through them"
+        @click="toggleFilterMode"
       >
-        &#8593;
+        <svg class="pg-search-icon" viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            d="M1.5 2.5h13a.5.5 0 0 1 .38.83L10 9.06V13a.5.5 0 0 1-.72.45l-2.5-1.25A.5.5 0 0 1 6.5 11.8V9.06L1.12 3.33a.5.5 0 0 1 .38-.83Zm1.15 1L7.4 8.6a.5.5 0 0 1 .1.3v2.59l1.5.75V8.9a.5.5 0 0 1 .13-.3l4.75-5.1H2.65Z"
+          />
+        </svg>
+        Filter
       </button>
-      <button
-        class="pg-search-btn"
-        title="Next match"
-        data-testid="json-grid-search-next"
-        @click="goToMatch(1)"
-      >
-        &#8595;
-      </button>
+      <template v-if="!isFiltering">
+        <button
+          class="pg-search-btn"
+          title="Previous match"
+          data-testid="json-grid-search-prev"
+          @click="goToMatch(-1)"
+        >
+          &#8593;
+        </button>
+        <button
+          class="pg-search-btn"
+          title="Next match"
+          data-testid="json-grid-search-next"
+          @click="goToMatch(1)"
+        >
+          &#8595;
+        </button>
+      </template>
       <button
         class="pg-search-btn"
         title="Close search"
@@ -559,7 +681,8 @@ function cancelEdit() {
               <span
                 v-if="row.isExpandable"
                 class="pg-toggle"
-                @click="toggleExpand(row.path)"
+                :class="{ 'is-static': isFiltering }"
+                @click="isFiltering ? null : toggleExpand(row.path)"
               >
                 {{ row.isExpanded ? '&#9660;' : '&#9654;' }}
               </span>
@@ -802,6 +925,42 @@ function cancelEdit() {
     background: #eef2ff;
     color: #4f46e5;
   }
+}
+
+.pg-search-toggle {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+  padding: 1px 6px;
+  font-size: 11px;
+  color: #4b5563;
+  background: transparent;
+  border: 1px solid #e5e7eb;
+  border-radius: 3px;
+  cursor: pointer;
+
+  &:hover {
+    background: #eef2ff;
+    color: #4f46e5;
+  }
+
+  &.is-on {
+    color: #4f46e5;
+    background: #e0e7ff;
+    border-color: #c7d2fe;
+  }
+}
+
+.pg-search-icon {
+  width: 11px;
+  height: 11px;
+  fill: currentcolor;
+}
+
+/* While filtering, the branches are held open and the arrow is only a marker. */
+.pg-toggle.is-static {
+  cursor: default;
+  opacity: 0.45;
 }
 
 /* The row the search is sitting on. */

--- a/front/src/shared/ui/EnhancedJsonEditor/JsonPropertyGrid.vue
+++ b/front/src/shared/ui/EnhancedJsonEditor/JsonPropertyGrid.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
+import {
+  ref,
+  computed,
+  watch,
+  nextTick,
+  onMounted,
+  onBeforeUnmount,
+} from 'vue';
 
 interface Props {
   data: any;
@@ -30,10 +37,6 @@ const searchQuery = ref('');
   that did not exist yet, which took the whole grid down on its second open.
 */
 const selfEdit = ref(false);
-const undoStack = ref<string[]>([]);
-const redoStack = ref<string[]>([]);
-const canUndo = computed(() => undoStack.value.length > 0);
-const canRedo = computed(() => redoStack.value.length > 0);
 
 interface FlatRow {
   key: string;
@@ -74,7 +77,8 @@ function flattenJson(
   parentKeys: string[] = [],
 ): FlatRow[] {
   const rows: FlatRow[] = [];
-  if (data === null || data === undefined || typeof data !== 'object') return rows;
+  if (data === null || data === undefined || typeof data !== 'object')
+    return rows;
 
   const entries: [string, any][] = Array.isArray(data)
     ? data.map((v, i) => [String(i), v])
@@ -97,7 +101,9 @@ function flattenJson(
       isExpanded,
       valueType: getValueType(value),
       childCount: isExpandable
-        ? (Array.isArray(value) ? value.length : Object.keys(value).length)
+        ? Array.isArray(value)
+          ? value.length
+          : Object.keys(value).length
         : undefined,
       isArrayItem: isArrayParent,
     });
@@ -115,8 +121,11 @@ function flattenJson(
 const parsedData = computed(() => {
   if (!props.data) return {};
   if (typeof props.data === 'string') {
-    try { return JSON.parse(props.data); }
-    catch { return {}; }
+    try {
+      return JSON.parse(props.data);
+    } catch {
+      return {};
+    }
   }
   return props.data;
 });
@@ -125,15 +134,70 @@ const flatRows = computed(() => {
   return flattenJson(parsedData.value, '$', 0, Array.isArray(parsedData.value));
 });
 
-const filteredRows = computed(() => {
-  if (!searchQuery.value.trim()) return flatRows.value;
-  const q = searchQuery.value.toLowerCase();
-  return flatRows.value.filter(row => {
-    const keyMatch = row.displayKey.toLowerCase().includes(q);
-    const valMatch = !row.isExpandable && getValueDisplay(row).toLowerCase().includes(q);
-    return keyMatch || valMatch;
-  });
+/*
+  Search moves through the rows rather than hiding the others, the way the tree
+  does. Filtering left people unsure whether a value was missing or merely out
+  of view, and the surrounding keys are what make a value readable.
+*/
+const filteredRows = computed(() => flatRows.value);
+
+const searchOpen = ref(false);
+const matchIndex = ref(0);
+
+const matches = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase();
+  if (!q) return [] as string[];
+  return flatRows.value
+    .filter(
+      row =>
+        row.displayKey.toLowerCase().includes(q) ||
+        (!row.isExpandable && getValueDisplay(row).toLowerCase().includes(q)),
+    )
+    .map(row => row.path);
 });
+
+const matchLabel = computed(() => {
+  if (!searchQuery.value.trim()) return '';
+  if (!matches.value.length) return 'no match';
+  return `${matchIndex.value + 1} / ${matches.value.length}`;
+});
+
+const currentMatch = computed(() => matches.value[matchIndex.value] ?? null);
+
+/** Step to the next or previous match and bring it into view. */
+function goToMatch(step: number) {
+  if (!matches.value.length) return;
+  matchIndex.value =
+    (matchIndex.value + step + matches.value.length) % matches.value.length;
+  scrollToCurrent();
+}
+
+function scrollToCurrent() {
+  nextTick(() => {
+    const el = document.querySelector('.pg-row.is-match');
+    el?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  });
+}
+
+watch(searchQuery, () => {
+  matchIndex.value = 0;
+  if (matches.value.length) scrollToCurrent();
+});
+
+function openSearch() {
+  searchOpen.value = true;
+  nextTick(() => {
+    const el = document.querySelector(
+      '[data-testid="json-grid-search-input"]',
+    ) as HTMLInputElement | null;
+    el?.focus();
+  });
+}
+
+function closeSearch() {
+  searchOpen.value = false;
+  searchQuery.value = '';
+}
 
 function toggleExpand(path: string) {
   const next = new Set(expandedPaths.value);
@@ -174,7 +238,13 @@ function collapseAll() {
 function expandToDepth(maxDepth: number) {
   const paths = new Set<string>();
   function collect(data: any, parentPath: string, depth: number) {
-    if (depth >= maxDepth || data === null || data === undefined || typeof data !== 'object') return;
+    if (
+      depth >= maxDepth ||
+      data === null ||
+      data === undefined ||
+      typeof data !== 'object'
+    )
+      return;
     const entries: [string, any][] = Array.isArray(data)
       ? data.map((v, i) => [String(i), v])
       : Object.entries(data);
@@ -202,8 +272,6 @@ watch(
       selfEdit.value = false;
       return;
     }
-    undoStack.value = [];
-    redoStack.value = [];
     expandToDepth(2);
   },
   { immediate: true },
@@ -250,40 +318,17 @@ function containerOf(data: any, keys: string[]): any {
 }
 
 /*
-  Undo / redo.
-  The tree and text views have it, and this is the third view of the same document
-  - having it only there makes the table feel like someone else's screen. The stack
-  holds whole documents, which is cheap enough here and cannot drift out of step
-  with the parent. An edit arriving from anywhere else clears it, since the history
-  belongs to the document we were handed.
+  No undo of our own. The editor's own undo covers what is changed here - an edit
+  made in this view is on its history and steps back with it - so a second stack
+  beside it would only be a second answer to the same question.
 */
-function currentText(): string {
-  return JSON.stringify(parsedData.value, null, 2);
-}
-
 function apply(text: string) {
   selfEdit.value = true;
   emit('update:data', text);
 }
 
 function commit(data: any) {
-  undoStack.value.push(currentText());
-  redoStack.value = [];
   apply(JSON.stringify(data, null, 2));
-}
-
-function undo() {
-  const previous = undoStack.value.pop();
-  if (previous === undefined) return;
-  redoStack.value.push(currentText());
-  apply(previous);
-}
-
-function redo() {
-  const next = redoStack.value.pop();
-  if (next === undefined) return;
-  undoStack.value.push(currentText());
-  apply(next);
 }
 
 const canEdit = computed(() => !props.readOnly);
@@ -374,6 +419,16 @@ function openRowMenu(event: MouseEvent, row: FlatRow) {
 */
 function keepMenuOpen() {}
 
+/* Called from the editor menu, which now carries these controls. */
+defineExpose({
+  expandAll,
+  collapseAll,
+  expandToDepth,
+  openSearch,
+  closeSearch,
+  isSearchOpen: () => searchOpen.value,
+});
+
 function closeRowMenu() {
   rowMenu.value = null;
 }
@@ -400,13 +455,11 @@ function onKeydown(e: KeyboardEvent) {
     closeRowMenu();
     return;
   }
-  // While a cell is open for editing, the input owns undo.
-  if (editingPath.value !== null || props.readOnly) return;
-  const key = e.key.toLowerCase();
-  if (!(e.ctrlKey || e.metaKey) || key !== 'z') return;
-  e.preventDefault();
-  if (e.shiftKey) redo();
-  else undo();
+  // Ctrl+F opens search here, as it does in the other views.
+  if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'f') {
+    e.preventDefault();
+    openSearch();
+  }
 }
 
 function confirmEdit(row: FlatRow) {
@@ -438,72 +491,43 @@ function cancelEdit() {
 
 <template>
   <div class="property-grid">
-    <!-- Toolbar -->
-    <div class="pg-toolbar">
-      <div class="pg-toolbar-left">
-        <button
-          class="pg-btn pg-btn-icon"
-          data-testid="json-grid-undo"
-          title="Undo (Ctrl+Z)"
-          :disabled="!canUndo"
-          @click="undo"
-        >
-          &#8630;
-        </button>
-        <button
-          class="pg-btn pg-btn-icon"
-          data-testid="json-grid-redo"
-          title="Redo (Ctrl+Shift+Z)"
-          :disabled="!canRedo"
-          @click="redo"
-        >
-          &#8631;
-        </button>
-        <span class="pg-toolbar-sep" />
-        <button class="pg-btn" title="Expand all" @click="expandAll">
-          <span class="pg-icon">&#9660;</span> Expand all
-        </button>
-        <button class="pg-btn" title="Collapse all" @click="collapseAll">
-          <span class="pg-icon">&#9654;</span> Collapse all
-        </button>
-        <span class="pg-toolbar-sep" />
-        <button
-          class="pg-btn"
-          title="Expand 2 levels"
-          @click="expandToDepth(2)"
-        >
-          D2
-        </button>
-        <button
-          class="pg-btn"
-          title="Expand 3 levels"
-          @click="expandToDepth(3)"
-        >
-          D3
-        </button>
-        <button
-          class="pg-btn"
-          title="Expand 5 levels"
-          @click="expandToDepth(5)"
-        >
-          D5
-        </button>
-        <button
-          class="pg-btn"
-          title="Expand 7 levels"
-          @click="expandToDepth(7)"
-        >
-          D7
-        </button>
-      </div>
-      <div class="pg-toolbar-right">
-        <input
-          v-model="searchQuery"
-          type="text"
-          class="pg-search"
-          placeholder="Search key or value..."
-        />
-      </div>
+    <!-- Search, shown when the editor menu asks for it. -->
+    <div v-if="searchOpen" class="pg-search-bar">
+      <input
+        ref="searchInput"
+        v-model="searchQuery"
+        type="text"
+        class="pg-search"
+        placeholder="Search key or value..."
+        data-testid="json-grid-search-input"
+        @keydown.enter="goToMatch(1)"
+        @keydown.escape="closeSearch"
+      />
+      <span class="pg-search-count">{{ matchLabel }}</span>
+      <button
+        class="pg-search-btn"
+        title="Previous match"
+        data-testid="json-grid-search-prev"
+        @click="goToMatch(-1)"
+      >
+        &#8593;
+      </button>
+      <button
+        class="pg-search-btn"
+        title="Next match"
+        data-testid="json-grid-search-next"
+        @click="goToMatch(1)"
+      >
+        &#8595;
+      </button>
+      <button
+        class="pg-search-btn"
+        title="Close search"
+        data-testid="json-grid-search-close"
+        @click="closeSearch"
+      >
+        &#10005;
+      </button>
     </div>
 
     <!-- Table -->
@@ -520,13 +544,17 @@ function cancelEdit() {
           <tr
             v-for="row in filteredRows"
             :key="row.path"
-            :class="['pg-row', `depth-${Math.min(row.depth, 8)}`]"
+            :class="[
+              'pg-row',
+              `depth-${Math.min(row.depth, 8)}`,
+              { 'is-match': row.path === currentMatch },
+            ]"
             @contextmenu="openRowMenu($event, row)"
           >
             <!-- Key column -->
             <td
               class="pg-cell-key"
-              :style="{ paddingLeft: (row.depth * 20 + 8) + 'px' }"
+              :style="{ paddingLeft: row.depth * 20 + 8 + 'px' }"
             >
               <span
                 v-if="row.isExpandable"
@@ -550,13 +578,13 @@ function cancelEdit() {
               <!-- Editing mode -->
               <template v-if="editingPath === row.path">
                 <input
+                  ref="editInput"
                   v-model="editValue"
                   class="pg-edit-input"
+                  autofocus
                   @keydown.enter="confirmEdit(row)"
                   @keydown.escape="cancelEdit"
                   @blur="confirmEdit(row)"
-                  ref="editInput"
-                  autofocus
                 />
               </template>
 
@@ -745,6 +773,42 @@ function cancelEdit() {
 }
 
 /* Table */
+.pg-search-bar {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  padding: 4px 8px;
+  background: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.pg-search-count {
+  min-width: 62px;
+  font-size: 11px;
+  color: #6b7280;
+  text-align: right;
+}
+
+.pg-search-btn {
+  padding: 1px 6px;
+  font-size: 12px;
+  color: #4b5563;
+  background: transparent;
+  border: 1px solid #e5e7eb;
+  border-radius: 3px;
+  cursor: pointer;
+
+  &:hover {
+    background: #eef2ff;
+    color: #4f46e5;
+  }
+}
+
+/* The row the search is sitting on. */
+.pg-row.is-match {
+  background: #fef9c3 !important;
+}
+
 .pg-table-wrapper {
   flex: 1;
   overflow: auto;
@@ -899,15 +963,27 @@ function cancelEdit() {
 }
 
 /* Depth zebra-striping for visual grouping */
-.pg-row.depth-0 { background-color: #ffffff; }
-.pg-row.depth-1 { background-color: #fafbfc; }
-.pg-row.depth-2 { background-color: #f6f8fa; }
-.pg-row.depth-3 { background-color: #f3f5f7; }
-.pg-row.depth-4 { background-color: #f0f2f5; }
+.pg-row.depth-0 {
+  background-color: #ffffff;
+}
+.pg-row.depth-1 {
+  background-color: #fafbfc;
+}
+.pg-row.depth-2 {
+  background-color: #f6f8fa;
+}
+.pg-row.depth-3 {
+  background-color: #f3f5f7;
+}
+.pg-row.depth-4 {
+  background-color: #f0f2f5;
+}
 .pg-row.depth-5,
 .pg-row.depth-6,
 .pg-row.depth-7,
-.pg-row.depth-8 { background-color: #eef0f3; }
+.pg-row.depth-8 {
+  background-color: #eef0f3;
+}
 
 .pg-cell-key {
   padding: 5px 8px;
@@ -958,10 +1034,19 @@ function cancelEdit() {
 }
 
 /* Value type colors */
-.type-string .pg-value { color: #059669; }
-.type-number .pg-value { color: #dc2626; }
-.type-boolean .pg-value { color: #7c3aed; }
-.type-null .pg-value { color: #9ca3af; font-style: italic; }
+.type-string .pg-value {
+  color: #059669;
+}
+.type-number .pg-value {
+  color: #dc2626;
+}
+.type-boolean .pg-value {
+  color: #7c3aed;
+}
+.type-null .pg-value {
+  color: #9ca3af;
+  font-style: italic;
+}
 
 .type-structural .pg-type-badge {
   display: inline-block;

--- a/front/tests/e2e/specs/json-editor-search.spec.ts
+++ b/front/tests/e2e/specs/json-editor-search.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+import { getUser } from '../fixtures/test-data';
+import { LoginPage } from '../pages/login.page';
+import { ModelsPage } from '../pages/models.page';
+
+/**
+ * JSON editor, table view — the two ways of searching.
+ *
+ * Stepping keeps every row on screen and moves from match to match, which leaves
+ * the neighbouring keys readable. Filtering drops everything else, which is the
+ * shorter road when one name runs through the whole document and all of it has
+ * to change.
+ *
+ * Both are checked here because they are easy to break in the same edit: the
+ * filter shares its match list with the stepping, and the branches above a match
+ * have to survive the filter or the rows lose their place in the document.
+ *
+ * Run:
+ *   BASE_URL=http://cmig.dev.cscmzc.com \
+ *   npx playwright test tests/e2e/specs/json-editor-search.spec.ts \
+ *     --config=tests/e2e/playwright.runviewer.config.ts
+ */
+
+test.describe('JSON 에디터 표 — 검색과 필터', () => {
+  test('@unit 검색은 일치 항목을 오가고, 필터를 켜면 일치한 행만 남는다', async ({
+    page,
+  }) => {
+    test.setTimeout(300_000);
+
+    const user = getUser('cmiguser');
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login(user.id, user.password);
+    await login.expectLoggedIn();
+
+    await page.goto(ModelsPage.targetModelsPath);
+    await page.waitForTimeout(3_000);
+    await page.locator('tbody tr', { hasText: 'CloudModel' }).first().click();
+    await page.waitForTimeout(2_500);
+    await page.getByText('Custom & View Target Model').first().click();
+    await page.waitForTimeout(3_500);
+
+    await page.locator('.jse-menu button[title*="table" i]').first().click();
+    await page.waitForTimeout(1_500);
+
+    // The controls live in the editor's own menu, not in a row of their own.
+    await page.locator('.jse-menu button[title^="Search"]').first().click();
+    await page.waitForTimeout(800);
+
+    const rows = page.locator('.property-grid .pg-row');
+    const before = await rows.count();
+
+    await page.getByTestId('json-grid-search-input').fill('name');
+    await page.waitForTimeout(1_500);
+
+    // Stepping leaves the document as it was and reports its position in it.
+    expect(await rows.count()).toBe(before);
+    expect(await page.locator('.pg-search-count').textContent()).toMatch(
+      /^\d+ \/ \d+$/,
+    );
+
+    await page.getByTestId('json-grid-search-filter').click();
+    await page.waitForTimeout(1_500);
+
+    const filtered = await rows.count();
+    expect(filtered).toBeLessThan(before);
+    expect(await page.locator('.pg-search-count').textContent()).toMatch(
+      /^\d+ rows$/,
+    );
+    // Nothing to step through when everything is already on screen.
+    expect(await page.getByTestId('json-grid-search-prev').count()).toBe(0);
+
+    // Every row left is either a match or a branch holding one.
+    const strays = await rows.evaluateAll(list =>
+      list
+        .filter(r => !r.querySelector('.pg-type-badge'))
+        .map(r => (r.textContent ?? '').toLowerCase())
+        .filter(t => !t.includes('name')),
+    );
+    expect(strays).toEqual([]);
+
+    await page.getByTestId('json-grid-search-filter').click();
+    await page.waitForTimeout(1_200);
+    expect(await rows.count()).toBe(before);
+  });
+});


### PR DESCRIPTION
JSON 편집기는 트리·텍스트·표 세 가지로 같은 문서를 보여 주는 하나의 기능인데, 표만 별개 화면처럼 보였다. 표가 자체 도구 줄을 따로 들고 있었기 때문이다.

## 무엇을 바꿨나

표 전용 도구 줄을 없애고 그 조작을 편집기 자신의 메뉴로 옮겼다. 펼치기·접기는 트리가 쓰던 자리에 그대로 뒀다 — 보기를 바꿔도 같은 아이콘이 같은 자리에 있다.

표에서 쓸 수 없던 것은 감췄다.

| 항목 | 표에서 왜 못 쓰나 |
|---|---|
| 편집기 검색 | 편집기가 *자기가 그린 화면*을 훑는데, 표 모드에서는 그 화면이 숨겨져 있어 아무것도 찾지 못한다 (돋보기가 두 개로 보이던 원인) |
| 정렬·변환 | 편집기가 *선택한 대상*에 작용하는데 표는 편집기에 선택을 만들지 않는다. 중첩 배열이 대상 목록에 나타나지 않던 이유 |

되돌리기는 편집기 것이 표 편집까지 되돌리는 것을 확인하고 한 벌로 정리했다. 펼침 단계는 3·5·7(기본 3)로 줄였다.

## 검색 — 두 방식

값 하나를 찾을 때는 옆에 붙은 키들이 그 값을 설명해 주므로 **오가기**가 낫고, 같은 이름이 문서 전체에 흩어져 전부 바꿔야 할 때는 **그 행만 남기는** 편이 짧다. 쓰임이 다르므로 둘 다 뒀다.

기본은 오가기(`1 / 52`), 검색창 안 `Filter` 토글로 필터(`52 rows`)로 전환한다. 필터는 일치한 행과 **그 위 가지**를 함께 남긴다 — 가지가 없으면 `[3] name` 같은 행이 어느 자원의 것인지 알 수 없다.

깔때기 아이콘은 쓰지 않았다. 트리·텍스트에서 이미 변환(Transform)을 가리키고 있어, 같은 아이콘이 보기에 따라 다른 뜻이 되면 더 헷갈린다.

## 같이 고친 결함

검색이 **펼쳐진 행만** 훑고 있었다. 표의 기본 펼침이 3단계이므로 그보다 깊은 값은 문서에 있어도 찾히지 않았고, 없는 것과 구분되지 않았다. 문서 전체를 훑도록 바꾸고, 이동하면 그 위 가지가 열리게 했다.

## 확인

개발 서버 공유 콘솔에서 목표 모델 Custom & View로 확인 — 18항목 전건 PASS.

* 메뉴 한 줄: `text | tree | table | 펼치기 | 접기 | D3 D5 D7 | 검색 | 컨텍스트 | 되돌리기 | 다시하기`
* 오가기 229행 유지 · `1 / 52`
* 필터 229 → 74행 (일치 52 + 상위 가지 22, 관계없는 행 0건) · 해제 시 229행 복귀
* 모두 접은 상태(40행)에서 깊은 값 검색 6건 발견, 이동하며 40 → 54 → 107행으로 가지 열림
* 브라우저 오류 없음

`front/tests/e2e/specs/json-editor-search.spec.ts` 로 두 방식을 자동화해 남겼다.

---

- [BAR-1644](https://mzdevs.atlassian.net/browse/BAR-1644) JSON 에디터 세 화면(트리·텍스트·표) 사용 경험 통일
- 테스트 결과서 `notion/cm-bf-ep-웹모델링JSON에디터고도화/005_표모드도구모음통합/ST3_단위테스트/TR-M11-JSON-005.md`