### PR TITLE
Bring the cm-beetle entries in api.yaml up to 0.5.7

### DIFF
--- a/api/conf/api.yaml
+++ b/api/conf/api.yaml
@@ -2537,6 +2537,10 @@ serviceActions:
       method: get
       resourcePath: /httpVersion
       description: "Checks and returns the HTTP protocol version of the incoming request.\n\n[Note]\n- The X-Request-Id header value (auto-generated if not provided) is propagated to Tumblebug when Beetle calls its APIs for distributed tracing."
+    CheckSSHReady:
+      method: get
+      resourcePath: /migration/ns/{nsId}/infra/{infraId}/ssh-ready
+      description: "Check if all nodes in the migrated infrastructure are SSH-accessible.\n\n\"Running\" status doesn't mean cloud-init (SSH user setup) is done; timing varies by\nCSP (IBM Cloud VPC: up to ~3 min in testing). Works for any CSP.\n\n**Rate Limiting**: To prevent SSH server abuse, this API can only be called\nonce every 3 minutes for the same infrastructure. If called too soon, it returns\nHTTP 429 with the time to wait before the next check is allowed.\n\n**Check Method**: This API runs a lightweight command on each node via Tumblebug's\nremote command API (not a direct connection from CM-Beetle), so it reuses Tumblebug's\nexisting SSH/bastion setup for the node's CSP.\n\n**Response Options**:\n- Default (no option): Returns summary information (ready, totalNodes, readyNodes, message)\n- option=detail: Returns summary + detailed node status array (nodeStatus) for troubleshooting (per-node SSH readiness)"
     CreateMigratedSSHKey:
       method: post
       resourcePath: /migration/ns/{nsId}/resources/sshKey
@@ -2649,6 +2653,10 @@ serviceActions:
       method: get
       resourcePath: /migration/middleware/ns/{nsId}/objectStorage/{osId}
       description: "Get details of a specific object storage (bucket)"
+    GetObjectStorageSupport:
+      method: get
+      resourcePath: /recommendation/middleware/objectStorage/support
+      description: "Forward object storage support request to CB-Tumblebug via Proxy (Returns ObjectStorageSupportResponse)"
     GetReadyz:
       method: get
       resourcePath: /readyz
@@ -2657,10 +2665,18 @@ serviceActions:
       method: get
       resourcePath: /request/{reqId}
       description: "Retrieves the details of a specific API request tracked by Beetle.\n\n[Note]\n- Request tracking is managed independently by Beetle (not shared with Tumblebug).\n- The reqId corresponds to the X-Request-Id header value from a previous API call.\n- Do NOT call Tumblebug's /request/{reqId} API with this reqId; each system manages its own request tracking.\n\n[Status Values]\n- Handling: Request is currently being processed\n- Success: Request completed successfully\n- Error: Request failed with an error"
+    GetSecurityPublicKey:
+      method: get
+      resourcePath: /migration/security/publicKey
+      description: "Generate and return a one-time RSA public key bundle for encrypting sensitive CSP access credentials (accessKey, secretKey, tokens) before scanning or sending across web clients."
     GetStorageObject:
       method: head
       resourcePath: /migration/middleware/ns/{nsId}/objectStorage/{osId}/object/{objectKey}
       description: "Retrieve metadata (key, size, ETag, last-modified, storage class) of a specific object\nby proxying Tumblebug HEAD /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}.\nNote: URL-encode the objectKey if it contains slashes (e.g., folder%2Ffile.txt)."
+    InspectObjectStorage:
+      method: post
+      resourcePath: /migration/middleware/objectStorage/inspect
+      description: "Deeply inspect and extract feature/usage metadata (totalSizeBytes, objectCount, versioning, encryption, CORS, policy, tags, creationDate) from selected cloud object storage buckets.\n\n[Note] Extracted fields strictly conform to Beetle's Recommendation API input specification (`SourceObjectStorage`).\n- Versioning: Extracted via `GetBucketVersioning`. If versioning is disabled or error occurs, `versioningEnabled` is false.\n- Encryption: Extracted via `GetBucketEncryption`. If encryption rules are absent or error occurs, `encryptionEnabled` is false.\n- CORS: Extracted via `GetBucketCors`. If CORS rules are absent or error occurs, `corsEnabled` is false and `corsRule` is nil.\n- Public Access: Extracted via `GetBucketPolicy`. If wildcard public policy statement is detected, `isPublic` is true, otherwise false.\n- Tags: Extracted via `GetBucketTagging`. If tags are not set, `tags` is nil/empty map.\n- CreationDate: Extracted via bucket listing creation timestamp formatted in RFC 3339 format.\n- AccessFrequency: Defaults to `\"frequent\"` (Standard storage tier baseline for recommendation)."
     ListInfra:
       method: get
       resourcePath: /migration/ns/{nsId}/infra
@@ -2753,6 +2769,10 @@ serviceActions:
       method: post
       resourcePath: /recommendation/resources/specs
       description: "Recommend an appropriate VM specification for cloud migration\n\n[Note] `desiredProvider` and `desiredRegion` are required.\n- `desiredProvider` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredProvider and desiredRegion are set on request body, the values in the query parameter will be ignored.\n- If `targetMachineId` is provided, only that specific machine will be processed."
+    ScanObjectStorage:
+      method: post
+      resourcePath: /migration/middleware/objectStorage/scan
+      description: "Scan and list all object storage buckets in the specified cloud provider account using provided CSP access credentials via MinIO S3 SDK."
     TestAuth:
       method: get
       resourcePath: /test/auth
@@ -2773,6 +2793,10 @@ serviceActions:
       method: get
       resourcePath: /test/tracing
       description: "Tests distributed tracing by calling Tumblebug's readyz endpoint.\n\n[Note]\n- The 'traceparent' header (W3C Trace Context) is propagated to Tumblebug for distributed tracing.\n- The 'X-Request-Id' header is propagated for log correlation.\n- Use this API to verify that tracing works correctly between Beetle and Tumblebug."
+    ValidateInfra:
+      method: post
+      resourcePath: /validation/ns/{nsId}/infra
+      description: "Runs, without creating or modifying any resource, the same checks\nmigration execution performs immediately before provisioning:\n\n- **Naming & referential integrity**: names must be 3-63 alphanumeric/hyphen\ncharacters, and internal references must resolve within the submitted model\n(e.g. a NodeGroup's `securityGroupIds` must match a `name` in `targetSecurityGroupList`).\n- **Required fields**, which differ by `useExisting`:\n- `true`: each NodeGroup's `vNetId`, `sshKeyId`, `securityGroupIds` must be set.\n- `false`: `targetVNet.name`, `targetSshKey.name`, and each security group's `name` must be set.\n- **Resource name collision / availability** against Tumblebug, which also differs by `useExisting`:\n- `false`: the VNet/SSH key/security groups to be created must NOT already exist in the\nnamespace (e.g. `targetVNet.name: \"vnet-01\"` fails if a VNet named `vnet-01` already exists).\n- `true`: an existing resource must be under the same CSP/region connection the NodeGroup\nrequests (e.g. reusing a VNet provisioned under connection `aws-ap-northeast-2` while the\nNodeGroup's `connectionName` is `gcp-asia-northeast3` fails); a resource that doesn't exist\nyet must have enough data alongside it to create it instead (e.g. `targetVNet.cidrBlock`).\n- **VM spec/image compatibility** per NodeGroup: `specId`, `imageId`, and `connectionName` must\nbe set, `connectionName` must be in `csp-region` format (e.g. `aws-ap-northeast-2`), and the\nresolved spec/image pair must be compatible for that CSP (e.g. an `x86_64` spec paired with\nan `arm64` image fails).\n- **Infra (MCI) name collision**: `targetInfra.name` must not already exist in the namespace.\n\nAlways returns HTTP 200: the response body's `valid` field and\n`issues` list carry the outcome, since a failed check is a normal,\nsuccessfully-answered result rather than a malformed request.\n400 is reserved for request body/parameter errors.\n\nBecause Tumblebug/CSP state can change afterward, a `valid: true`\nresult is a best-effort snapshot, not a guarantee - the migration\nAPI re-runs this same validation immediately before provisioning."
     ValidateNames:
       method: post
       resourcePath: /naming/validation


### PR DESCRIPTION
## 무엇을 바꾸나

`api/conf/api.yaml` 의 cm-beetle 항목을 **0.5.7** 에 맞춘다. 62건 → **68건**.

라인업이 cm-beetle 0.5.7 로 올라갔다([cm-mayfly #97](https://github.com/MZC-CSC/cm-mayfly/pull/97) 머지). api.yaml 은 콘솔이 연계 프레임워크를 부를 때 쓰는 경로 목록이라, 부를 대상이 바뀌면 함께 맞춰야 한다. 뒤처진 채 두면 폐기된 경로로 요청이 나가고, **폐기 경로는 404 를 주므로 그걸 "자원이 없다"로 읽으면 정상 동작을 결함으로 오보한다.**

## 무엇이 바뀌었나

0.5.6·0.5.7 swagger 를 operationId 단위로 전수 대조했다. **이름·경로 변경도 폐기도 없고 신규 6건**이다. 마이그레이션·추천 API 의 비동기 응답은 기존 API 에 선택 파라미터로 얹힌 것이라 식별자가 그대로다.

| 신규 | method | 경로 | 무엇인가 |
|---|---|---|---|
| `CheckSSHReady` | get | `/migration/ns/{nsId}/infra/{infraId}/ssh-ready` | 마이그레이션한 노드가 SSH 로 붙는지. Running 이 곧 접속 가능은 아니라 cloud-init 이 끝나는 시점의 간극을 메운다 |
| `ValidateInfra` | post | `/validation/ns/{nsId}/infra` | 자원을 만들지 않고 프로비저닝 직전 검사만 그대로 돌린다 |
| `GetSecurityPublicKey` | get | `/migration/security/publicKey` | CSP 자격증명을 암호화해 보내기 위한 일회용 공개키 |
| `GetObjectStorageSupport` | get | `/recommendation/middleware/objectStorage/support` | 오브젝트 스토리지 지원 여부 |
| `ScanObjectStorage` | post | `/migration/middleware/objectStorage/scan` | 계정의 버킷 목록 |
| `InspectObjectStorage` | post | `/migration/middleware/objectStorage/inspect` | 버킷의 사용량·버저닝·암호화·정책·태그 |

## 왜 6건을 다 넣나

콘솔이 지금 부르는 것만 넣으면 결과적으로 아무것도 안 넣게 된다 — 6건 모두 대응 화면이 아직 없다. **v0.6.0 라인업의 연계 API 를 다 담아 두고 화면은 그 위에서 붙이는** 방침으로 전부 넣는다.

## 확인한 것

| | |
|---|---|
| 0.5.7 swagger 대조 | 68건 전부 일치, 불일치 0건 |
| Go 파싱(서비스가 읽는 방식) | `services`·`serviceActions` 정상 |
| `go build ./...` | 통과 |
| cm-mayfly `conf/api.yaml` 의 cm-beetle 블록과 대조 | **차이 없음** |

마지막 항목이 중요하다. 두 파일은 같은 서비스를 보고 읽는 목록이라 **한쪽만 갱신되면 한쪽에서는 되고 다른 쪽에서는 없는 경로가 생긴다.**

기능 확인은 화면이 이 API 를 쓰기 시작할 때 그 작업에서 한다. 지금은 목록을 맞추는 단계다.

---

- [BAR-1678](https://mzdevs.atlassian.net/browse/BAR-1678) [cm-butterfly] api.yaml 현행화 — cm-beetle 0.5.7
- [BAR-1677](https://mzdevs.atlassian.net/browse/BAR-1677) [cm-mayfly] docker-compose 라인업 현행화 — cm-beetle 0.5.7 · cm-butterfly 0.5.4

테스트 결과서 · 분석 · 개발 현황: `cmig-workflow/notion/cm-bf-ep-연계시스템버전현행화/001_tb-0.12.9_현행화/`
