### PR TITLE
fix(menu): withhold Cloud Resources until credentials can be managed safely

### DIFF
--- a/api/conf/menu.yaml
+++ b/api/conf/menu.yaml
@@ -54,12 +54,23 @@ menus:
     isaction: "false"
     priority: 5
   
-  - id: cloudresources
-    parentid: migrations
-    displayname: Cloud Resources
-    restype: menu
-    isaction: "false"
-    priority: 6
+  # Cloud Resources is hidden until credential management can be offered safely.
+  #
+  # Registering a credential fans out into one connection config per region, and
+  # there is no way to remove it again - the upstream framework has no delete
+  # route - so a mistaken entry cannot be undone from the console, and those
+  # connections are what later provisioning and spec recommendation run on.
+  # Credentials are registered through the setup procedure in the meantime.
+  #
+  # The screens themselves are untouched; only the menu, the reachable list and
+  # the routes are disconnected. Restore all three together.
+  #
+  # - id: cloudresources
+  #   parentid: migrations
+  #   displayname: Cloud Resources
+  #   restype: menu
+  #   isaction: "false"
+  #   priority: 6
 
   ################## step3 : menu : migrations > sourcecomputing ################
   - id: sourceservices
@@ -122,19 +133,21 @@ menus:
     priority: 0
   
   ################## step3 : menu : migrations > workloadoperations ################
-  - id: cloudcredentials
-    parentid: cloudresources
-    displayname: Cloud Credentials
-    restype: menu
-    isaction: "true"
-    priority: 0
-
-  - id: apis
-    parentid: cloudresources
-    displayname: APIs
-    restype: menu
-    isaction: "true"
-    priority: 1
+  # Hidden along with their Cloud Resources parent - see the note there.
+  #
+  # - id: cloudcredentials
+  #   parentid: cloudresources
+  #   displayname: Cloud Credentials
+  #   restype: menu
+  #   isaction: "true"
+  #   priority: 0
+  #
+  # - id: apis
+  #   parentid: cloudresources
+  #   displayname: APIs
+  #   restype: menu
+  #   isaction: "true"
+  #   priority: 1
 
   ###################### step4 : submenu : migrations > workloadoperations > workloads ################
   - id: mciwls

--- a/front/src/app/providers/router/routes/cloudResources.ts
+++ b/front/src/app/providers/router/routes/cloudResources.ts
@@ -1,32 +1,43 @@
 import { RouteConfig } from 'vue-router';
-import { CLOUD_RESOURCES_ROUTE } from '@/app/providers/router/routes/constants';
-import { cloudCredentialsPage, apisPage } from '@/pages/cloudResources';
+// import { CLOUD_RESOURCES_ROUTE } from '@/app/providers/router/routes/constants';
+// import { cloudCredentialsPage, apisPage } from '@/pages/cloudResources';
 
+/*
+  Cloud Resources is withheld until credential management can be offered safely.
+  The reasoning is in api/conf/menu.yaml, which drops the same entries from the
+  menu tree the server hands out.
 
+  The routes go too, not just the menu. Hiding a menu still leaves the address
+  reachable by typing it, and these screens can write state that cannot be
+  undone from the console.
+
+  The pages and widgets are left in place - only the wiring is cut. Restoring
+  means putting back this file, the menu tree and the reachable list together.
+*/
 export const cloudResourcesRoutes: RouteConfig[] = [
-  {
-    path: 'cloud-resources',
-    name: CLOUD_RESOURCES_ROUTE._NAME,
-    component: { template: '<router-view/>' },
-    children: [
-      {
-        path: 'cloud-credentials',
-        name: CLOUD_RESOURCES_ROUTE.CLOUD_CREDENTIALS._NAME,
-        component: cloudCredentialsPage,
-        meta: {
-          menuId: CLOUD_RESOURCES_ROUTE.CLOUD_CREDENTIALS._NAME,
-          category: CLOUD_RESOURCES_ROUTE._NAME,
-        },
-      },
-      {
-        path: 'apis',
-        name: CLOUD_RESOURCES_ROUTE.APIS._NAME,
-        component: apisPage,
-        meta: {
-          menuId: CLOUD_RESOURCES_ROUTE.APIS._NAME,
-          category: CLOUD_RESOURCES_ROUTE._NAME,
-        },
-      },
-    ],
-  },
+  // {
+  //   path: 'cloud-resources',
+  //   name: CLOUD_RESOURCES_ROUTE._NAME,
+  //   component: { template: '<router-view/>' },
+  //   children: [
+  //     {
+  //       path: 'cloud-credentials',
+  //       name: CLOUD_RESOURCES_ROUTE.CLOUD_CREDENTIALS._NAME,
+  //       component: cloudCredentialsPage,
+  //       meta: {
+  //         menuId: CLOUD_RESOURCES_ROUTE.CLOUD_CREDENTIALS._NAME,
+  //         category: CLOUD_RESOURCES_ROUTE._NAME,
+  //       },
+  //     },
+  //     {
+  //       path: 'apis',
+  //       name: CLOUD_RESOURCES_ROUTE.APIS._NAME,
+  //       component: apisPage,
+  //       meta: {
+  //         menuId: CLOUD_RESOURCES_ROUTE.APIS._NAME,
+  //         category: CLOUD_RESOURCES_ROUTE._NAME,
+  //       },
+  //     },
+  //   ],
+  // },
 ];

--- a/front/src/widgets/layout/menuCategory/ui/MenuCategory.vue
+++ b/front/src/widgets/layout/menuCategory/ui/MenuCategory.vue
@@ -28,8 +28,12 @@ const REACHABLE_MENU_IDS: string[] = [
   MENU_ID.WORKFLOW_TEMPLATES,
   MENU_ID.TASK_COMPONENTS,
   MENU_ID.WORKLOADS,
-  MENU_ID.CLOUD_CREDENTIALS,
-  'apis',
+  // Cloud Credentials and APIs are withheld until credential management can be
+  // offered safely - the reasoning is in api/conf/menu.yaml, where the menu tree
+  // itself drops them. Kept here, commented, so restoring means putting back the
+  // same three places rather than rediscovering them.
+  // MENU_ID.CLOUD_CREDENTIALS,
+  // 'apis',
 ];
 
 function isReachable(menuId: string): boolean {


### PR DESCRIPTION
## What

Cloud Resources and its two entries, Cloud Credentials and APIs, are taken out of the console - from the menu tree the server hands out, from the reachable list, and from the routes.

## Why

Registering a credential fans out into one connection config per region and there is no delete route upstream, so a mistaken entry cannot be undone from the console - and those connections are what later provisioning and spec recommendation run on.

Credential ownership also reaches past this screen: choosing an owner only takes effect if the matching header rides along on every later call, which it does not today, so the screen would disagree with what actually happens.

Asset loading runs longer than the front proxy will hold a connection open and offers no way to poll progress.

Credentials are registered through the setup procedure in the meantime.

## Notes

Routes go too, not just the menu - hiding a menu still leaves the address reachable by typing it. The pages and widgets are left in place; only the wiring is cut, so restoring means putting back the same three places.

## Verified

On a dev slot running this branch, compared against the unchanged dev screen:

| Check | This branch | Unchanged |
|---|---|---|
| Menu tree contains the three entries | no | yes |
| Sidebar shows Cloud Resources / Cloud Credentials / APIs | no | yes |
| `/main/cloud-resources/cloud-credentials` opened directly | 404 page | screen renders |
| `/main/cloud-resources/apis` opened directly | 404 page | screen renders |

The same checks give the opposite result on the unchanged screen, so they can fail as well as pass.

---

- [BAR-1673](https://mzdevs.atlassian.net/browse/BAR-1673) Withhold the cloud credential and API menus
- [BAR-1671](https://mzdevs.atlassian.net/browse/BAR-1671) Cloud credential registration (on hold)
- Test record: `notion/cm-bf-ep-시스템설정및운영관리/001_클라우드크레덴셜등록기능구현/ST3_단위테스트/TR-BAR-1673-메뉴화면제외.md`