### PR TITLE
improve(workflow): let saving be what tells the run status screen to read again

### DIFF
--- a/front/src/features/sequential/designer/editor/ui/BashTaskEditor.vue
+++ b/front/src/features/sequential/designer/editor/ui/BashTaskEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="custom-task-editor">
+  <div class="custom-task-editor" data-testid="wf-task-editor">
     <div class="section-header"><h4>Bash Task</h4></div>
 
     <div class="field">
@@ -8,6 +8,7 @@
         class="text-input"
         type="text"
         :value="name"
+        data-testid="wf-task-name"
         placeholder="Enter task name"
         @input="onName"
       />
@@ -20,6 +21,7 @@
       <textarea
         class="text-area"
         rows="6"
+        data-testid="wf-task-spec-bash_command"
         :value="model.bash_command"
         placeholder="e.g. echo 'hello world'"
         @input="onCommand"

--- a/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
+++ b/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
@@ -73,9 +73,24 @@ function handleEditJson(workflowId: string) {
 function handleSavedWorkflow(workflowId: string) {
   if (workflowId) selectedWorkflowId.value = workflowId;
   mainTabState.activeTab = 'runViewer';
+  markDefinitionSaved();
+}
+
+/**
+ * Tell the run status screen that the definition it is showing is no longer the current one.
+ *
+ * ★ The id is not enough to notice a save. Clone & Edit selects the clone up front, so the id is
+ *   already the clone's while it is being edited and does not move when it is saved — the screen
+ *   then keeps the definition it read before the edit and shows the old values under the words
+ *   "Values from the current definition". Saying it plainly is what this does.
+ */
+function markDefinitionSaved() {
+  runViewerReloadToken.value += 1;
 }
 
 const selectedWorkflowId = ref<string>('');
+/** Goes up by one on every save — the run status screen reads it as "read the definition again". */
+const runViewerReloadToken = ref<number>(0);
 
 /**
  * When arriving after creating a workflow on another screen (the target model).
@@ -209,6 +224,8 @@ async function handleUpdateWorkflow(updatedData: object) {
     // This used to throw and fall into the catch, which then showed a hardcoded, unrelated message.
     if (data.responseData?.data?.task_groups != null) {
       modalState.addWorkflow.trigger = true;
+      // Same event: saving from the JSON editor dates the definition on screen just as much.
+      markDefinitionSaved();
       showSuccessMessage('Success', 'Workflow data updated successfully.');
     } else {
       modalState.addWorkflow.trigger = true;
@@ -273,6 +290,7 @@ async function handleUpdateWorkflow(updatedData: object) {
             </div>
             <workflow-run-viewer
               :workflow-id="selectedWorkflowId"
+              :reload-token="runViewerReloadToken"
               @edit-json="handleEditJson"
               @view-json="handleEditJson"
               @edit-clone="handleEditClone"

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -23,6 +23,17 @@ interface Props {
   workflowId: string | null;
   /** If empty, open the most recent run */
   runId?: string | null;
+  /**
+   * Bumped by the page whenever the definition is saved.
+   *
+   * ★ Reloading used to hang on the id changing, and that is not enough. Editing a clone sets the
+   *   id to the clone *before* the editor opens, so by the time it is saved the id is already what
+   *   it will be — nothing changes, nothing reloads, and the panel keeps showing the definition it
+   *   read before the edit. It says "Values from the current definition" while showing the values
+   *   the clone was made from; the saved definition and the machine that gets built use the new
+   *   ones. Saving is its own event, so it gets its own trigger.
+   */
+  reloadToken?: number;
 }
 
 const props = defineProps<Props>();
@@ -443,7 +454,7 @@ function formatDuration(seconds?: number): string {
 }
 
 watch(
-  () => [props.workflowId, props.runId],
+  () => [props.workflowId, props.runId, props.reloadToken],
   async () => {
     if (props.workflowId) await open(props.workflowId, props.runId);
   },

--- a/front/tests/e2e/pages/workflow.page.ts
+++ b/front/tests/e2e/pages/workflow.page.ts
@@ -316,6 +316,96 @@ export class WorkflowPage {
     return modal;
   }
 
+  /**
+   * Copy the workflow on screen and open the copy for editing.
+   *
+   * The console has no "save as", and a workflow that has already run cannot be edited in place -
+   * so this is the only way to keep the original and vary it. The button appears once there is
+   * run history. The backend names the copy `{original}_copy`; the caller renames it.
+   */
+  async cloneAndEdit(): Promise<void> {
+    const button = this.page.getByTestId('workflow-clone-edit-btn');
+    await expect(
+      button,
+      'Clone & Edit 버튼이 없다 — 실행 이력이 있는 워크플로우에서만 나타난다',
+    ).toBeVisible({ timeout: 30_000 });
+    await humanClick(button);
+
+    const confirm = this.page.getByTestId('workflow-clone-confirm');
+    await expect(confirm).toBeVisible({ timeout: 15_000 });
+    await humanClick(this.page.getByTestId('workflow-clone-confirm-ok'));
+
+    await this.expectDesignerOpen();
+  }
+
+  /**
+   * Open everything the panel folded away.
+   *
+   * The editor collapses arrays and objects deeper than two levels so the form stays readable, so a
+   * test that reads the rendered fields cannot see the values that decide the outcome. A person
+   * clicks to open them; so do we.
+   *
+   * The toggles carry no test identifier, so they are found by the component's own class names.
+   */
+  async expandAllParams(maxRounds = 6): Promise<number> {
+    let opened = 0;
+    for (let round = 0; round < maxRounds; round++) {
+      const closed = this.page.locator(
+        '[data-testid="wf-task-editor"] button.btn-collapse, [data-testid="wf-task-editor"] button.btn-item-collapse',
+      );
+      const count = await closed.count().catch(() => 0);
+      let clickedThisRound = 0;
+      for (let i = 0; i < count; i++) {
+        const button = closed.nth(i);
+        const label = (await button.innerText().catch(() => '')).trim();
+        if (!label.includes('\u25b6')) continue;
+        await button.click({ timeout: 5_000 }).catch(() => {});
+        clickedThisRound++;
+        opened++;
+        await this.page.waitForTimeout(12);
+      }
+      if (clickedThisRound === 0) break;
+    }
+    await this.page.waitForTimeout(400);
+    return opened;
+  }
+
+  /** Rename the task whose edit panel is open. */
+  async renameSelectedTask(name: string): Promise<void> {
+    const field = this.page.getByTestId('wf-task-name');
+    await expect(field).toBeVisible({ timeout: 15_000 });
+    await humanFill(field, name);
+    await this.page.waitForTimeout(400);
+  }
+
+  /** Set a value on the open edit panel, addressed by the spec key it belongs to. */
+  async setTaskSpec(key: string, value: string): Promise<void> {
+    const field = this.page.getByTestId(`wf-task-spec-${key}`);
+    await expect(field).toBeVisible({ timeout: 15_000 });
+    await humanFill(field, value);
+    await this.page.waitForTimeout(400);
+  }
+
+  /** A task node in the run graph, by its name. */
+  taskNode(name: string): Locator {
+    return this.page
+      .getByTestId('workflow-run-node')
+      .filter({ hasText: name })
+      .first();
+  }
+
+  /** Select a task in the run graph so its detail and parameters open. */
+  async pickTask(name: string): Promise<void> {
+    const node = this.taskNode(name);
+    await node.scrollIntoViewIfNeeded().catch(() => {});
+    await humanClick(node);
+    await expect(this.page.getByTestId('workflow-run-task-detail')).toBeVisible(
+      {
+        timeout: 15_000,
+      },
+    );
+  }
+
   async cancelClone(): Promise<void> {
     await humanClick(this.page.getByTestId('workflow-clone-confirm-cancel'));
     await expect(this.page.getByTestId('workflow-clone-confirm')).toBeHidden();
@@ -452,13 +542,27 @@ export class WorkflowPage {
    * name is *our data* (task_component), not screen text, so it does not wobble when the screen changes.
    * We target it with that.
    */
-  async selectTaskInDesigner(taskComponentName: string): Promise<void> {
+  async selectTaskInDesigner(
+    taskComponentName: string,
+    taskName?: string,
+  ): Promise<void> {
     await expect(this.designer).toBeVisible({ timeout: 20_000 });
-    await humanClick(
-      this.designer
-        .locator(`.sqd-step-task.sqd-type-${taskComponentName}`)
-        .first(),
-    );
+    // 같은 컴포넌트를 쓰는 작업이 여럿이면 첫 번째가 원하는 그것이 아니다 — 이름으로 좁힌다.
+    //
+    // 이름으로 고를 때는 컴포넌트 클래스를 함께 걸지 않는다. 클래스는 컴포넌트 이름을 그대로
+    // 붙인 것이라 `_` 로 시작하는 예제 컴포넌트에서는 잡히지 않는 경우가 있었다 — 노드에 적힌
+    // 이름이 우리가 아는 값이므로 그것으로 충분하다.
+    // 이름으로 거르면 그 이름을 *품고 있는* 바깥 상자(TaskGroup·Parallel)까지 함께 걸린다.
+    // 바깥을 누르면 아무 일도 일어나지 않으므로 가장 안쪽 것을 잡는다.
+    const step = taskName
+      ? this.designer
+          .locator('.sqd-step-task')
+          .filter({ hasText: taskName })
+          .last()
+      : this.designer
+          .locator(`.sqd-step-task.sqd-type-${taskComponentName}`)
+          .first();
+    await humanClick(step);
     await expect(this.taskEditor).toBeVisible({ timeout: 15_000 });
   }
 


### PR DESCRIPTION
The run status screen re-read the workflow definition only when the workflow id changed. Editing a copy sets the id to the copy before the editor opens, so by the time it is saved the id is already what it will be and nothing prompts a re-read.

It still showed the right values, because the editor happens to change the same object the screen is holding. Correctness rested on two parts sharing an object rather than on anything said out loud.

Where that sharing did not hold, the screen kept the values the copy was made from while the saved definition and the machine that got built used the new ones. That is what a deployed build showed: port 5555 on screen, 6666 in the stored definition and in the security group of the machine it created.

On develop this does not reproduce. Three routes were measured before the change and all showed the saved value: a bash task's command, a shallow field, and a deep array field with the 196 folded rows opened. In each, the definition was not re-read after saving; the value was right for the reason above.

Saving now says so, from both the graphic editor and the JSON editor.

Also gives the bash task panel a test identifier: only the generic editor carried one, so a test could not find the panel when the task was of another type.

### No regression test

A case that fails before the change cannot be written while the symptom does not reproduce. A test that only ever passes guards nothing. The tooling for one is in place; the case gets added if the symptom becomes reachable again.

---

- [BAR-1727](https://mzdevs.atlassian.net/browse/BAR-1727) 실행 상태 화면이 저장을 갱신 계기로 삼도록
