### PR TITLE
improve(workflow): fill a task's body from the model by path, not by a list of keys

### DIFF
--- a/front/src/features/workflow/workflowEditor/lib/mapModelToTaskBody.ts
+++ b/front/src/features/workflow/workflowEditor/lib/mapModelToTaskBody.ts
@@ -1,0 +1,187 @@
+/**
+ * Fills a task's request body from a model, matching by **path** rather than by name.
+ *
+ * ## Why by path
+ *
+ * A task component's body shape comes from the target system's swagger; a target model holds the
+ * values. The two use the same names for the same things, so most of the body can be filled by
+ * simply carrying values across. What cannot be done is matching on the *leaf name alone* — the
+ * same name means different things in different places:
+ *
+ *   targetSecurityGroupList   under a recommended infra  → the security groups to create
+ *   targetSecurityGroupList   under a recommendation set → recommendation entries wrapping them
+ *   targetSpecList            under a recommended infra  → the specs that were chosen
+ *   targetSpec                under a recommendation     → one server's recommended spec
+ *   specId                    under a node group         → the spec that node group will use
+ *
+ * Matching "spec" to "spec" would hand a candidate list to a field expecting the chosen ones. So a
+ * value is carried across only when **the whole path agrees**, and the shape agrees with it.
+ *
+ * ## Why not a list of keys
+ *
+ * The previous approach named every key in code. It worked, and it kept working — until the other
+ * side grew a field. Then nothing failed: the new field simply was not carried, and the workflow
+ * was built without it. Silence is the problem this replaces. Here, whatever the body asks for is
+ * looked up, and **whatever could not be filled is reported** rather than passed over.
+ */
+
+/** A JSON-schema-ish node as it arrives from the task component (`body_params`). */
+interface SchemaNode {
+  type?: string;
+  properties?: Record<string, SchemaNode>;
+  items?: SchemaNode;
+  required?: string[];
+  [key: string]: unknown;
+}
+
+export interface MapResult {
+  /** The body to send, with everything that could be carried across. */
+  body: Record<string, any>;
+  /** Paths that were filled from the model. */
+  filled: string[];
+  /** Paths the body asks for that the model had nothing for. */
+  missing: string[];
+  /** Of those, the ones the body declares as required — worth telling the user about. */
+  missingRequired: string[];
+  /** Paths where both sides had a value but the shapes disagreed (array vs object vs plain). */
+  mismatched: string[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Whether a schema node and a value describe the same kind of thing. */
+function shapeAgrees(schema: SchemaNode, value: unknown): boolean {
+  const declared = schema?.type;
+  if (declared === 'array') return Array.isArray(value);
+  if (declared === 'object') return isPlainObject(value);
+  if (declared === undefined) {
+    // No declared type — infer from what the schema carries.
+    if (schema?.items) return Array.isArray(value);
+    if (schema?.properties) return isPlainObject(value);
+    return true;
+  }
+  // string / number / boolean / integer
+  return !Array.isArray(value) && !isPlainObject(value);
+}
+
+/**
+ * Walks the body's schema and carries values across from the model at the same path.
+ *
+ * A path that the model has is taken whole — no descending into it. Its inside is the other
+ * system's business, and rebuilding it here is how values get quietly dropped. Descending happens
+ * only where the model has nothing at that path but the body asks for something deeper.
+ */
+function walk(
+  schemaProps: Record<string, SchemaNode>,
+  requiredHere: string[],
+  source: unknown,
+  into: Record<string, any>,
+  prefix: string,
+  result: MapResult,
+): void {
+  for (const [key, schema] of Object.entries(schemaProps ?? {})) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    const isRequired = requiredHere.includes(key);
+    const value = isPlainObject(source) ? source[key] : undefined;
+
+    if (value !== undefined && value !== null) {
+      if (shapeAgrees(schema, value)) {
+        into[key] = value;
+        result.filled.push(path);
+      } else {
+        result.mismatched.push(path);
+        if (isRequired) result.missingRequired.push(path);
+        else result.missing.push(path);
+      }
+      continue;
+    }
+
+    // Nothing at this path. If the body asks for something deeper, look there before giving up —
+    // a model may carry the pieces without carrying the container.
+    if (schema?.properties) {
+      const nested: Record<string, any> = {};
+      const before = result.filled.length;
+      walk(
+        schema.properties,
+        schema.required ?? [],
+        isPlainObject(source) ? source[key] : undefined,
+        nested,
+        path,
+        result,
+      );
+      if (result.filled.length > before) {
+        into[key] = nested;
+        continue;
+      }
+    }
+
+    result.missing.push(path);
+    if (isRequired) result.missingRequired.push(path);
+  }
+}
+
+/**
+ * Fills a body from a model.
+ *
+ * @param bodyParams the task component's `body_params` (properties + required)
+ * @param model      the model with the values, **already unwrapped** (see unwrapModel)
+ * @param skeleton   the body the component came with; kept as the starting point so anything the
+ *                   schema does not describe is not thrown away
+ */
+export function mapModelToTaskBody(
+  bodyParams: { properties?: Record<string, SchemaNode>; required?: string[] } | undefined,
+  model: unknown,
+  skeleton: Record<string, any> = {},
+): MapResult {
+  const result: MapResult = {
+    body: { ...skeleton },
+    filled: [],
+    missing: [],
+    missingRequired: [],
+    mismatched: [],
+  };
+
+  if (!bodyParams?.properties) {
+    // No schema to go by. Carrying values across blind would be guessing, so the body is left as
+    // it came and the caller is told nothing was filled.
+    return result;
+  }
+
+  walk(
+    bodyParams.properties,
+    bodyParams.required ?? [],
+    model,
+    result.body,
+    '',
+    result,
+  );
+  return result;
+}
+
+/**
+ * Takes the values out of the wrapper a target model keeps them in.
+ *
+ * A target model holds its values under `cloudInfraModel` (infra) or `targetSoftwareModel`
+ * (software), while the body asks for them at the top. The wrapper is the only difference, so
+ * removing it lines the two up.
+ *
+ * `targetSoftwareModel` is also a field *inside* the software body, so it is kept alongside the
+ * unwrapped values rather than replaced by them.
+ */
+export function unwrapModel(targetModel: any): Record<string, any> {
+  if (!isPlainObject(targetModel)) return {};
+
+  if (isPlainObject(targetModel.cloudInfraModel)) {
+    return { ...targetModel, ...targetModel.cloudInfraModel };
+  }
+  if (isPlainObject(targetModel.targetSoftwareModel)) {
+    return {
+      ...targetModel,
+      ...targetModel.targetSoftwareModel,
+      targetSoftwareModel: targetModel.targetSoftwareModel,
+    };
+  }
+  return { ...targetModel };
+}

--- a/front/src/features/workflow/workflowEditor/ui/WorkflowEditor.vue
+++ b/front/src/features/workflow/workflowEditor/ui/WorkflowEditor.vue
@@ -33,6 +33,10 @@ import {
 } from '@/features/sequential/designer/toolbox/model/api';
 import getRandomId from '@/shared/utils/uuid';
 import { parseRequestBody } from '@/shared/utils/stringToObject';
+import {
+  mapModelToTaskBody,
+  unwrapModel,
+} from '@/features/workflow/workflowEditor/lib/mapModelToTaskBody';
 import SequentialDesigner from '@/features/sequential/designer/ui/SequentialDesigner.vue';
 import { DEFAULT_NAMESPACE } from '@/shared/constants/namespace';
 import { normalizeTaskComponentList } from '@/entities/workflow/lib/schemaAdapter';
@@ -372,84 +376,128 @@ function mapTargetModelToTaskComponent(
 
   const parseString = parseRequestBody(taskComponent.data.options.request_body);
 
-  if (isInfraModel && targetModel?.cloudInfraModel?.targetInfra) {
-    // Handle infra model data - use targetInfra from cloudInfraModel
-    console.log(
-      'Processing infra model with targetInfra:',
-      targetModel.cloudInfraModel.targetInfra,
-    );
+  // ── Filling the body: matched by path, not by name ─────────────────────
+  //
+  // The body's shape comes from the other system's swagger; the model holds the values. Both use
+  // the same names for the same things, so the body is filled by looking up **the same path** in
+  // the model — not by matching leaf names, which collide (see mapModelToTaskBody).
+  //
+  // What this replaces is below, kept as a comment on purpose: it named every key in code, and a
+  // field the other side added was simply never carried — with nothing said about it.
+  const unwrapped = unwrapModel(targetModel);
+  const mapped = mapModelToTaskBody(
+    taskComponent?.data?.body_params,
+    unwrapped,
+    parseString ?? {},
+  );
+  Object.assign(parseString, mapped.body);
 
-    if (parseString) {
-      // Set the targetInfra data directly
-      parseString['targetInfra'] = targetModel.cloudInfraModel.targetInfra;
-
-      // Also set other related infra data if available
-      if (targetModel.cloudInfraModel.targetSecurityGroupList) {
-        parseString['targetSecurityGroupList'] =
-          targetModel.cloudInfraModel.targetSecurityGroupList;
-      }
-      if (targetModel.cloudInfraModel.targetSshKey) {
-        parseString['targetSshKey'] = targetModel.cloudInfraModel.targetSshKey;
-      }
-      if (targetModel.cloudInfraModel.targetVNet) {
-        parseString['targetVNet'] = targetModel.cloudInfraModel.targetVNet;
-      }
-      if (targetModel.cloudInfraModel.targetOsImageList) {
-        parseString['targetOsImageList'] =
-          targetModel.cloudInfraModel.targetOsImageList;
-      }
-      if (targetModel.cloudInfraModel.targetSpecList) {
-        parseString['targetSpecList'] =
-          targetModel.cloudInfraModel.targetSpecList;
-      }
-    }
-    console.log('Processed infra model data:', parseString);
-  } else if (isSoftwareModel && (targetModel as any)?.targetSoftwareModel) {
-    // Handle software model data - use targetSoftwareModel
-    const targetSoftwareModel = (targetModel as any).targetSoftwareModel;
-    console.log(
-      'Processing software model with targetSoftwareModel:',
-      targetSoftwareModel,
-    );
-
-    if (parseString) {
-      // Set the targetSoftwareModel data directly
-      parseString['targetSoftwareModel'] = targetSoftwareModel;
-
-      // Also set other related software data if available
-      if (targetSoftwareModel.softwareList) {
-        parseString['softwareList'] = targetSoftwareModel.softwareList;
-      }
-      if (targetSoftwareModel.targetSpecList) {
-        parseString['targetSpecList'] = targetSoftwareModel.targetSpecList;
-      }
-      if (targetSoftwareModel.targetOsImageList) {
-        parseString['targetOsImageList'] =
-          targetSoftwareModel.targetOsImageList;
-      }
-      if (targetSoftwareModel.targetSecurityGroupList) {
-        parseString['targetSecurityGroupList'] =
-          targetSoftwareModel.targetSecurityGroupList;
-      }
-      if (targetSoftwareModel.targetSshKey) {
-        parseString['targetSshKey'] = targetSoftwareModel.targetSshKey;
-      }
-      if (targetSoftwareModel.targetVNet) {
-        parseString['targetVNet'] = targetSoftwareModel.targetVNet;
-      }
-
-      // Set basic model information
-      parseString['softwareModel'] = {
-        id: targetModel.id,
-        name: targetModel.userModelName,
-        description: targetModel.description,
-        csp: targetModel.csp,
-        region: targetModel.region,
-        zone: targetModel.zone,
-      };
-    }
-    console.log('Processed software model data:', parseString);
+  // Software migration also names the model itself in the body; it is not part of the recommended
+  // infra shape, so it is set here rather than being looked up.
+  if (isSoftwareModel) {
+    parseString['softwareModel'] = {
+      id: targetModel.id,
+      name: targetModel.userModelName,
+      description: targetModel.description,
+      csp: targetModel.csp,
+      region: targetModel.region,
+      zone: targetModel.zone,
+    };
   }
+
+  // **Say what could not be carried.** A body that asks for something the model has nothing for is
+  // the failure this whole change exists to surface — before, it left no trace at all.
+  if (mapped.missingRequired.length > 0) {
+    showErrorMessage(
+      'Some required values could not be filled',
+      `The workflow asks for ${mapped.missingRequired.join(', ')}, and the selected target model has no value for them. Check the task before running it.`,
+    );
+  }
+  console.log('[task body] filled:', mapped.filled);
+  console.log('[task body] not filled:', mapped.missing);
+  if (mapped.mismatched.length > 0) {
+    console.warn('[task body] shape did not agree:', mapped.mismatched);
+  }
+
+  // ── What this replaced, kept so the change is legible: every key named in code ──
+  // if (isInfraModel && targetModel?.cloudInfraModel?.targetInfra) {
+  //   // Handle infra model data - use targetInfra from cloudInfraModel
+  //   console.log(
+  //     'Processing infra model with targetInfra:',
+  //     targetModel.cloudInfraModel.targetInfra,
+  //   );
+  //
+  //   if (parseString) {
+  //     // Set the targetInfra data directly
+  //     parseString['targetInfra'] = targetModel.cloudInfraModel.targetInfra;
+  //
+  //     // Also set other related infra data if available
+  //     if (targetModel.cloudInfraModel.targetSecurityGroupList) {
+  //       parseString['targetSecurityGroupList'] =
+  //         targetModel.cloudInfraModel.targetSecurityGroupList;
+  //     }
+  //     if (targetModel.cloudInfraModel.targetSshKey) {
+  //       parseString['targetSshKey'] = targetModel.cloudInfraModel.targetSshKey;
+  //     }
+  //     if (targetModel.cloudInfraModel.targetVNet) {
+  //       parseString['targetVNet'] = targetModel.cloudInfraModel.targetVNet;
+  //     }
+  //     if (targetModel.cloudInfraModel.targetOsImageList) {
+  //       parseString['targetOsImageList'] =
+  //         targetModel.cloudInfraModel.targetOsImageList;
+  //     }
+  //     if (targetModel.cloudInfraModel.targetSpecList) {
+  //       parseString['targetSpecList'] =
+  //         targetModel.cloudInfraModel.targetSpecList;
+  //     }
+  //   }
+  //   console.log('Processed infra model data:', parseString);
+  // } else if (isSoftwareModel && (targetModel as any)?.targetSoftwareModel) {
+  //   // Handle software model data - use targetSoftwareModel
+  //   const targetSoftwareModel = (targetModel as any).targetSoftwareModel;
+  //   console.log(
+  //     'Processing software model with targetSoftwareModel:',
+  //     targetSoftwareModel,
+  //   );
+  //
+  //   if (parseString) {
+  //     // Set the targetSoftwareModel data directly
+  //     parseString['targetSoftwareModel'] = targetSoftwareModel;
+  //
+  //     // Also set other related software data if available
+  //     if (targetSoftwareModel.softwareList) {
+  //       parseString['softwareList'] = targetSoftwareModel.softwareList;
+  //     }
+  //     if (targetSoftwareModel.targetSpecList) {
+  //       parseString['targetSpecList'] = targetSoftwareModel.targetSpecList;
+  //     }
+  //     if (targetSoftwareModel.targetOsImageList) {
+  //       parseString['targetOsImageList'] =
+  //         targetSoftwareModel.targetOsImageList;
+  //     }
+  //     if (targetSoftwareModel.targetSecurityGroupList) {
+  //       parseString['targetSecurityGroupList'] =
+  //         targetSoftwareModel.targetSecurityGroupList;
+  //     }
+  //     if (targetSoftwareModel.targetSshKey) {
+  //       parseString['targetSshKey'] = targetSoftwareModel.targetSshKey;
+  //     }
+  //     if (targetSoftwareModel.targetVNet) {
+  //       parseString['targetVNet'] = targetSoftwareModel.targetVNet;
+  //     }
+  //
+  //     // Set basic model information
+  //     parseString['softwareModel'] = {
+  //       id: targetModel.id,
+  //       name: targetModel.userModelName,
+  //       description: targetModel.description,
+  //       csp: targetModel.csp,
+  //       region: targetModel.region,
+  //       zone: targetModel.zone,
+  //     };
+  //   }
+  //   console.log('Processed software model data:', parseString);
+  // }
 
   // Set path_params and query_params from task component with nsId default value.
   // ★ A schema property's description is *explanatory text (a placeholder)*, not a value. Leave the


### PR DESCRIPTION
## 왜

타깃 모델에서 워크플로우를 만들면 모델의 값이 태스크 본문으로 옮겨진다. **지금도 정상 동작한다** — 고칠 결함이 있어서 손대는 것이 아니다.

다만 그 코드가 **옮길 키를 하나씩 나열**하고 있다. 그래서 상대가 받는 본문에 필드가 늘어나면 그 필드는 따라가지 않고, 나열을 사람이 다시 손봐야 한다. 앞으로 늘어날 것을 대비해 **나열 대신 본문 스키마를 훑는 방식으로 보완**한다.

지금 나열에 없는 것 중 하나가 **로드밸런서 목록**(`targetNlbList`)이다. 그 값이 모델에 담기게 되면 이 방식에서는 손대지 않아도 실린다. 다만 로드밸런서는 인프라를 만든 뒤 별도로 부르는 흐름이라 이 매핑만으로 끝나는 것은 아니다 — 그쪽은 별건이다.

## 무엇을

본문의 모양은 이미 넘어온다 — 워크플로우 엔진이 기동할 때 상대 시스템의 swagger 를 읽어 **필수 여부까지 포함한 스키마**를 준다. 그 스키마를 훑어 **모델에서 같은 경로**를 찾아 채운다.

**이름이 아니라 경로인 이유** — 같은 이름이 자리마다 다른 것을 뜻한다.

| 이름 | 어디에 | 무엇 |
|---|---|---|
| `targetSecurityGroupList` | 추천된 인프라 아래 | **만들 보안 그룹** |
| `targetSecurityGroupList` | 추천 묶음 아래 | 그것을 감싼 **추천 항목들** |
| `targetSpecList` | 추천된 인프라 아래 | **선택된 스펙** |
| `targetSpec` | 추천 아래 | 서버 한 대의 **후보 스펙** |

이름만 보고 옮기면 후보를 선택 자리에 넣게 된다. **경로가 통째로 맞고 모양(객체/배열/값)도 맞을 때만** 옮긴다.

**못 채운 것은 말한다.** 본문이 필수로 요구하는데 모델에 값이 없으면 그 이름을 들어 알린다 — 나중에 상대가 필수 필드를 늘렸을 때 조용히 지나가지 않게 하는 안전장치다.

**이전 키 목록은 바로 아래에 주석으로 남겼다.** 무엇이 어떻게 자동으로 바뀌었는지 둘을 나란히 읽어 확인할 수 있다.

## 검증

기준본(현재 develop)과 이 브랜치를 각각 이미지로 빌드해 같은 네트워크에 띄우고, **같은 기능 e2e 전체를 양쪽에** 돌렸다.

| 기준 | 결과 |
|---|---|
| develop | 36 통과 / 21 실패 |
| 이 브랜치 | 41 통과 / 16 실패 |
| **이 브랜치에서만 실패** | **0건** |

**건수로 판정하지 않았다** — 실행마다 3~5건씩 편차가 난다(실자원·상태가 필요한 시나리오가 부하에 따라 시간 초과). **실패한 시나리오 이름을 정렬해 차집합**을 낸 것이 판정 근거다. 공통 실패 16건은 양쪽 동일하다.

`vue-tsc --noEmit` · 이미지 빌드 통과.

## 확인하지 못한 것

- 만들어진 본문으로 **실제 마이그레이션이 도는 것**은 실자원이 필요해 하지 않았다
- **로드밸런서 값이 실려 가는지**는 확인할 수 없다 — 콘솔이 부르는 추천이 그 값을 만들지 않아 모델에 값 자체가 없다. 매핑은 있는 것을 옮길 뿐이다
