### PR TITLE
chore(front): drop internal tracker references from source comments

### DIFF
--- a/front/src/entities/notification/lib/notificationStore.ts
+++ b/front/src/entities/notification/lib/notificationStore.ts
@@ -52,7 +52,7 @@ export function setNotificationPopupEnabled(on: boolean): void {
 }
 
 /**
- * Arrival pulse (BAR-1579).
+ * Arrival pulse.
  *
  * Bumped once whenever a poll brings a *genuinely new* notification (not the login backlog).
  * The topbar watches this and plays the arrival cue — an envelope flying into the badge — so

--- a/front/src/features/topbar/topbarNotifications/ui/TopBarNotifications.vue
+++ b/front/src/features/topbar/topbarNotifications/ui/TopBarNotifications.vue
@@ -63,7 +63,7 @@ onUnmounted(() => {
 });
 
 /**
- * Arrival cue (BAR-1579) — the "you got mail" gesture.
+ * Arrival cue — the "you got mail" gesture.
  *
  * An envelope pops up at the screen centre, jitters like a ringing alarm for a beat, then
  * swoops into the notification badge and vanishes. The eye follows the movement to the badge
@@ -132,30 +132,31 @@ const playArrivalCue = () => {
   );
 
   ring.finished
-    .then(() =>
-      // Phase 2 — rise all the way to the badge, then vanish *into* it. Stays fully opaque for
-      // most of the trip (fading early made it look like it disappeared mid-air); only the last
-      // stretch shrinks and fades as it lands on the badge.
-      el.animate(
-        [
-          { transform: 'translate(0,0) scale(1)', opacity: 1, offset: 0 },
+    .then(
+      () =>
+        // Phase 2 — rise all the way to the badge, then vanish *into* it. Stays fully opaque for
+        // most of the trip (fading early made it look like it disappeared mid-air); only the last
+        // stretch shrinks and fades as it lands on the badge.
+        el.animate(
+          [
+            { transform: 'translate(0,0) scale(1)', opacity: 1, offset: 0 },
+            {
+              transform: `translate(${dx * 0.9}px, ${dy * 0.9}px) scale(0.55)`,
+              opacity: 1,
+              offset: 0.8,
+            },
+            {
+              transform: `translate(${dx}px, ${dy}px) scale(0.12)`,
+              opacity: 0,
+              offset: 1,
+            },
+          ],
           {
-            transform: `translate(${dx * 0.9}px, ${dy * 0.9}px) scale(0.55)`,
-            opacity: 1,
-            offset: 0.8,
+            duration: 1000,
+            easing: 'cubic-bezier(.35,0,.6,1)',
+            fill: 'forwards',
           },
-          {
-            transform: `translate(${dx}px, ${dy}px) scale(0.12)`,
-            opacity: 0,
-            offset: 1,
-          },
-        ],
-        {
-          duration: 1000,
-          easing: 'cubic-bezier(.35,0,.6,1)',
-          fill: 'forwards',
-        },
-      ).finished,
+        ).finished,
     )
     .then(done)
     .catch(done);

--- a/front/src/features/workload/lifecycleControl/model/index.ts
+++ b/front/src/features/workload/lifecycleControl/model/index.ts
@@ -175,7 +175,7 @@ export function useLifecycleControl() {
    *
    * **Sequential on purpose.** Firing them together is what broke the workload list once already:
    * cb-tumblebug turns away lookups past the second in flight, and a `Promise.all` threw away the
-   * successful answers along with the rejected one (BAR-1637). A handful of selected workloads costs
+   * successful answers along with the rejected one. A handful of selected workloads costs
    * nothing to walk in order, and each one's outcome lands on screen as it arrives instead of all of
    * them appearing at the end.
    *

--- a/front/src/pages/workloadOperations/mci/ui/MciPage.vue
+++ b/front/src/pages/workloadOperations/mci/ui/MciPage.vue
@@ -61,7 +61,7 @@ function handleSelectVmListTableRow(id: string) {
             e2e anchor only. mirinae PTab renders each tab <li> from the :tabs prop, so a
             data-testid cannot be attached to the tab element itself. The always-present
             per-tab `extra` slot lets us drop an empty, zero-size marker (mci-tab-detail /
-            mci-tab-server) without changing what is rendered. (BAR-1595 / CLAUDE.md §12)
+            mci-tab-server) without changing what is rendered.
           -->
           <template #extra="{ name }">
             <span :data-testid="`mci-tab-${name}`" class="e2e-tab-marker" />

--- a/front/src/widgets/models/recommendedInfraModel/ui/RecommendedInfraModel.vue
+++ b/front/src/widgets/models/recommendedInfraModel/ui/RecommendedInfraModel.vue
@@ -125,7 +125,7 @@ const candidateLimit = ref<number>(3);
 /*
  * Minimum Match Rate — cm-beetle takes ONE number (query `minMatchRate`, 0-100, default 90.0).
  * There is no "max" counterpart, so this is a single field: a range string such as "90-100"
- * fails ParseFloat on the server, which then silently falls back to 90.0 (BAR-1634).
+ * fails ParseFloat on the server, which then silently falls back to 90.0.
  *
  * Empty means "send nothing" so the server default applies. The slider therefore rests at
  * MATCH_RATE_DEFAULT while the field is empty, and the hint under the field says which one is in effect.
@@ -549,7 +549,7 @@ function handleSave(e: { name: string; description: string }) {
             Provider sits in the same fixed-width cell as Candidate Limit on the row below, so
             "Region" and "Minimum Match Rate (%)" start at the same x. Aligning to whatever width
             the Provider dropdown happens to take does not work — its width follows the selected
-            value, so the column shifts between runs. (BAR-1634)
+            value, so the column shifts between runs.
           -->
           <section class="select-service-box params-section__row w-full">
             <div class="param-group">
@@ -626,7 +626,7 @@ function handleSave(e: { name: string; description: string }) {
                 Minimum Match Rate — one value only. cm-beetle exposes a single `minMatchRate`
                 (0-100, default 90) and answers anything it cannot parse by silently using 90,
                 so the screen must not invent a range. The '?' badge sits at the label's
-                bottom-right and opens the detailed explanation on hover/focus. (BAR-1634)
+                bottom-right and opens the detailed explanation on hover/focus.
               -->
               <span class="match-rate-label">
                 <span class="text-label-lg font-bold"
@@ -800,7 +800,7 @@ function handleSave(e: { name: string; description: string }) {
         data-testid cannot reach it otherwise. The replacement mirrors the default exactly —
         same style-type (tertiary), same label, and the `margin-top` the default carries via
         PIconModal's scoped `.button` rule (which does not reach parent-provided slot content)
-        is restored inline so the render is unchanged. (BAR-1595 / CLAUDE.md §12)
+        is restored inline so the render is unchanged.
       -->
       <template #custom-button>
         <p-button

--- a/front/src/widgets/workload/mci/mciList/model/index.ts
+++ b/front/src/widgets/workload/mci/mciList/model/index.ts
@@ -151,7 +151,7 @@ export function useMciListModel(props: IProps) {
   // status from before the action and the screen would look as though nothing had happened.
   //
   // ★ The list, and only the list. Asking each workload for its own detail is exactly the fan-out
-  //   that broke this screen once (BAR-1637): cb-tumblebug allows two infra lookups at a time, so
+  //   that broke this screen once: cb-tumblebug allows two infra lookups at a time, so
   //   from the third workload on the extra calls came back 429 and took the whole list with them.
   //   One list call already carries every status shown here.
   const FOLLOW_INTERVAL_MS = 5_000;


### PR DESCRIPTION
소스 주석에 남아 있던 **내부 추적 정보를 걷어낸다.** 업스트림은 공개 저장소이고, 한번 올라가면 되돌릴 수 없다.

## 무엇이 있었나

`front/src` 전수 조사에서 **6개 파일 9곳**이 나왔다.

| 대상 | 내용 |
|---|---|
| 알림 도착 연출 2곳 | 이슈 키 |
| 워크로드 라이프사이클·목록 모델 2곳 | 이슈 키 |
| 워크로드 상세 탭 마커·추천 모델 표 2곳 | 이슈 키 + 사내 핸드북 절 참조 |
| 추천 모델 화면 3곳 | 이슈 키 |

회사 밖에서는 아무 의미가 없는 값들이다.

## 어떻게 고쳤나

**문장의 뜻은 그대로 두고 참조만 뺐다.** 주석이 설명하던 맥락(왜 그렇게 짰는지)은 남는다.

작업 후 `front/src` 와 `api` 에 이슈 키·내부 문서 참조·내부 도메인이 **하나도 남지 않았다.**

## 함께 들어간 형식 변경

`TopBarNotifications.vue` 에 형식 변경 23줄이 함께 있다. 이 편집과 무관하게 **원래부터 포매터 기준에 맞지 않던 파일**이고, 로컬 게이트가 손댄 파일 전체를 검사하기 때문에 그대로는 커밋할 수 없었다. 리뷰 시 참고 바란다.

> v0.5.2 때의 내부정보 스크럽과 같은 성격의 후속이다.
