### PR TITLE
chore: sync develop with upstream/main after the README version fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@
 cm-butterfly is a framework that provides a GUI environment for a multi-cloud migration platform. It provides a GUI that can be used in a user-friendly and consistent manner to migrate infrastructure, applications, and data from on-premise or cloud source environments to the cloud environments.
 
 
-## Prerequisition
-### Recommend Envionment (Test Finished)
-  - Ubuntu 22.04
-  - Go 1.23.0
+## Prerequisites
+### Recommended Environment (Test Finished)
+  - Ubuntu 22.04 or later
+  - Go 1.26.5 (api)
+  - Node 20 (front — see `front/.nvmrc`)
   - Docker engine 25.0.0
 
 
@@ -48,7 +49,7 @@ git clone https://github.com/cloud-barista/cm-butterfly.git
 or if you need specific version with minimize the size
 
 ```bash
-git clone --depth 1 --branch v0.3.0 https://github.com/cloud-barista/cm-butterfly.git
+git clone --depth 1 --branch v0.6.0 https://github.com/cloud-barista/cm-butterfly.git
 ```
 
 ### 2. Create the api environment file ⭐
@@ -110,31 +111,27 @@ You can call all the APIs configured in api.yaml through the same request format
 
 Modify the value of services.{subsystem-name}.baseurl. The host currently in use by default is set to the service DNS of the Docker container. If changes are necessary (if there is a IP address or domain), you need to change the corresponding value. Requests will be sent to the URL defined in api.yaml.
    
-  ```yaml
-  ```yaml
-
 ```yaml
-
   cb-spider: #service name
-    version: 0.10.0
+    version: 0.12.35
     baseurl: http://cb-spider:1024/spider  ## change this end with /spider
-    auth: 
+    auth:
       type: basic
-      username: 
-      password: 
-  
+      username:
+      password:
+
   cb-tumblebug:
-    version: 0.10.3
+    version: 0.12.25
     baseurl: http://cb-tumblebug:1323/tumblebug ## change this end with /tumblebug
-    auth: 
+    auth:
       type: basic
       username: default
       password: default
 
   cm-beetle:
-    version: 0.3.0
+    version: 0.6.0
     baseurl: http://cm-beetle:8056/beetle  ## change this end with /beetle
-    auth: 
+    auth:
 
   # others ...
 ```


### PR DESCRIPTION
업스트림 [#119](https://github.com/cloud-barista/cm-butterfly/pull/119) 이 머지돼 그 내용을 develop 으로 내려받는다.

README 의 버전 표기를 현행 라인업에 맞춘 변경이다 — clone 예시 `v0.3.0` → `v0.6.0`, Go `1.23.0` → `1.26.5`, Node 20 명시 추가, api.yaml 예시의 cb-spider `0.10.0` → `0.12.35` · cb-tumblebug `0.10.3` → `0.12.25` · cm-beetle `0.3.0` → `0.6.0`. 그 예시 블록은 코드 펜스를 세 번 열고 한 번만 닫고 있어 대부분이 본문으로 렌더되던 것도 함께 정리했다.

**순서를 뒤집어 진행한 것을 바로잡는 PR이기도 하다.** 새로 쓴 내용은 develop PR 이 먼저고 업스트림 반영이 나중인데, 이 변경은 업스트림에 먼저 올렸다. 결과 상태는 같지만 순서는 어긋났고, 다음부터는 develop 을 먼저 거친다.

- [BAR-1213](https://mzdevs.atlassian.net/browse/BAR-1213) cm-butterfly v0.6.0 릴리스 범위 확정 및 프리릴리스