### PR TITLE
fix(source): show a source service's real connection state, not the refresh reply

### DIFF
--- a/front/src/entities/sourceService/model/stores.ts
+++ b/front/src/entities/sourceService/model/stores.ts
@@ -6,8 +6,35 @@ import {
   IInfraSourceGroupResponse,
 } from '@/entities/sourceService/model/types';
 import { defineStore } from 'pinia';
+import type {
+  ISourceConnectionStatusCountResponse,
+  ISourceConnectionOutcome,
+} from '@/entities/sourceService/model/types';
 
 const NAMESPACE = 'SOURCESERVICE';
+
+/**
+ * Whether a source service can be reached, worked out from what the server reports
+ * about its connections.
+ *
+ * The screen used to take its status from the *response of the refresh call*, whose
+ * body says only that the refresh finished - the same `success` whether the servers
+ * answered or not. A stopped server therefore showed as healthy. The state the server
+ * actually reports travels in these counts, and this is the only thing that decides
+ * what is shown.
+ */
+export function deriveSourceServiceStatus(
+  counts: ISourceConnectionStatusCountResponse | undefined,
+): string {
+  if (!counts || counts.connection_info_total === 0) return 'unknown';
+
+  const failed = counts.count_connection_failed + counts.count_agent_failed;
+  const succeeded = counts.count_connection_success + counts.count_agent_success;
+
+  if (failed === 0 && succeeded > 0) return 'success';
+  if (succeeded === 0) return 'failed';
+  return 'partialSuccess';
+}
 
 export const useSourceServiceStore = defineStore(NAMESPACE, () => {
   const services = ref<ISourceService[]>([]);
@@ -23,6 +50,7 @@ export const useSourceServiceStore = defineStore(NAMESPACE, () => {
       connectionCount:
         service.connection_info_status_count.connection_info_total,
       connectionIds: [],
+      status: deriveSourceServiceStatus(service.connection_info_status_count),
     }));
   }
 
@@ -56,11 +84,35 @@ export const useSourceServiceStore = defineStore(NAMESPACE, () => {
     }
   }
 
-  function mappingSourceGroupStatus(sgId: string, status: string) {
+  /**
+   * Record what the server says about a service's connections.
+   *
+   * Takes the counts rather than a status string on purpose: a caller holding a
+   * message from some other call cannot pass it off as the connection state.
+   */
+  function mappingSourceGroupStatus(
+    sgId: string,
+    counts: ISourceConnectionStatusCountResponse | undefined,
+  ) {
     const sg = getServiceById(sgId);
 
     if (sg) {
-      sg.status = status;
+      sg.status = deriveSourceServiceStatus(counts);
+      if (counts) {
+        sg.connectionCount = counts.connection_info_total;
+      }
+    }
+  }
+
+  /** Keep what the server said about each connection, so a failure can be explained. */
+  function mappingConnectionOutcomes(
+    sgId: string,
+    outcomes: ISourceConnectionOutcome[],
+  ) {
+    const sg = getServiceById(sgId);
+
+    if (sg) {
+      sg.connectionOutcomes = outcomes;
     }
   }
 
@@ -72,5 +124,6 @@ export const useSourceServiceStore = defineStore(NAMESPACE, () => {
     mappinginfraModel,
     mappingSoftwareModel,
     mappingSourceGroupStatus,
+    mappingConnectionOutcomes,
   };
 });

--- a/front/src/entities/sourceService/model/types.ts
+++ b/front/src/entities/sourceService/model/types.ts
@@ -6,6 +6,23 @@ export interface ISourceGroup {
   connections: SourceConnection[];
 }
 
+/**
+ * What the server said about one connection, kept as it said it.
+ *
+ * A source service that cannot be reached is shown as failed, but "failed" alone does
+ * not say whether the machine refused the SSH connection or answered and then failed to
+ * take the agent. The server distinguishes the two and explains each in its own message;
+ * nothing in the console was reading them.
+ */
+export interface ISourceConnectionOutcome {
+  name: string;
+  ipAddress: string;
+  connectionStatus: string;
+  connectionMessage: string;
+  agentStatus: string;
+  agentMessage: string;
+}
+
 export interface ISourceService {
   id: string;
   name: string;
@@ -14,6 +31,8 @@ export interface ISourceService {
   connectionIds: string[];
   // status: SourceServiceStatusType;
   status?: string;
+  /** Per-connection outcome behind the aggregated status, for the reader who asks why. */
+  connectionOutcomes?: ISourceConnectionOutcome[];
   infraModel?: IInfraSourceGroupResponse;
   softwareModel?: any;
 }

--- a/front/src/widgets/source/sourceServices/sourceServiceDetail/model/sourceServiceDetailModel.ts
+++ b/front/src/widgets/source/sourceServices/sourceServiceDetail/model/sourceServiceDetailModel.ts
@@ -50,7 +50,10 @@ export function useSourceServiceDetailModel() {
         name: sourceService.name,
         id: sourceService.id,
         description: sourceService.description,
-        status: setServiceStatus(sourceService.status),
+        status: {
+          ...setServiceStatus(sourceService.status),
+          outcomes: sourceService.connectionOutcomes ?? [],
+        },
         viewInfra: {
           isShow: !!sourceService.infraModel,
         },

--- a/front/src/widgets/source/sourceServices/sourceServiceDetail/ui/SourceServiceDetail.vue
+++ b/front/src/widgets/source/sourceServices/sourceServiceDetail/ui/SourceServiceDetail.vue
@@ -12,6 +12,7 @@ import { showErrorMessage } from '@/shared/utils';
 import {
   useRefreshSourceGroupConnectionInfoStatus,
   useCollectSWSourceGroup,
+  useGetSourceConnectionList,
 } from '@/entities/sourceConnection/api';
 import SourceServiceRefineModal from '@/features/sourceServices/sourceServiceRefinedModal/ui/sourceServiceRefineModal.vue';
 
@@ -37,6 +38,7 @@ const {
 const refreshSourceGroupConnectionInfoStatus =
   useRefreshSourceGroupConnectionInfoStatus(null);
 const getSourceService = useGetSourceService(null);
+const getSourceConnectionList = useGetSourceConnectionList(null);
 const resGetInfraSourceGroup = useGetInfraSourceGroup(null);
 const resGetInfraInfoSourceGroup = useGetInfraInfoSourceGroup(null);
 const infraModel = ref<any>(null);
@@ -45,6 +47,26 @@ const infraModel = ref<any>(null);
 const softwareModel = ref<any>(null);
 const resCollectSWSourceGroup = useCollectSWSourceGroup(null);
 const resGetSoftwareInfoSourceGroup = useGetSoftwareInfoSourceGroup(null);
+
+/*
+  Where to draw the explanation.
+
+  Positioned against the viewport rather than the cell: the definition table clips its
+  cells, so a layer anchored inside one is cut down to a sliver. The coordinates are
+  taken from the status when it is pointed at or focused.
+*/
+const statusDetailAt = ref<{ top: number; left: number } | null>(null);
+
+function openStatusDetail(event: Event) {
+  const el = event.currentTarget as HTMLElement | null;
+  if (!el) return;
+  const box = el.getBoundingClientRect();
+  statusDetailAt.value = { top: box.bottom + 6, left: box.left };
+}
+
+function closeStatusDetail() {
+  statusDetailAt.value = null;
+}
 
 const modalState = reactive({
   open: false,
@@ -71,6 +93,9 @@ watch(
   props,
   () => {
     setServiceId(props.selectedServiceId);
+    // Selecting a service is a fair moment to ask why its status is what it is;
+    // waiting for a refresh would leave the explanation empty until then.
+    if (props.selectedServiceId) loadConnectionOutcomes();
   },
   { immediate: true },
 );
@@ -154,23 +179,66 @@ function getSourceGroupSoftware() {
     });
 }
 
+/**
+ * What the server said about each connection, so that a failure can be explained.
+ *
+ * The aggregated status answers "can this be used"; this answers "why not". The two
+ * failures it distinguishes are not the same problem: the machine refusing SSH is the
+ * user's network or credentials, while the machine answering and then failing to take
+ * the agent is something else again. The server separates them and explains each; the
+ * console was showing neither.
+ */
+async function loadConnectionOutcomes() {
+  try {
+    const { data } = await getSourceConnectionList.execute({
+      pathParams: { sgId: props.selectedServiceId },
+    });
+    const list = data.responseData?.connection_info ?? [];
+    sourceServiceStore.mappingConnectionOutcomes(
+      props.selectedServiceId,
+      list.map((c: any) => ({
+        name: c.name,
+        ipAddress: c.ip_address,
+        connectionStatus: c.connection_status,
+        connectionMessage: c.connection_failed_message,
+        agentStatus: c.agent_status,
+        agentMessage: c.agent_failed_message,
+      })),
+    );
+  } catch {
+    // The aggregated status still stands on its own; the explanation is simply absent.
+  }
+}
+
+/**
+ * Re-probe the servers behind this source service and show what came back.
+ *
+ * The refresh call answers `success` once it has finished probing - it says the
+ * refresh ran, not that the servers answered. So its message is used only as the
+ * cue to read the state again; what is shown comes from the counts the server
+ * reports for the connections themselves.
+ */
 async function handleSourceGroupStatusRefresh() {
   try {
-    const { data } = await refreshSourceGroupConnectionInfoStatus.execute({
+    await refreshSourceGroupConnectionInfoStatus.execute({
       pathParams: {
         sgId: props.selectedServiceId,
       },
     });
 
-    if (data.responseData && data.responseData.message) {
-      sourceServiceStore.mappingSourceGroupStatus(
-        props.selectedServiceId,
-        data.responseData.message,
-      );
+    const { data } = await getSourceService.execute({
+      pathParams: {
+        sgId: props.selectedServiceId,
+      },
+    });
 
-      loadSourceServiceData(props.selectedServiceId);
-      console.log(tableModel.tableState.data);
-    }
+    sourceServiceStore.mappingSourceGroupStatus(
+      props.selectedServiceId,
+      data.responseData?.connection_info_status_count,
+    );
+
+    await loadConnectionOutcomes();
+    loadSourceServiceData(props.selectedServiceId);
   } catch (err: any) {
     showErrorMessage('error', err.errorMsg?.value || 'Unknown error occurred');
   }
@@ -195,8 +263,61 @@ function handleSoftwareModal() {
       "
       :block="true"
     >
+      <!--
+        The status, and behind it what the server said.
+
+        Hover rather than a permanent block: the answer to "can this be used" is one
+        word and belongs on the line, while the answer to "why not" is several lines and
+        only matters when the first one is bad. Focus opens it too, so it is not reachable
+        by pointer alone.
+      -->
       <template #data-status="{ data }">
-        <p-status :theme="data.color" :text="data.text" />
+        <span
+          class="status-cell"
+          tabindex="0"
+          data-testid="source-group-status"
+          @mouseenter="openStatusDetail"
+          @mouseleave="closeStatusDetail"
+          @focus="openStatusDetail"
+          @blur="closeStatusDetail"
+        >
+          <p-status :theme="data.color" :text="data.text" />
+
+          <span
+            v-if="statusDetailAt && (data.outcomes || []).length"
+            class="status-detail"
+            :style="{ top: `${statusDetailAt.top}px`, left: `${statusDetailAt.left}px` }"
+            data-testid="source-group-status-detail"
+          >
+            <span
+              v-for="outcome in data.outcomes"
+              :key="outcome.name"
+              class="status-detail-item"
+            >
+              <span class="status-detail-name"
+                >{{ outcome.name }} ({{ outcome.ipAddress }})</span
+              >
+              <span class="status-detail-line">
+                <span class="status-detail-label">Connection</span>
+                <span :class="`status-detail-value is-${outcome.connectionStatus}`"
+                  >{{ outcome.connectionStatus }}</span
+                >
+              </span>
+              <span v-if="outcome.connectionMessage" class="status-detail-message"
+                >{{ outcome.connectionMessage }}</span
+              >
+              <span class="status-detail-line">
+                <span class="status-detail-label">Agent</span>
+                <span :class="`status-detail-value is-${outcome.agentStatus}`"
+                  >{{ outcome.agentStatus }}</span
+                >
+              </span>
+              <span v-if="outcome.agentMessage" class="status-detail-message"
+                >{{ outcome.agentMessage }}</span
+              >
+            </span>
+          </span>
+        </span>
       </template>
 
       <template #data-viewInfra="{ data }">
@@ -279,3 +400,73 @@ function handleSoftwareModal() {
     />
   </div>
 </template>
+
+<style scoped lang="postcss">
+/*
+  The explanation behind the status.
+
+  Plain markup and plain CSS on purpose - a new screen should not widen the mirinae
+  surface, and a hover layer is small enough not to need one.
+*/
+.status-cell {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.status-detail {
+  position: fixed;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 320px;
+  max-width: 520px;
+  margin-top: 6px;
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+  box-shadow: 0 4px 14px rgb(0 0 0 / 12%);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: normal;
+}
+
+.status-detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.status-detail-name {
+  font-weight: 600;
+  color: #111827;
+}
+
+.status-detail-line {
+  display: flex;
+  gap: 8px;
+}
+
+.status-detail-label {
+  width: 76px;
+  flex-shrink: 0;
+  color: #6b7280;
+}
+
+.status-detail-value.is-success {
+  color: #047857;
+}
+
+.status-detail-value.is-failed {
+  color: #b91c1c;
+}
+
+/* The server's own words, kept as they came. */
+.status-detail-message {
+  padding-left: 84px;
+  color: #6b7280;
+  word-break: break-word;
+}
+</style>


### PR DESCRIPTION
## 무엇이 문제였나

소스 서비스의 상태가 **새로고침 호출의 응답 메시지**에서 왔다. 그 응답은 *갱신을 마쳤다*는 뜻이지 *서버가 답했다*는 뜻이 아니다 — 서버가 살아 있든 꺼져 있든 똑같이 `success` 다. 그래서 **꺼진 서버가 초록으로** 보였다.

서버가 실제로 보내는 상태는 `connection_info_status_count` 에 있는데 **한 번도 읽히지 않았다.** 목록을 읽는 `setService` 가 `status` 를 채우지 않아, 새로고침 응답이 그 값을 채우는 유일한 경로였다.

## 무엇을 바꿨나

- **상태를 counts 에서 파생한다** — 목록을 읽을 때부터, 그리고 새로고침 뒤에도
- `mappingSourceGroupStatus` 가 **문자열이 아니라 counts 를 받는다** — 다른 호출의 메시지를 상태인 척 넘기는 것이 타입 단계에서 막힌다
- **실패 사유를 보여준다** — `failed` 한 단어로는 서버에 못 닿은 것인지, 닿았는데 에이전트가 안 붙은 것인지 알 수 없다. 서버는 그 둘을 나눠 각각 메시지를 보내는데 **콘솔 어디에서도 읽지 않고 있었다**(`connection_failed_message`·`agent_failed_message` 사용처 0건). 상태를 가리키거나 포커스하면 서버가 준 말 그대로 연결별로 나온다

## 결과 화면

같은 소스 서비스, **서버를 중단한 상태**에서 Refresh 를 눌렀다. 데이터도 서버도 같고 화면만 다르다.

**전** — 서버가 꺼져 있는데 초록

![before](https://raw.githubusercontent.com/wiki/MZC-CSC/cm-butterfly/assets/source-status-1730/before.png)

**후** — 실패로 표시

![after](https://raw.githubusercontent.com/wiki/MZC-CSC/cm-butterfly/assets/source-status-1730/after.png)

**실패 사유** — 상태에 마우스를 올리거나 포커스하면

![reason](https://raw.githubusercontent.com/wiki/MZC-CSC/cm-butterfly/assets/source-status-1730/reason.png)

```
statusbug-live-01 (172.31.48.174)
  Connection   failed
               dial tcp 172.31.48.174:22: connect: no route to host
  Agent        failed
               dial tcp 172.31.48.174:22: i/o timeout
```

## 검증

목 없이, 실제 EC2 서버 1대를 **켜고 끄며** 브라우저에서 Refresh 를 눌러 확인했다.

| 경우 | 새로고침 응답 | 저장된 연결 상태 | 기준본 | 수정본 |
|---|---|---|---|---|
| 살아 있을 때 등록 → 중단 | `success` | failed (`i/o timeout`) | success | **failed** |
| 이미 죽은 뒤 등록 | `success` | failed (`no route to host`) | success | **failed** |
| 서버 기동 중 | `success` | success | success | success (회귀 없음) |

**응답 메시지는 세 경우 모두 같다.** 갈리는 것은 연결 상태뿐이고, 수정본은 그것을 읽는다.

## 부수 효과

- 목록을 열기만 해도 상태가 보인다. 전에는 Refresh 를 눌러야 비로소(그것도 틀린) 값이 채워졌다
- `partialSuccess`(노란색)는 상태 타입에 이미 있었으나 **한 번도 표시된 적이 없다** — 이제 일부만 실패하면 그대로 나온다

## 아직 확인하지 못한 것

- 살아 있는 서버에서의 호버(양쪽 `success`)
- `partialSuccess` 실물 — 연결 여럿 중 일부만 죽은 상태가 필요하다

---

- [BAR-1730](https://mzdevs.atlassian.net/browse/BAR-1730) 소스 서비스 Refresh 가 닿지 않는 서버를 정상으로 표시한다
