### PR TITLE
feat(api): read subsystem credentials from the environment instead of hardcoding them

### DIFF
--- a/api/conf/api.yaml
+++ b/api/conf/api.yaml
@@ -87,7 +87,7 @@ services:
       latest: https://raw.githubusercontent.com/cloud-barista/cm-ant/main/api/swagger.json
       release: https://raw.githubusercontent.com/cloud-barista/cm-ant/{release}/api/swagger.json
   cm-beetle:
-    version: 0.5.10(latest)
+    version: 0.5.11(latest)
     baseurl: http://cm-beetle:8056/beetle
     auth:
       type: basic
@@ -116,7 +116,7 @@ services:
       release: https://raw.githubusercontent.com/cloud-barista/cm-cicada/{release}/pkg/api/rest/docs/swagger.json
 
   cm-honeybee:
-    version: 0.5.11(latest)
+    version: 0.5.12(latest)
     baseurl: http://cm-honeybee:8081/honeybee
     auth:
       type: none
@@ -140,7 +140,7 @@ services:
   # out rather than appearing as a service that is always unreachable.
   #
   #cm-honeybee-agent:
-  #  version: 0.5.11(latest)
+  #  version: 0.5.12(latest)
   #  baseurl: http://cm-honeybee:8082/honeybee-agent
   #  auth:
   #    type: none

--- a/api/conf/api.yaml
+++ b/api/conf/api.yaml
@@ -124,14 +124,29 @@ services:
       latest: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/main/server/pkg/api/rest/docs/swagger.json
       release: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/{release}/server/pkg/api/rest/docs/swagger.json
 
-  cm-honeybee-agent:
-    version: 0.5.11(latest)
-    baseurl: http://cm-honeybee:8082/honeybee-agent
-    auth:
-      type: none
-    swagger:
-      latest: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/main/agent/pkg/api/rest/docs/swagger.json
-      release: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/{release}/agent/pkg/api/rest/docs/swagger.json
+  # cm-honeybee-agent — commented out, not removed.
+  #
+  # The agent runs on the server being migrated, not next to cm-honeybee, so the
+  # baseurl below never resolves as written. It is kept because losing the entry
+  # would also lose the spec, and without the spec there is no way to call the
+  # agent at all.
+  #
+  # To reach an agent, replace the host with the address of the server it is
+  # installed on. `mayfly api` and `mayfly rest` can override the host, so an
+  # operator can check one server's agent that way. The console could do the
+  # same by rewriting the host from the target server chosen for a call.
+  #
+  # Nothing in cm-mayfly or cm-butterfly calls it today, so it stays commented
+  # out rather than appearing as a service that is always unreachable.
+  #
+  #cm-honeybee-agent:
+  #  version: 0.5.11(latest)
+  #  baseurl: http://cm-honeybee:8082/honeybee-agent
+  #  auth:
+  #    type: none
+  #  swagger:
+  #    latest: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/main/agent/pkg/api/rest/docs/swagger.json
+  #    release: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/{release}/agent/pkg/api/rest/docs/swagger.json
 
   cm-grasshopper:
     version: 0.5.3(latest)
@@ -3269,31 +3284,33 @@ serviceActions:
       method: post
       resourcePath: /velero/migration/precheck
       description: "Check source cluster, target cluster, and the S3 object store before executing Velero migration."
-  cm-honeybee-agent:
-    Get-Data-Info:
-      method: get
-      resourcePath: /data
-      description: "Get data migration information (required fields only for data migration)."
-    Get-Helm-Info:
-      method: get
-      resourcePath: /helm
-      description: "Get helm information."
-    Get-Infra-Info:
-      method: get
-      resourcePath: /infra
-      description: "Get infra information."
-    Get-Kubernetes-Info:
-      method: get
-      resourcePath: /kubernetes
-      description: "Get kubernetes information."
-    Get-Software-Info:
-      method: get
-      resourcePath: /software
-      description: "Get software information."
-    Health-Check-Readyz:
-      method: get
-      resourcePath: /readyz
-      description: "Check Honeybee Agent is ready"
+  # cm-honeybee-agent — commented out with the service entry above.
+  #
+  #cm-honeybee-agent:
+  #  Get-Data-Info:
+  #    method: get
+  #    resourcePath: /data
+  #    description: "Get data migration information (required fields only for data migration)."
+  #  Get-Helm-Info:
+  #    method: get
+  #    resourcePath: /helm
+  #    description: "Get helm information."
+  #  Get-Infra-Info:
+  #    method: get
+  #    resourcePath: /infra
+  #    description: "Get infra information."
+  #  Get-Kubernetes-Info:
+  #    method: get
+  #    resourcePath: /kubernetes
+  #    description: "Get kubernetes information."
+  #  Get-Software-Info:
+  #    method: get
+  #    resourcePath: /software
+  #    description: "Get software information."
+  #  Health-Check-Readyz:
+  #    method: get
+  #    resourcePath: /readyz
+  #    description: "Check Honeybee Agent is ready"
   cm-honeybee:
     Create-Connection-Info:
       method: post

--- a/api/conf/api.yaml
+++ b/api/conf/api.yaml
@@ -39,7 +39,7 @@
 # =============================================================================
 services:
   cb-spider: #service name
-    version: 0.12.35(latest)
+    version: 0.12.42(latest)
     baseurl: http://cb-spider:1024/spider # baseurl is Scheme + Host + Base Path
     auth: # cb-spider 0.12.17+ requires REST auth; credentials are read from the env (see header).
       type: basic
@@ -47,19 +47,19 @@ services:
       password: default
 
   cb-tumblebug:
-    version: 0.12.25(latest)
+    version: 0.12.30(latest)
     baseurl: http://cb-tumblebug:1323/tumblebug
     auth:
       type: basic
       username: default
       password: default
   cm-ant:
-    version: 0.5.7(0.6.0)
+    version: 0.6.0(0.6.0)
     baseurl: http://cm-ant:8880/ant
     auth:
       type: none
   cm-beetle:
-    version: 0.5.6(latest)
+    version: 0.5.10(latest)
     baseurl: http://cm-beetle:8056/beetle
     auth:
       type: basic
@@ -74,25 +74,25 @@ services:
       type: none
       
   cm-cicada:
-    version: 0.5.2(latest)
+    version: 0.5.3(latest)
     baseurl: http://cm-cicada:8083/cicada
     auth:
       type: none
 
   cm-honeybee:
-    version: 0.5.3(latest)
+    version: 0.5.11(latest)
     baseurl: http://cm-honeybee:8081/honeybee
     auth:
       type: none 
 
   cm-grasshopper:
-    version: 0.5.2(latest)
+    version: 0.5.3(latest)
     baseurl: http://cm-grasshopper:8084/grasshopper
     auth:
       type: none
 
   cm-damselfly:
-    version: 0.5.3(latest)
+    version: 0.6.1(latest)
     baseurl: http://cm-damselfly:8088/damselfly
     auth: # cm-damselfly checks these only when DAMSELFLY_API_AUTH_ENABLED=true; otherwise they are ignored.
       type: basic
@@ -206,6 +206,10 @@ serviceActions:
       method: get
       resourcePath: /countrdbms
       description: "Get the total number of RDBMS instances across all connections."
+    Count-All-S3-Bucket:
+      method: get
+      resourcePath: /counts3
+      description: "Get the total number of S3 Buckets registered across all connections. (CB-Spider special feature)"
     Count-All-Securitygroup:
       method: get
       resourcePath: /countsecuritygroup
@@ -366,6 +370,10 @@ serviceActions:
       method: delete
       resourcePath: /csprdbms/{Id}
       description: "Delete a specified CSP RDBMS."
+    Delete-Csp-S3-Bucket:
+      method: delete
+      resourcePath: /csps3/{Id}
+      description: "Delete a specified CSP S3 Bucket directly from the CSP without affecting CB-Spider metadata. (CB-Spider special feature)"
     Delete-Csp-Securitygroup:
       method: delete
       resourcePath: /cspsecuritygroup/{Id}
@@ -677,7 +685,7 @@ serviceActions:
     List-All-Disk-Info:
       method: get
       resourcePath: /alldiskinfo
-      description: "Retrieve a list of all Disk information associated with all connections."
+      description: "Retrieve a comprehensive list of all Disk information associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
     List-All-Keypair:
       method: get
       resourcePath: /allkeypair
@@ -685,7 +693,7 @@ serviceActions:
     List-All-Keypair-Info:
       method: get
       resourcePath: /allkeypairinfo
-      description: "Retrieve a list of KeyPair information associated with all connections."
+      description: "Retrieve a comprehensive list of all KeyPair information associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
     List-All-Myimage:
       method: get
       resourcePath: /allmyimage
@@ -709,7 +717,15 @@ serviceActions:
     List-All-Rdbms-Info:
       method: get
       resourcePath: /allrdbmsinfo
-      description: "Retrieve a list of all RDBMS information associated with all connections."
+      description: "Retrieve a comprehensive list of all RDBMS information associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
+    List-All-S3-Bucket:
+      method: get
+      resourcePath: /alls3
+      description: "Retrieve a comprehensive list of all S3 Buckets associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP. (CB-Spider special feature)"
+    List-All-S3-Bucket-Info:
+      method: get
+      resourcePath: /alls3info
+      description: "Retrieve detailed info of all S3 Buckets associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP. (CB-Spider special feature)"
     List-All-Securitygroup:
       method: get
       resourcePath: /allsecuritygroup
@@ -717,7 +733,7 @@ serviceActions:
     List-All-Securitygroup-Info:
       method: get
       resourcePath: /allsecuritygroupinfo
-      description: "Retrieve a list of Security Group information associated with all connections."
+      description: "Retrieve a comprehensive list of all Security Group information associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP."
     List-All-Vm:
       method: get
       resourcePath: /allvm
@@ -946,6 +962,10 @@ serviceActions:
       method: post
       resourcePath: /region
       description: "Register a new Region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/features-and-usages#3-cloud-regionzone-%EC%A0%95%EB%B3%B4-%EB%93%B1%EB%A1%9D-%EB%B0%8F-%EA%B4%80%EB%A6%AC)]"
+    Register-S3-Bucket:
+      method: post
+      resourcePath: /regs3
+      description: "Register an existing CSP S3 bucket into CB-Spider metadata with a user-defined name. (CB-Spider special feature)"
     Register-Securitygroup:
       method: post
       resourcePath: /regsecuritygroup
@@ -1054,6 +1074,10 @@ serviceActions:
       method: delete
       resourcePath: /region/{RegionName}
       description: "Unregister a specific Region."
+    Unregister-S3-Bucket:
+      method: delete
+      resourcePath: /regs3/{Name}
+      description: "Remove an S3 bucket mapping from CB-Spider metadata without deleting it from the CSP. (CB-Spider special feature)"
     Unregister-Securitygroup:
       method: delete
       resourcePath: /regsecuritygroup/{Name}
@@ -1082,6 +1106,7 @@ serviceActions:
       method: get
       resourcePath: /version
       description: "Retrieves the version information of CB-Spider."
+
   cb-tumblebug:
     AddNLBNodes:
       method: post
@@ -1135,10 +1160,6 @@ serviceActions:
       method: put
       resourcePath: /ns/{nsId}/resources/objectStorage
       description: "Create an object storage (bucket)"
-    CreateObjectStorageLagacy:
-      method: put
-      resourcePath: /resources/objectStorage/{objectStorageName}
-      description: "(To be deprecated) Create an object storage (bucket)\n\n**Important Notes:**\n- The `objectStorageName` must be globally unique across all existing buckets in the S3 compatible storage.\n- The bucket namespace is shared by all users of the system."
     CreateOrUpdateLabel:
       method: put
       resourcePath: /label/{labelType}/{uid}
@@ -1182,7 +1203,7 @@ serviceActions:
     DelAllSharedResources:
       method: delete
       resourcePath: /ns/{nsId}/sharedResources
-      description: "Delete all Default Resource Objects in the given namespace"
+      description: "Release auto-generated resources that are no longer referenced: shared resources\nnamed \"{nsId}-shared-...\" (SecurityGroup, SSHKey, vNet) and per-Infra dedicated\nSecurityGroups that became orphaned after their Infra was deleted. Only resources\nwith no associated objects are removed; user-created or in-use resources are kept.\nUse dryRun=true to preview what would be released without deleting anything."
     DelAllSshKey:
       method: delete
       resourcePath: /ns/{nsId}/resources/sshKey
@@ -1242,11 +1263,11 @@ serviceActions:
     DelSubnet:
       method: delete
       resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}
-      description: "Delete Subnet\n---\n**action options:**\n\n**reconcile** – Synchronize Tumblebug metadata with the actual CSP state.\nChecks whether the Subnet resource still exists on CSP (via Spider).\nIf the CSP resource is gone, removes the orphaned Tumblebug metadata.\nIf the CSP resource still exists, keeps the metadata intact.\nUse this to clean up stale metadata after system errors or partial failures.\n(e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}?action=reconcile`)\n\n**force** – Force-delete the Subnet on CSP (passes `?force=true` to Spider).\nUse this when normal deletion fails due to CSP-side constraints (e.g., resource in use).\n(e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}?action=force`)"
+      description: "Delete Subnet\n---\n**action options:**\n\n**reconcile** – (To be deprecated: Use PUT /ns/{nsId}/resources/vNet/{vNetId}/reconcile instead) Synchronize Tumblebug metadata with the actual CSP state.\nChecks whether the Subnet resource still exists on CSP (via Spider).\nIf the CSP resource is gone, removes the orphaned Tumblebug metadata.\nIf the CSP resource still exists, keeps the metadata intact.\nUse this to clean up stale metadata after system errors or partial failures.\n(e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}?action=reconcile` - To be deprecated)\n\n**force** – Force-delete the Subnet on CSP (passes `?force=true` to Spider).\nUse this when normal deletion fails due to CSP-side constraints (e.g., resource in use).\n(e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}?action=force`)"
     DelVNet:
       method: delete
       resourcePath: /ns/{nsId}/resources/vNet/{vNetId}
-      description: "Delete VNet\n---\n**action options:**\n\n**withsubnets** – Delete the VNet together with all its subnets in a single call.\n\n**reconcile** – Synchronize Tumblebug metadata with the actual CSP state.\nChecks whether the VNet/Subnet resource still exists on CSP (via Spider).\nIf the CSP resource is gone, removes the orphaned Tumblebug metadata.\nIf the CSP resource still exists, keeps the metadata intact.\nUse this to clean up stale metadata after system errors or partial failures.\n(e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}?action=reconcile`)\n\n**force** – Force-delete the VNet and its subnets on CSP (passes `?force=true` to Spider).\nUse this when normal deletion fails due to CSP-side constraints (e.g., resource in use).\n(e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}?action=force`)"
+      description: "Delete VNet\n---\n**action options:**\n\n**withsubnets** – Delete the VNet together with all its subnets in a single call.\n\n**reconcile** – (To be deprecated: Use PUT /ns/{nsId}/resources/vNet/{vNetId}/reconcile instead) Synchronize Tumblebug metadata with the actual CSP state.\nChecks whether the VNet/Subnet resource still exists on CSP (via Spider).\nIf the CSP resource is gone, removes the orphaned Tumblebug metadata.\nIf the CSP resource still exists, keeps the metadata intact.\nUse this to clean up stale metadata after system errors or partial failures.\n(e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}?action=reconcile` - To be deprecated)\n\n**force** – Force-delete the VNet and its subnets on CSP (passes `?force=true` to Spider).\nUse this when normal deletion fails due to CSP-side constraints (e.g., resource in use).\n(e.g., `DELETE /ns/{nsId}/resources/vNet/{vNetId}?action=force`)"
     DeleteAllInfraDynamicTemplate:
       method: delete
       resourcePath: /ns/{nsId}/template/infra
@@ -1275,10 +1296,6 @@ serviceActions:
       method: delete
       resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}
       description: "Delete an object from an object storage (bucket)"
-    DeleteDataObjectLagacy:
-      method: delete
-      resourcePath: /resources/objectStorage/{objectStorageName}/{objectKey}
-      description: "(To be deprecated) Delete an object from a bucket"
     DeleteDeregisterSubnet:
       method: delete
       resourcePath: /ns/{nsId}/deregisterResource/vNet/{vNetId}/subnet/{subnetId}
@@ -1307,10 +1324,6 @@ serviceActions:
       method: delete
       resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}
       description: "Remove a K8sNodeGroup"
-    DeleteMultipleDataObjectsLagacy:
-      method: post
-      resourcePath: /resources/objectStorage/{objectStorageName}
-      description: "(To be deprecated) `Delete` multiple objects from a bucket\n\n**Important Notes:**\n- The request body must contain the list of objects to delete in XML format\n- The `delete` query parameter must be set to `true`\n\n**Request Body Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Delete xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Object>\n<Key>test-object1.txt</Key>\n</Object>\n<Object>\n<Key>test-object2.txt</Key>\n</Object>\n</Delete>\n```\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<DeleteResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Deleted>\n<Key>test-object1.txt</Key>\n</Deleted>\n<Deleted>\n<Key>test-object2.txt</Key>\n</Deleted>\n</DeleteResult>\n```"
     DeleteNodeCommandStatus:
       method: delete
       resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatus/{index}
@@ -1331,14 +1344,6 @@ serviceActions:
       method: delete
       resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
       description: "Delete all CORS rules of an object storage (bucket)"
-    DeleteObjectStorageCORSLagacy:
-      method: delete
-      resourcePath: /resources/objectStorage/{objectStorageName}/cors
-      description: "(To be deprecated) Delete CORS configuration of an object storage (bucket)"
-    DeleteObjectStorageLagacy:
-      method: delete
-      resourcePath: /resources/objectStorage/{objectStorageName}
-      description: "(To be deprecated) Delete an object storage (bucket)"
     DeleteObjects:
       method: delete
       resourcePath: /objects
@@ -1367,10 +1372,6 @@ serviceActions:
       method: delete
       resourcePath: /ns/{nsId}/infra/{infraId}/vpn/{vpnId}
       description: "Delete a site-to-site VPN\n\n- Note: A one-time retry is performed to handle transient failures caused by CSP-internal timing issues between dependent resources.\n\n**Query option:**\n\n| option | Description |\n|--------|-------------|\n| (none) | Standard delete via Terrarium. |\n| `reconcile` | Do not call the Terrarium delete API. Instead, check whether the Terrarium resource actually exists. If it is missing, remove orphaned Tumblebug metadata. If it exists but the metadata is stuck in a terminal-failure state (e.g., `Failed(DeletionFailed)`), restore the status to `Available`. Returns a reconcile result object instead of a normal delete response. |"
-    DeleteSqlDb:
-      method: delete
-      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
-      description: "Delete a SQL datatbase"
     DeleteVNetTemplate:
       method: delete
       resourcePath: /ns/{nsId}/template/vNet/{templateId}
@@ -1379,10 +1380,6 @@ serviceActions:
       method: delete
       resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versions/{objectKey}
       description: "Delete a specific version of an object in an object storage (bucket)\n\n**Note: **\n- If no version is specified, we will define how it behaves and update it when necessary.\n"
-    DeleteVersionedObjectLagacy:
-      method: delete
-      resourcePath: /resources/objectStorage/{objectStorageName}/versions/{objectKey}
-      description: "(To be deprecated) Delete a specific version of an object in an object storage (bucket)"
     DeregisterCustomImage:
       method: delete
       resourcePath: /ns/{nsId}/deregisterResource/customImage/{customImageId}
@@ -1403,10 +1400,6 @@ serviceActions:
       method: delete
       resourcePath: /ns/{nsId}/deregisterResource/sshKey/{sshKeyId}
       description: "Deregister SSH Key from Spider and TB without deleting the actual CSP resource"
-    ExistObjectStorageLagacy:
-      method: head
-      resourcePath: /resources/objectStorage/{objectStorageName}
-      description: "(To be deprecated) Check existence of an object storage (bucket)"
     FetchImages:
       method: post
       resourcePath: /fetchImages
@@ -1431,18 +1424,10 @@ serviceActions:
       method: post
       resourcePath: /forward/{path}
       description: "Forward any (GET) request to CB-Spider"
-    GeneratePresignedDownloadURLLagacy:
-      method: get
-      resourcePath: /resources/objectStorage/presigned/download/{objectStorageName}/{objectKey}
-      description: "(To be deprecated) Generate a presigned URL for downloading an object from a bucket\n\n**Important Notes:**\n- The actual response will be XML format with root element `PresignedURLResult`\n- The `expires` query parameter specifies the expiration time in seconds for the presigned URL (default: 3600 seconds)\n- The generated presigned URL can be used to download the object directly without further authentication\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<PresignedURLResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<PresignedURL>https://globally-unique-bucket-hctdx3.s3.dualstack.ap-southeast-2.amazonaws.com/test-file.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA***EXAMPLE%2F20250904%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20250904T061448Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=***-signature</PresignedURL>\n<Expires>3600</Expires>\n<Method>GET</Method>\n</PresignedURLResult>\n```"
     GeneratePresignedURL:
       method: post
       resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}/presignedUrl
       description: "Generate a presigned URL for uploading  or downloading an object to an object storage (bucket)\n\n**Important Notes:**\n- The generated presigned URL can be used to upload the object directly without further authentication\n- The expiration time is specified in seconds (default: 3600 seconds)\n\n**Example Usage: Upload**\n```bash\n# Using the presigned URL to upload a file\ncurl -i -H \"Content-Type: text/plain\" -X PUT \"<PRESIGNED_URL>\" --data-binary \"@local-file.txt\"\n```\n\n**Example Usage: download**\n```bash\n# Using the presigned URL to download a file\ncurl -X GET \"<PRESIGNED_URL>\" -o downloaded-file.txt\n```"
-    GeneratePresignedUploadURLLagacy:
-      method: get
-      resourcePath: /resources/objectStorage/presigned/upload/{objectStorageName}/{objectKey}
-      description: "(To be deprecated) Generate a presigned URL for uploading an object to a bucket\n\n**Important Notes:**\n- The actual response will be XML format with root element `PresignedURLResult`\n- The `expires` query parameter specifies the expiration time in seconds for the presigned URL (default: 3600 seconds)\n- The generated presigned URL can be used to upload the object directly without further authentication\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<PresignedURLResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<PresignedURL>https://globally-unique-bucket-hctdx3.s3.dualstack.ap-southeast-2.amazonaws.com/test-file.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA***EXAMPLE%2F20250904%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20250904T061448Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=***-signature</PresignedURL>\n<Expires>3600</Expires>\n<Method>PUT</Method>\n</PresignedURLResult>\n```"
     GetAllBenchmark:
       method: post
       resourcePath: /ns/{nsId}/benchmarkAll/infra/{infraId}
@@ -1487,6 +1472,14 @@ serviceActions:
       method: get
       resourcePath: /ns/{nsId}/infra/{infraId}/nlb
       description: "List all NLBs or NLBs' ID"
+    GetAllNLBInNs:
+      method: get
+      resourcePath: /ns/{nsId}/resources/nlb
+      description: "List all NLBs in a namespace regardless of the Infra they belong to. Each item carries its parent infraId.\nThis is a read-only listing; create/delete an NLB through /ns/{nsId}/infra/{infraId}/nlb.\nWith option=id, each entry is \"{infraId}/{nlbId}\" because an NLB id is only unique within its Infra."
+    GetAllNodeInNs:
+      method: get
+      resourcePath: /ns/{nsId}/resources/node
+      description: "List all Nodes in a namespace regardless of the Infra they belong to. Each item carries its parent infraId.\nThis is a read-only listing; create/delete a Node through /ns/{nsId}/infra/{infraId}/node.\nWith option=id, each entry is \"{infraId}/{nodeId}\" because a Node id is only unique within its Infra."
     GetAllNs:
       method: get
       resourcePath: /ns
@@ -1507,10 +1500,6 @@ serviceActions:
       method: get
       resourcePath: /ns/{nsId}/infra/{infraId}/vpn
       description: "Get all site-to-site VPNs"
-    GetAllSqlDb:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sqlDb
-      description: "Get all SQL Databases (TBD)"
     GetAllSshKey:
       method: get
       resourcePath: /ns/{nsId}/resources/sshKey
@@ -1611,10 +1600,6 @@ serviceActions:
       method: head
       resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/object/{objectKey}
       description: "Get object info from an object storage (bucket)\n\n**Important Notes:**\n- This API retrieves the metadata of an object without downloading the actual content\n- Returns metadata in response headers (Content-Length, Content-Type, ETag, Last-Modified)"
-    GetDataObjectInfoLagacy:
-      method: head
-      resourcePath: /resources/objectStorage/{objectStorageName}/{objectKey}
-      description: "(To be deprecated) Get an object info from a bucket\n\n**Important Notes:**\n- The generated `Download file` link in Swagger UI may not work because this API get the object metadata only."
     GetExecutionTask:
       method: get
       resourcePath: /ns/{nsId}/cmd/infra/{infraId}/task/{taskId}
@@ -1715,6 +1700,10 @@ serviceActions:
       method: get
       resourcePath: /ns/{nsId}/benchmarkLatency/infra/{infraId}
       description: "Run Infra benchmark for network latency"
+    GetLivez:
+      method: get
+      resourcePath: /livez
+      description: "Check Tumblebug server process is alive (liveness probe). Always returns 200 while the process is running."
     GetMonitorData:
       method: get
       resourcePath: /ns/{nsId}/monitoring/infra/{infraId}/metric/{metric}
@@ -1763,22 +1752,10 @@ serviceActions:
       method: get
       resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
       description: "Get CORS configuration of an object storage (bucket)"
-    GetObjectStorageCORSLagacy:
-      method: get
-      resourcePath: /resources/objectStorage/{objectStorageName}/cors
-      description: "(To be deprecated) Get CORS configuration of an object storage (bucket)\n\n**Important Notes:**\n- The actual response will be XML format with root element `CORSConfiguration`\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CORSConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<CORSRule>\n<AllowedOrigin>*</AllowedOrigin>\n<AllowedMethod>GET</AllowedMethod>\n<AllowedMethod>PUT</AllowedMethod>\n<AllowedMethod>POST</AllowedMethod>\n<AllowedMethod>DELETE</AllowedMethod>\n<AllowedHeader>*</AllowedHeader>\n<ExposeHeader>ETag</ExposeHeader>\n<ExposeHeader>x-amz-server-side-encryption</ExposeHeader>\n<ExposeHeader>x-amz-request-id</ExposeHeader>\n<ExposeHeader>x-amz-id-2</ExposeHeader>\n<MaxAgeSeconds>3000</MaxAgeSeconds>\n</CORSRule>\n</CORSConfiguration>\n```\n\n**Error Response Example (if CORS not configured):**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n<Code>NoSuchCORSConfiguration</Code>\n<Message>The CORS configuration does not exist</Message>\n<Resource>/example-bucket</Resource>\n<RequestId>656c76696e6727732072657175657374</RequestId>\n</Error>\n```"
-    GetObjectStorageLagacy:
-      method: get
-      resourcePath: /resources/objectStorage/{objectStorageName}
-      description: "(To be deprecated) Get details of an object storage (bucket)\n\n**Important Notes:**\n- The actual response will be XML format with root element `ListBucketResult`\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Name>spider-test-bucket</Name>\n<Prefix></Prefix>\n<Marker></Marker>\n<MaxKeys>1000</MaxKeys>\n<IsTruncated>false</IsTruncated>\n</ListBucketResult>\n```"
     GetObjectStorageLocation:
       method: get
       resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/location
       description: "Get the location of an object storage (bucket)"
-    GetObjectStorageLocationLagacy:
-      method: get
-      resourcePath: /resources/objectStorage/{objectStorageName}/location
-      description: "(To be deprecated) Get the location of an object storage (bucket)\n\n**Important Notes:**\n- The actual response will be XML format with root element `LocationConstraint`\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<LocationConstraint xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">ap-northeast-2</LocationConstraint>\n```"
     GetObjectStorageSupport:
       method: get
       resourcePath: /objectStorage/support
@@ -1787,10 +1764,6 @@ serviceActions:
       method: get
       resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versioning
       description: "Get versioning configuration of an object storage (bucket)"
-    GetObjectStorageVersioningLagacy:
-      method: get
-      resourcePath: /resources/objectStorage/{objectStorageName}/versioning
-      description: "(To be deprecated) Get versioning status of an object storage (bucket)\n\n**Important Notes:**\n- The actual response will be XML format with root element `VersioningConfiguration`\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VersioningConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Status>Enabled</Status>\n</VersioningConfiguration>\n```"
     GetObjects:
       method: get
       resourcePath: /objects
@@ -1811,10 +1784,14 @@ serviceActions:
       method: get
       resourcePath: /credential/publicKey
       description: "Generates an RSA key pair using a 4096-bit key size with the RSA algorithm. The public key is generated using the RSA algorithm with OAEP padding and SHA-256 as the hash function. This key is used to encrypt an AES key that will be used for hybrid encryption of credentials."
+    GetRDBMSSupport:
+      method: get
+      resourcePath: /rdbms/support
+      description: "Get CSP support metadata and capabilities for RDBMS engines (e.g., mysql, mariadb, postgresql)\nQuery parameters can be filtered by providerName, regionName, or dbEngine."
     GetReadyz:
       method: get
       resourcePath: /readyz
-      description: "Check Tumblebug is ready. Returns ready status and initialization status."
+      description: "Check Tumblebug is ready. Returns ready status and initialization status. With TB_READYZ_CHECK_DEPS=true, also verifies etcd/PostgreSQL connectivity."
     GetRegion:
       method: get
       resourcePath: /provider/{providerName}/region/{regionName}
@@ -1867,10 +1844,6 @@ serviceActions:
       method: get
       resourcePath: /ns/{nsId}/resources/spec/{specId}
       description: "Get spec"
-    GetSqlDb:
-      method: get
-      resourcePath: /ns/{nsId}/resources/sqlDb/{sqlDbId}
-      description: "Get resource info of a SQL datatbase"
     GetSshKey:
       method: get
       resourcePath: /ns/{nsId}/resources/sshKey/{sshKeyId}
@@ -1919,18 +1892,10 @@ serviceActions:
       method: get
       resourcePath: /ns/{nsId}/resources/objectStorage
       description: "Get the list of object storages (buckets)\n\n**Filtering with filterKey and filterVal:**\nBoth parameters perform a case-insensitive substring match against the stored JSON of each resource.\nA resource is included in the result only when its JSON contains **both** the filterKey string and the filterVal string.\n\nCommon filterKey examples:\n- `connectionName` — filter by cloud connection (e.g. filterVal: `aws-ap-northeast-2`)\n- `status`         — filter by resource status  (e.g. filterVal: `Available`)"
-    ListObjectStoragesLagacy:
-      method: get
-      resourcePath: /resources/objectStorage
-      description: "(To be deprecated) Get the list of all object storages (buckets)\n\n**Important Notes:**\n- The actual response will be XML format with root element `ListAllMyBucketsResult`\n- The response includes xmlns attribute: `xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"`\n- Swagger UI may show `resource.ListAllMyBucketsResult` due to rendering limitations\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListAllMyBucketsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Owner>\n<ID>aws-ap-northeast-2</ID>\n<DisplayName>aws-ap-northeast-2</DisplayName>\n</Owner>\n<Buckets>\n</Buckets>\n</ListAllMyBucketsResult>\n```"
     ListObjectVersions:
       method: get
       resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versions
       description: "List all versions of objects in an object storage (bucket)"
-    ListObjectVersionsLagacy:
-      method: get
-      resourcePath: /resources/objectStorage/{objectStorageName}/versions
-      description: "(To be deprecated) List object versions in an object storage (bucket)\n\n**Important Notes:**\n- The actual response will be XML format with root element `ListVersionsResult`\n\n**Actual XML Response Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListVersionsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Name>spider-test-bucket</Name>\n<Prefix></Prefix>\n<KeyMarker></KeyMarker>\n<VersionIdMarker></VersionIdMarker>\n<NextKeyMarker></NextKeyMarker>\n<NextVersionIdMarker></NextVersionIdMarker>\n<MaxKeys>1000</MaxKeys>\n<IsTruncated>false</IsTruncated>\n<Version>\n<Key>test-file.txt</Key>\n<VersionId>yb4PgjnFVD2LfRZHXBjjsHBkQRHlu.TZ</VersionId>\n<IsLatest>true</IsLatest>\n<LastModified>2025-09-04T04:24:12Z</LastModified>\n<ETag>23228a38faecd0591107818c7281cece</ETag>\n<Size>23</Size>\n<StorageClass>STANDARD</StorageClass>\n<Owner>\n<ID>aws-config01</ID>\n<DisplayName>aws-config01</DisplayName>\n</Owner>\n</Version>\n</ListVersionsResult>\n```"
     LoadAssets:
       method: get
       resourcePath: /loadAssets
@@ -2118,7 +2083,7 @@ serviceActions:
     PostNodeDataDisk:
       method: post
       resourcePath: /ns/{nsId}/infra/{infraId}/node/{nodeId}/dataDisk
-      description: "Provisioning (Create and attach) dataDisk"
+      description: "Provisioning (Create and attach) dataDisk. The dataDisk is created in the Node's zone unless a zone is given."
     PostNs:
       method: post
       resourcePath: /ns
@@ -2163,10 +2128,6 @@ serviceActions:
       method: post
       resourcePath: /specImagePairReview
       description: "Validate whether a spec and image pair is compatible for node provisioning.\nThis lightweight API checks:\n- Spec availability in DB and CSP\n- Image availability in DB and CSP (auto-registers if found in CSP but not in DB)\n- Cost estimation based on spec\n\n**Use Cases:**\n- Quick validation before node creation\n- Pre-check for dynamic provisioning\n- Verify custom image IDs entered by user"
-    PostSqlDb:
-      method: post
-      resourcePath: /ns/{nsId}/resources/sqlDb
-      description: "Create a SQL Databases\n\nSupported CSPs: AWS, Azure, GCP, NCP\n- Note - `connectionName` example: aws-ap-northeast-2, azure-koreacentral, gcp-asia-northeast3, ncp-kr\n\n- Note - Please check the `requiredCSPResource` property which includes CSP specific values.\n\n- Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/110\n"
     PostSshKey:
       method: post
       resourcePath: /ns/{nsId}/resources/sshKey
@@ -2211,6 +2172,14 @@ serviceActions:
       method: post
       resourcePath: /ns/{nsId}/infra/{infraId}/vpn/{vpnId}/health
       description: "Perform a bidirectional ping test on a site-to-site VPN using existing Infra nodes and return the results.\n\nIt finds nodes that belong to the VPN's two sites and runs ping tests\nin both directions (site1→site2 and site2→site1) via private IP.\nThe VPN is considered healthy only when both directions succeed.\n\nA retry strategy is used with configurable interval and max attempts\n(default: 15s interval, 20 attempts)."
+    PruneObjectStorages:
+      method: post
+      resourcePath: /ns/{nsId}/resources/objectStorage/prune
+      description: "Purges Tumblebug metadata for Object Storage resources diagnosed as missing on CSP."
+    PruneVNets:
+      method: post
+      resourcePath: /ns/{nsId}/resources/vNet/prune
+      description: "Purges Tumblebug metadata for vNet resources diagnosed as missing on CSP."
     PutChangeK8sNodeGroupAutoscaleSize:
       method: put
       resourcePath: /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/autoscaleSize
@@ -2307,10 +2276,22 @@ serviceActions:
       method: get
       resourcePath: /recommendSpecOptions
       description: "Get available options for filtering and prioritizing specs in RecommendSpec API"
+    ReconcileAllObjectStorages:
+      method: put
+      resourcePath: /ns/{nsId}/resources/objectStorage/reconcile
+      description: "Compares Tumblebug metadata with actual CSP object storage status via Spider.\nRestores status for alive resources and flags discrepancies."
     ReconcileAllVNets:
       method: put
       resourcePath: /ns/{nsId}/resources/vNet/reconcile
       description: "Reconcile all VNets and their subnets in the namespace by comparing TB metadata with CSP state. TB metadata is the source of truth; only TB-registered resources are reconciled.\n\n⚠️ **PERFORMANCE NOTE**: Reconciliation may take 1-2 minutes per cloud connection due to CSP API response time. Plan accordingly for namespaces with multiple cloud connections."
+    ReconcileObjectStorage:
+      method: put
+      resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/reconcile
+      description: "Compares Tumblebug metadata for a specific Object Storage resource with actual CSP status via Spider."
+    ReconcileVNet:
+      method: put
+      resourcePath: /ns/{nsId}/resources/vNet/{vNetId}/reconcile
+      description: "Compares Tumblebug metadata for a specific vNet resource with actual CSP status via Spider."
     RecordProvisioningEvent:
       method: post
       resourcePath: /provisioning/event
@@ -2383,18 +2364,10 @@ serviceActions:
       method: put
       resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/cors
       description: "Set CORS configuration of an object storage (bucket)"
-    SetObjectStorageCORSLagacy:
-      method: put
-      resourcePath: /resources/objectStorage/{objectStorageName}/cors
-      description: "(To be deprecated) Set CORS configuration of an object storage (bucket)\n\n**Important Notes:**\n- The CORS configuration must be provided in the request body in XML format.\n- The actual request body should have root element `CORSConfiguration`\n\n**Actual XML Request Body Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CORSConfiguration>\n<CORSRule>\n<AllowedOrigin>https://example.com</AllowedOrigin>\n<AllowedOrigin>https://app.example.com</AllowedOrigin>\n<AllowedMethod>GET</AllowedMethod>\n<AllowedMethod>PUT</AllowedMethod>\n<AllowedHeader>Content-Type</AllowedHeader>\n<AllowedHeader>Authorization</AllowedHeader>\n<ExposeHeader>ETag</ExposeHeader>\n<MaxAgeSeconds>1800</MaxAgeSeconds>\n</CORSRule>\n<CORSRule>\n<AllowedOrigin>*</AllowedOrigin>\n<AllowedMethod>GET</AllowedMethod>\n<MaxAgeSeconds>300</MaxAgeSeconds>\n</CORSRule>\n</CORSConfiguration>\n```"
     SetObjectStorageVersioning:
       method: put
       resourcePath: /ns/{nsId}/resources/objectStorage/{osId}/versioning
       description: "Set versioning configuration of an object storage (bucket)\n\n**Note: **\n- Versioning options: \"Enabled\", \"Suspended\", \"Unversioned\"\n"
-    SetObjectStorageVersioningLagacy:
-      method: put
-      resourcePath: /resources/objectStorage/{objectStorageName}/versioning
-      description: "(To be deprecated) Set versioning status of an object storage (bucket)\n\n**Important Notes:**\n- The request body must be XML format with root element `VersioningConfiguration`\n- The `Status` field can be either `Enabled` or `Suspended`\n\n**Request Body Example:**\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VersioningConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n<Status>Enabled</Status>\n</VersioningConfiguration>\n```"
     SetSystemInitialized:
       method: put
       resourcePath: /readyz/init
@@ -2415,6 +2388,7 @@ serviceActions:
       method: post
       resourcePath: /updateImagesFromAsset
       description: "Update image information based on the cloudimage.csv asset file"
+
   cm-ant:
     AntServerReadiness:
       method: get
@@ -2528,6 +2502,7 @@ serviceActions:
       method: put
       resourcePath: /api/v1/load/templates/test-scenario-catalogs/{id}
       description: "Update an existing load test scenario catalog with the provided configuration."
+
   cm-beetle:
     AlignNames:
       method: post
@@ -2540,7 +2515,7 @@ serviceActions:
     CheckSSHReady:
       method: get
       resourcePath: /migration/ns/{nsId}/infra/{infraId}/ssh-ready
-      description: "Check if all nodes in the migrated infrastructure are SSH-accessible.\n\n\"Running\" status doesn't mean cloud-init (SSH user setup) is done; timing varies by\nCSP (IBM Cloud VPC: up to ~3 min in testing). Works for any CSP.\n\n**Rate Limiting**: To prevent SSH server abuse, this API can only be called\nonce every 3 minutes for the same infrastructure. If called too soon, it returns\nHTTP 429 with the time to wait before the next check is allowed.\n\n**Check Method**: This API runs a lightweight command on each node via Tumblebug's\nremote command API (not a direct connection from CM-Beetle), so it reuses Tumblebug's\nexisting SSH/bastion setup for the node's CSP.\n\n**Response Options**:\n- Default (no option): Returns summary information (ready, totalNodes, readyNodes, message)\n- option=detail: Returns summary + detailed node status array (nodeStatus) for troubleshooting (per-node SSH readiness)"
+      description: "Check if all nodes in the migrated infrastructure are SSH-accessible.\n\n\"Running\" status doesn't mean cloud-init (SSH user setup) is done; timing varies by\nCSP (IBM Cloud VPC: up to ~3 min in testing). Works for any CSP.\n\n**Rate limiting**: At most **1 check per 30 seconds per infrastructure**, counted per\n`nsId:infraId` rather than per caller, because the protected resource is the nodes' own SSH\nservers. The window matches this API's own **30 s** runtime, so only one check per\ninfrastructure runs at a time. An early or concurrent call is rejected with **`429`** plus a\n**`Retry-After`** header in seconds, and performs no SSH activity. A client that awaits each\nresponse is never rate limited: a not-ready check runs the full 30 s before answering.\n\n**Check Method**: This API runs a lightweight command on each node via Tumblebug's\nremote command API (not a direct connection from CM-Beetle), so it reuses Tumblebug's\nexisting SSH/bastion setup for the node's CSP. It re-probes every **10 s** for up to\n**30 s**, returning as soon as every node responds.\n\n**Response Options**:\n- Default (no option): Returns summary information (ready, totalNodes, readyNodes, message)\n- option=detail: Returns summary + detailed node status array (nodeStatus) for troubleshooting (per-node SSH readiness)"
     CreateMigratedSSHKey:
       method: post
       resourcePath: /migration/ns/{nsId}/resources/sshKey
@@ -2560,7 +2535,11 @@ serviceActions:
     DeleteInfra:
       method: delete
       resourcePath: /migration/ns/{nsId}/infra/{infraId}
-      description: "Delete the migrated mult-cloud infrastructure (MCI)"
+      description: "Delete the migrated multi-cloud infrastructure (Infra).\n\nThis operation can take a long time (multiple settle-time waits and vNet-deletion\nretries). By default it runs synchronously. Send header `Prefer: respond-async` to run\nit asynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.\n\n**Rate limiting** — Calls to CB-Tumblebug are paced at **~1.6 req/s (one per 625 ms)** to stay\nunder its **2 req/s per-client-IP** limit. This operation allows its paced read up to **30 s**\nfor a slot, rather than the usual 8 s, because deletion tolerates a longer wait. On timeout the\nresponse is **`503`** with a **`Retry-After`** header in seconds."
+    DeleteK8sCluster:
+      method: delete
+      resourcePath: /migration/ns/{nsId}/k8sCluster/{k8sClusterId}
+      description: "Delete a K8s cluster created via cm-beetle migration. This removes the cluster and all its node groups."
     DeleteMigratedSSHKey:
       method: delete
       resourcePath: /migration/ns/{nsId}/resources/sshKey/{sshKeyId}
@@ -2588,11 +2567,11 @@ serviceActions:
     DeleteNlb:
       method: delete
       resourcePath: /migration/middleware/ns/{nsId}/infra/{infraId}/nlb/{nlbId}
-      description: "Delete a specific NLB from the target infra.\n\n[Note] Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.\nDeleting VNet/subnets immediately after NLB deletion may cause dependency errors (e.g., DependencyViolation on AWS).\nCM-Beetle waits a short period (e.g., 15s) after a successful deletion response to allow CSP-side cleanup to complete."
+      description: "Delete a specific NLB from the target infra.\n\n[Note] Some CSPs delete NLBs asynchronously — the API returns success before ENIs are fully released.\nDeleting VNet/subnets immediately after NLB deletion may cause dependency errors (e.g., DependencyViolation on AWS).\nCM-Beetle waits a short period (e.g., 15s) after a successful deletion response to allow CSP-side cleanup to complete.\n\nBy default this API runs synchronously (always includes the 15s settle wait). Send header\n`Prefer: respond-async` to run it asynchronously instead: receive 202 Accepted with a reqId,\nthen poll GET /request/{reqId} (status flow: Handling → Success / Error)."
     DeleteObjectStorage:
       method: delete
       resourcePath: /migration/middleware/ns/{nsId}/objectStorage/{osId}
-      description: "Delete a specific object storage (bucket).\n\nDeletion behavior is controlled by the `option` query parameter (mutually exclusive):\n- (none): Standard delete — fails if the bucket is not empty.\n- `empty`: Empty the bucket first, then delete.\n- `force`: Force-delete with all contents (passed to Spider as force=true).\n- `reconcile`: Remove only Tumblebug metadata without calling the CSP delete API."
+      description: "Delete a specific object storage (bucket).\n\nBy default this API runs synchronously. Send header `Prefer: respond-async` to run it\nasynchronously (RFC 7240). Check progress via GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.\n\nDeletion behavior is controlled by the `option` query parameter (mutually exclusive):\n- (none): Standard delete — fails if the bucket is not empty.\n- `empty`: Empty the bucket first, then delete.\n- `force`: Force-delete with all contents (passed to Spider as force=true).\n- `reconcile`: Remove only Tumblebug metadata without calling the CSP delete API."
     DeleteRequest:
       method: delete
       resourcePath: /request/{reqId}
@@ -2620,7 +2599,7 @@ serviceActions:
     GetAllRequests:
       method: get
       resourcePath: /requests
-      description: "Retrieves all API requests tracked by Beetle with optional filters.\n\n[Note]\n- Request tracking is managed independently by Beetle (not shared with Tumblebug).\n- This API only returns requests made to Beetle, not to Tumblebug.\n\n[Status Values]\n- Handling: Request is currently being processed\n- Success: Request completed successfully\n- Error: Request failed with an error"
+      description: "Retrieves all API requests tracked by Beetle with optional filters.\n\n[Note]\n- Request tracking is managed independently by Beetle (not shared with Tumblebug).\n- This API only returns requests made to Beetle, not to Tumblebug.\n\n[Status Values]\n- Handling: Request is currently being processed\n- Success: Request completed successfully\n- Error: Request failed with an error\n\n[Retry Information]\n- retry.retryable: Whether the failed request can be retried (present only for retriable errors)\n- retry.retryAfter: Suggested retry delay in seconds\n- retry.retryReason: Human-readable reason for retry requirement (e.g., \"Rate Limit Exceeded\")"
     GetDataMigrationEncryptionKey:
       method: get
       resourcePath: /migration/data/encryptionKey
@@ -2628,7 +2607,11 @@ serviceActions:
     GetInfra:
       method: get
       resourcePath: /migration/ns/{nsId}/infra/{infraId}
-      description: "Get the migrated multi-cloud infrastructure (MCI)"
+      description: "Get the migrated multi-cloud infrastructure (Infra)\n\n**Rate limiting** — Calls to CB-Tumblebug are paced at **~1.6 req/s (one per 625 ms)** to stay\nunder its **2 req/s per-client-IP** limit, and wait up to **8 s** for a slot. If none frees up\nin time the response is **`503`** with a **`Retry-After`** header in seconds. Those are the\ndefaults; operators tune them via `BEETLE_TUMBLEBUG_RETRIEVAL_REQUESTS_PER_SEC` and `_MAX_WAIT_SEC`."
+    GetK8sCluster:
+      method: get
+      resourcePath: /migration/ns/{nsId}/k8sCluster/{k8sClusterId}
+      description: "Retrieve information about a specific K8s cluster created via cm-beetle migration."
     GetMigratedSSHKey:
       method: get
       resourcePath: /migration/ns/{nsId}/resources/sshKey/{sshKeyId}
@@ -2664,7 +2647,7 @@ serviceActions:
     GetRequest:
       method: get
       resourcePath: /request/{reqId}
-      description: "Retrieves the details of a specific API request tracked by Beetle.\n\n[Note]\n- Request tracking is managed independently by Beetle (not shared with Tumblebug).\n- The reqId corresponds to the X-Request-Id header value from a previous API call.\n- Do NOT call Tumblebug's /request/{reqId} API with this reqId; each system manages its own request tracking.\n\n[Status Values]\n- Handling: Request is currently being processed\n- Success: Request completed successfully\n- Error: Request failed with an error"
+      description: "Retrieves the details of a specific API request tracked by Beetle.\n\n[Note]\n- Request tracking is managed independently by Beetle (not shared with Tumblebug).\n- The reqId corresponds to the X-Request-Id header value from a previous API call.\n- Do NOT call Tumblebug's /request/{reqId} API with this reqId; each system manages its own request tracking.\n\n[Status Values]\n- Handling: Request is currently being processed\n- Success: Request completed successfully\n- Error: Request failed with an error\n\n[Retry Information]\n- retry.retryable: Whether the failed request can be retried (present only for retriable errors)\n- retry.retryAfter: Suggested retry delay in seconds\n- retry.retryReason: Human-readable reason for retry requirement (e.g., \"Rate Limit Exceeded\")"
     GetSecurityPublicKey:
       method: get
       resourcePath: /migration/security/publicKey
@@ -2680,7 +2663,11 @@ serviceActions:
     ListInfra:
       method: get
       resourcePath: /migration/ns/{nsId}/infra
-      description: "Get the migrated multi-cloud infrastructure (MCI)"
+      description: "Get the migrated multi-cloud infrastructure (Infra)\n\n**Rate limiting** — Calls to CB-Tumblebug are paced at **~1.6 req/s (one per 625 ms)** to stay\nunder its **2 req/s per-client-IP** limit, and wait up to **8 s** for a slot. If none frees up\nin time the response is **`503`** with a **`Retry-After`** header in seconds. Those are the\ndefaults; operators tune them via `BEETLE_TUMBLEBUG_RETRIEVAL_REQUESTS_PER_SEC` and `_MAX_WAIT_SEC`."
+    ListK8sClusters:
+      method: get
+      resourcePath: /migration/ns/{nsId}/k8sCluster
+      description: "List all K8s clusters created in the namespace via cm-beetle migration."
     ListMigratedSSHKeys:
       method: get
       resourcePath: /migration/ns/{nsId}/resources/sshKey
@@ -2708,23 +2695,27 @@ serviceActions:
     MigrateData:
       method: post
       resourcePath: /migration/data
-      description: "**Asynchronous Operation**: This API returns immediately with a request ID. The actual migration runs in the background.\n\n[How to Use]\n1. Call this API → Receive 202 Accepted with reqId\n2. Poll GET /request/{reqId} to check status\n3. Status flow: Handling → Success / Error\n\n[Endpoint Requirements]\n* Both source and destination must be remote endpoints (SSH or object storage)\n* Local filesystem access is not allowed for security reasons\n\n[Transfer Options]\n* Strategy: auto (default), direct, relay\n* SSH: Supports PrivateKey content or PrivateKeyPath\n\n[Encryption Support]\n* To encrypt sensitive fields, first call GET /migration/data/encryptionKey\n* Encrypted requests include `encryptionKeyId` field\n* Server automatically detects and decrypts encrypted requests\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n"
+      description: "By default this API runs synchronously and returns the migration result directly.\n\n[Async Operation (opt-in)]\n1. Send header `Prefer: respond-async` → Receive 202 Accepted with reqId\n2. Poll GET /request/{reqId} to check status\n3. Status flow: Handling → Success / Error\n* Only the \"respond-async\" preference token is recognized; other tokens (e.g. wait=N) are ignored.\n* If too many async jobs are already running, this returns 503 instead of 202; retry after the `Retry-After` seconds.\n\n[Endpoint Requirements]\n* Both source and destination must be remote endpoints (SSH or object storage)\n* Local filesystem access is not allowed for security reasons\n\n[Transfer Options]\n* Strategy: auto (default), direct, relay\n* SSH: Supports PrivateKey content or PrivateKeyPath\n\n[Encryption Support]\n* To encrypt sensitive fields, first call GET /migration/data/encryptionKey\n* Encrypted requests include `encryptionKeyId` field\n* Server automatically detects and decrypts encrypted requests\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n"
     MigrateInfra:
       method: post
       resourcePath: /migration/ns/{nsId}/infra
-      description: "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults.\n\n**[Request Field: `nodeGroups[].cspImageName`]** Optional CSP-native image identifier.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses `imageId` for the standard DB lookup (may encounter stale images for some CSPs).\n- Recommended: pass the recommendation API response as-is to use the latest resolved image."
+      description: "Migrate an infrastructure to the multi-cloud infrastructure (Infra) with defaults.\n\n**[Request Field: `nodeGroups[].cspImageName`]** Optional CSP-native image identifier.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-node image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses `imageId` for the standard DB lookup (may encounter stale images for some CSPs).\n- Recommended: pass the recommendation API response as-is to use the latest resolved image.\n\nBy default this API runs synchronously. Send header `Prefer: respond-async` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.\n\n**Rate limiting** — Calls to CB-Tumblebug are paced at **~1.6 req/s (one per 625 ms)** to stay\nunder its **2 req/s per-client-IP** limit, and wait up to **8 s** for a slot. If none frees up\nin time the response is **`503`** with a **`Retry-After`** header in seconds. Those are the\ndefaults; operators tune them via `BEETLE_TUMBLEBUG_RETRIEVAL_REQUESTS_PER_SEC` and `_MAX_WAIT_SEC`."
     MigrateInfraWithDefaults:
       method: post
       resourcePath: /migration/ns/{nsId}/infraWithDefaults
-      description: "Migrate an infrastructure to the multi-cloud infrastructure (MCI) with defaults."
+      description: "Migrate an infrastructure to the multi-cloud infrastructure (Infra) with defaults.\n\nBy default this API runs synchronously. Send header `Prefer: respond-async` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized."
+    MigrateK8sCluster:
+      method: post
+      resourcePath: /migration/ns/{nsId}/k8sCluster
+      description: "Migrate an on-premise Kubernetes cluster to a managed K8s service (e.g., AWS EKS).\n\n**Workflow**:\n1. Call POST /recommendation/k8sCluster to get a RecommendedK8sInfra.\n2. Pass the recommendation result as-is to this endpoint.\n\n**Internal steps**: VNet → SSH Key → Security Group → K8s Cluster → Node Groups\n\nBy default this API runs synchronously (EKS takes ~10-20 min). Send header\n`Prefer: respond-async` to run it asynchronously: receive 202 Accepted with a\nreqId, then poll GET /request/{reqId} to check status."
     MigrateNlbs:
       method: post
       resourcePath: /migration/middleware/ns/{nsId}/infra/{infraId}/nlb
-      description: "Migrate NLBs to the target cloud infra based on recommendation results.\n\n[Prerequisites]\n- The target Namespace (nsId) must exist.\n- The target Infra (infraId) must exist and have at least one NodeGroup in Running state.\n- Each `targetNlbList[].targetGroup.nodeGroupId` must reference an existing NodeGroup in the Infra.\n\n[Note] Input should be the `targetNlbList` field from the POST /recommendation/infraWithNlb response.\nEnsure `targetGroup.nodeGroupId` matches the NodeGroup IDs created during infra migration.\n\n[Note] All NLBs are attempted independently. Partial success is possible."
+      description: "Migrate NLBs to the target cloud infra based on recommendation results.\n\n[Prerequisites]\n- The target Namespace (nsId) must exist.\n- The target Infra (infraId) must exist and have at least one NodeGroup in Running state.\n- Each `targetNlbList[].targetGroup.nodeGroupId` must reference an existing NodeGroup in the Infra.\n\n[Note] Input should be the `targetNlbList` field from the POST /recommendation/infraWithNlb response.\nEnsure `targetGroup.nodeGroupId` matches the NodeGroup IDs created during infra migration.\n\n[Note] All NLBs are attempted independently. Partial success is possible.\n\nBy default this API runs synchronously. Send header `Prefer: respond-async` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized."
     MigrateObjectStorage:
       method: post
       resourcePath: /migration/middleware/ns/{nsId}/objectStorage
-      description: "Migrate object storages to cloud based on recommendation results\n\n[Note]\n- This API creates object storages (buckets) in the target cloud within the specified namespace\n- Input should be the output from RecommendObjectStorage API\n- Connection name is automatically generated from CSP and region in the request body\n\n[Note] `nameSeed` enables dynamic naming via **Late Binding**.\n- If `nameSeed` query param is set (e.g., `?nameSeed=my`), bucket names are prefixed at migration time: `my-os-01`.\n- If `nameSeed` is omitted, bucket names are used as-is from the recommendation result.\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n"
+      description: "Migrate object storages to cloud based on recommendation results\n\n[Note]\n- This API creates object storages (buckets) in the target cloud within the specified namespace\n- Input should be the output from RecommendObjectStorage API\n- Connection name is automatically generated from CSP and region in the request body\n\n[Note] `nameSeed` enables dynamic naming via **Late Binding**.\n- If `nameSeed` query param is set (e.g., `?nameSeed=my`), bucket names are prefixed at migration time: `my-os-01`.\n- If `nameSeed` is omitted, bucket names are used as-is from the recommendation result.\n\n[Examples]\n* Test results: https://github.com/cloud-barista/cm-beetle/blob/main/docs/test-results-data-migration.md\n\nBy default this API runs synchronously. Send header `Prefer: respond-async` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized."
     PreviewInfra:
       method: post
       resourcePath: /naming/preview
@@ -2733,14 +2724,26 @@ serviceActions:
       method: post
       resourcePath: /recommendation/infraWithNlb
       description: "Perform NLB-aware infrastructure recommendation and return multiple Pareto-optimal candidates.\n\nThe recommendation engine:\n1. Correlates NLB backend server IPs with source Node IPs\n2. Normalizes backend ports via majority vote when ports differ\n3. Assigns NLB-related nodes to shared NodeGroups (N:1), unrelated nodes to individual NodeGroups (1:1)\n4. Finds ranked compatible spec-image pairs per NodeGroup (representative node for NLB groups)\n5. Generates up to `limit` candidates — candidate i uses the i-th ranked pair per NodeGroup\n6. Maps source NLB configuration to target cloud NLB model (same for all candidates)\n\n[Note] `sourceInfra.nlbs` must be populated (HAProxy frontend-backend pairs from cm-honeybee).\n\n[Note] The returned `targetInfra.nodeGroups[].name` values are referenced by `targetNlbList[].targetGroup.nodeGroupId`.\nUse the same NodeGroup IDs when calling POST /migration/infra so that the NLB migration can reference them immediately.\n\n---\n## CSP-Specific NLB Notes\n\nAWS:\n- Port translation supported (e.g., listener 9999 → backend 8086).\n- DNS endpoint; allow ~5 min for propagation after creation.\n- [Auto] SG rule for backend port opened from 0.0.0.0/0.\n\nAzure:\n- Port translation supported. DNS + static IP endpoint.\n- [Auto] Health check timeout omitted (not supported by Azure).\n\nGCP:\n- Port translation NOT supported; traffic arrives at backend VMs on the listener port.\n- [Auto] Listener port is forced equal to the backend port — clients must connect on the application port (e.g., 8086, not 9999).\n- IP-only endpoint (no DNS name).\n\nIBM:\n- Port translation supported.\n- Listener address is assigned asynchronously; re-query if the address is empty after migration.\n- [Auto] Health check timeout forced strictly less than the interval.\n---"
-    RecommendK8sControlPlane:
+    RecommendK8sCluster:
       method: post
-      resourcePath: /recommendation/k8sControlPlane
-      description: "Get recommendation for K8s control plane based on honeybee source cluster data\nReturns configuration that can be directly used with cb-tumblebug k8sClusterDynamic API"
-    RecommendK8sNodeGroup:
+      resourcePath: /recommendation/k8sCluster
+      description: "Recommend a complete K8s cluster configuration based on on-premise infra data from cm-honeybee.\nReturns a RecommendedK8sInfra that can be passed directly to the K8s migration API.\n\n**Required Parameters**: `desiredProvider`, `desiredRegion`\n**Input**: On-premise infra model (from honeybee /infra/refined) with K8s cluster info and node roles"
+    RecommendK8sNodeGroupImages:
       method: post
-      resourcePath: /recommendation/k8sNodeGroup
-      description: "Get recommendation for K8s worker node group based on honeybee source cluster data\nReturns configuration that can be directly used with cb-tumblebug k8sNodeGroupDynamic API"
+      resourcePath: /recommendation/resources/k8sNodeGroupImages
+      description: "Recommend a node image for each worker node group derived from the source infrastructure.\n\nUnlike VM OS image recommendation, K8s node images are selected from a provider-curated\nlist (k8sclusterinfo.yaml) rather than the image DB. The selection is architecture-based:\nx86_64 groups receive \"default\"; arm64 groups receive the provider ARM image when\nNodeImageDesignation=true for the target provider.\n\n[Note] Only nodes with `role=worker` are considered. `k8sCluster` is not required.\n[Note] Only `targetOsImage.id` is populated in each entry; other ImageInfo fields are empty."
+    RecommendK8sNodeGroupSpecs:
+      method: post
+      resourcePath: /recommendation/resources/k8sNodeGroupSpecs
+      description: "Recommend worker node specs for each node group derived from the source infrastructure.\n\nSource workers are grouped by spec signature (vCPU/memory/architecture) because managed\nK8s node groups are homogeneous; one recommendation set is produced per group, and the\ngroup's source machines are listed in `sourceServers`.\n\n[Note] Only nodes with `role=worker` are considered. `k8sCluster` is not required.\n[Note] Specs below the target's K8s node minimum are upscaled, and the adjustment is\nreported in the entry's `description`."
+    RecommendMultiInfraCandidates:
+      method: post
+      resourcePath: /recommendation/multiInfra
+      description: "Recommend a single best-effort infrastructure candidate for each of several target CSP/region pairs.\n\nUse this API to compare candidate clouds before committing to one; once a target is chosen,\nuse `POST /recommendation/infra` against that single CSP/region to explore multiple candidates.\n\n**[Required Parameter: `desiredCspAndRegionPairs`]** 2 to 10 target CSP/region pairs (project scope: 10 supported CSPs).\nDuplicate pairs are rejected.\n\n**[Response]** Always returns exactly one item per requested target, in request order\n(`len(data) == len(desiredCspAndRegionPairs)`), so items map back to targets via `targetCloud`\nwithout needing to be re-sorted or grouped. A target that fails validation or yields no\ncompatible infrastructure still produces one item, with `status` set to `failed` or\n`nothing-to-recommend` and `targetInfra` left empty.\n\n**[Optional Parameter: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n[Note] Each target costs roughly as much as one `/recommendation/infra` call; requests with\nseveral targets can take a while. `Prefer: respond-async` is strongly recommended."
+    RecommendMultiInfraWithNlbCandidates:
+      method: post
+      resourcePath: /recommendation/multiInfraWithNlb
+      description: "NLB-aware counterpart of `POST /recommendation/multiInfra`. Recommends a single best-effort\ninfrastructure candidate (including NLB mapping) for each of several target CSP/region pairs.\n\nUse this API to compare candidate clouds before committing to one; once a target is chosen,\nuse `POST /recommendation/infraWithNlb` against that single CSP/region to explore multiple candidates.\n\n**[Required Parameter: `desiredCspAndRegionPairs`]** 2 to 10 target CSP/region pairs (project scope: 10 supported CSPs).\nDuplicate pairs are rejected.\n\n[Note] `sourceInfra.nlbs` must be populated (HAProxy frontend-backend pairs from cm-honeybee).\n\n**[Response]** Always returns exactly one item per requested target, in request order\n(`len(data) == len(desiredCspAndRegionPairs)`), so items map back to targets via `targetCloud`\nwithout needing to be re-sorted or grouped. A target that fails validation or yields no\ncompatible infrastructure still produces one item, with `status` set to `failed` or\n`nothing-to-recommend` and `targetInfra` left empty.\n\n**[Optional Parameter: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n[Note] Each target costs roughly as much as one `/recommendation/infraWithNlb` call; requests with\nseveral targets can take a while. `Prefer: respond-async` is strongly recommended."
     RecommendObjectStorage:
       method: post
       resourcePath: /recommendation/middleware/objectStorage
@@ -2752,7 +2755,7 @@ serviceActions:
     RecommendVMInfraWithDefaults:
       method: post
       resourcePath: /recommendation/infraWithDefaults
-      description: "Recommend an appropriate VM infrastructure (i.e., MCI, multi-cloud infrastructure) with defaults for cloud migration\n\n[Note] `desiredCsp` and `desiredRegion` are required.\n- `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.\n\n**[Response Field: `nodeGroups[].cspImageName`]** Set only when the spec-image review resolved a newer image than the DB cache.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses `imageId` for the standard DB lookup path."
+      description: "Recommend an appropriate infrastructure (i.e., Infra, multi-cloud infrastructure) with defaults for cloud migration\n\n[Note] `desiredCsp` and `desiredRegion` are required.\n- `desiredCsp` and `desiredRegion` can set on the query parameter or the request body.\n\n- If desiredCsp and desiredRegion are set on request body, the values in the query parameter will be ignored.\n\n**[Response Field: `nodeGroups[].cspImageName`]** Set only when the spec-image review resolved a newer image than the DB cache.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses `imageId` for the standard DB lookup path."
     RecommendVNet:
       method: post
       resourcePath: /recommendation/resources/vNet
@@ -2760,7 +2763,7 @@ serviceActions:
     RecommendVmInfraCandidates:
       method: post
       resourcePath: /recommendation/infra
-      description: "Recommend best-effort VM infrastructure (MCI) candidates for migrating on-premise workloads to cloud environments.\n\n- See overview and examples on https://github.com/cloud-barista/cm-beetle/discussions/256\n\n**[Required Parameters: `desiredCsp`, `desiredRegion`]** The desired cloud service provider and region for the recommended infrastructure.\n- if **desiredCsp** and **desiredRegion** are set on request body, the values in the query parameter will be ignored.\n\n**[Optional Parameters: `limit`]** Maximum number of recommended infrastructures to return (default: 3)\n\n**[Optional Parameters: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n**[Response Field: `status`]** Candidate status based on the match rate threshold\n- **highly-matched**: Candidates meet or exceed the match rate threshold\n- **partially-matched**: Valid candidates below the match rate threshold\n\n**[Response Field: `description`]** Summary containing Candidate ID, status, match rate statistics (Min/Max/Avg), and VM counts\n- Example: \"Candidate #1 | partially-matched | Overall Match Rate: Min=88.9% Max=100.0% Avg=98.7% | VMs: 3 total, 2 matched, 1 acceptable\"\n\n**[Response Field: `nodeGroups[].cspImageName`]** Set only when the spec-image review resolved a newer image than the DB cache.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses `imageId` for the standard DB lookup path.\n- Pass the recommendation response as-is to the migration API to ensure the resolved image is used.\n"
+      description: "Recommend best-effort infrastructure (Infra) candidates for migrating on-premise workloads to cloud environments.\n\n- See overview and examples on https://github.com/cloud-barista/cm-beetle/discussions/256\n\n**[Required Parameters: `desiredCsp`, `desiredRegion`]** The desired cloud service provider and region for the recommended infrastructure.\n- if **desiredCsp** and **desiredRegion** are set on request body, the values in the query parameter will be ignored.\n\n**[Optional Parameters: `limit`]** Maximum number of recommended infrastructures to return (default: 3)\n\n**[Optional Parameters: `minMatchRate`]** Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)\n\n**[Response Field: `status`]** Candidate status based on the match rate threshold\n- **highly-matched**: Candidates meet or exceed the match rate threshold\n- **partially-matched**: Valid candidates below the match rate threshold\n\n**[Response Field: `description`]** Summary containing Candidate ID, status, match rate statistics (Min/Max/Avg), and VM counts\n- Example: \"Candidate #1 | partially-matched | Overall Match Rate: Min=88.9% Max=100.0% Avg=98.7% | VMs: 3 total, 2 matched, 1 acceptable\"\n\n**[Response Field: `nodeGroups[].cspImageName`]** Set only when the spec-image review resolved a newer image than the DB cache.\n- **Non-empty**: TumbleBug sends this to Spider directly, bypassing the per-VM image DB lookup (prevents stale image failures, e.g., Alibaba alibase images).\n- **Empty**: TumbleBug uses `imageId` for the standard DB lookup path.\n- Pass the recommendation response as-is to the migration API to ensure the resolved image is used.\n"
     RecommendVmOsImages:
       method: post
       resourcePath: /recommendation/resources/osImages
@@ -2796,11 +2799,12 @@ serviceActions:
     ValidateInfra:
       method: post
       resourcePath: /validation/ns/{nsId}/infra
-      description: "Runs, without creating or modifying any resource, the same checks\nmigration execution performs immediately before provisioning:\n\n- **Naming & referential integrity**: names must be 3-63 alphanumeric/hyphen\ncharacters, and internal references must resolve within the submitted model\n(e.g. a NodeGroup's `securityGroupIds` must match a `name` in `targetSecurityGroupList`).\n- **Required fields**, which differ by `useExisting`:\n- `true`: each NodeGroup's `vNetId`, `sshKeyId`, `securityGroupIds` must be set.\n- `false`: `targetVNet.name`, `targetSshKey.name`, and each security group's `name` must be set.\n- **Resource name collision / availability** against Tumblebug, which also differs by `useExisting`:\n- `false`: the VNet/SSH key/security groups to be created must NOT already exist in the\nnamespace (e.g. `targetVNet.name: \"vnet-01\"` fails if a VNet named `vnet-01` already exists).\n- `true`: an existing resource must be under the same CSP/region connection the NodeGroup\nrequests (e.g. reusing a VNet provisioned under connection `aws-ap-northeast-2` while the\nNodeGroup's `connectionName` is `gcp-asia-northeast3` fails); a resource that doesn't exist\nyet must have enough data alongside it to create it instead (e.g. `targetVNet.cidrBlock`).\n- **VM spec/image compatibility** per NodeGroup: `specId`, `imageId`, and `connectionName` must\nbe set, `connectionName` must be in `csp-region` format (e.g. `aws-ap-northeast-2`), and the\nresolved spec/image pair must be compatible for that CSP (e.g. an `x86_64` spec paired with\nan `arm64` image fails).\n- **Infra (MCI) name collision**: `targetInfra.name` must not already exist in the namespace.\n\nAlways returns HTTP 200: the response body's `valid` field and\n`issues` list carry the outcome, since a failed check is a normal,\nsuccessfully-answered result rather than a malformed request.\n400 is reserved for request body/parameter errors.\n\nBecause Tumblebug/CSP state can change afterward, a `valid: true`\nresult is a best-effort snapshot, not a guarantee - the migration\nAPI re-runs this same validation immediately before provisioning."
+      description: "Runs, without creating or modifying any resource, the same checks\nmigration execution performs immediately before provisioning:\n\n- **Naming & referential integrity**: names must be 3-63 alphanumeric/hyphen\ncharacters, and internal references must resolve within the submitted model\n(e.g. a NodeGroup's `securityGroupIds` must match a `name` in `targetSecurityGroupList`).\n- **Required fields**, which differ by `useExisting`:\n- `true`: each NodeGroup's `vNetId`, `sshKeyId`, `securityGroupIds` must be set.\n- `false`: `targetVNet.name`, `targetSshKey.name`, and each security group's `name` must be set.\n- **Resource name collision / availability** against Tumblebug, which also differs by `useExisting`:\n- `false`: the VNet/SSH key/security groups to be created must NOT already exist in the\nnamespace (e.g. `targetVNet.name: \"vnet-01\"` fails if a VNet named `vnet-01` already exists).\n- `true`: an existing resource must be under the same CSP/region connection the NodeGroup\nrequests (e.g. reusing a VNet provisioned under connection `aws-ap-northeast-2` while the\nNodeGroup's `connectionName` is `gcp-asia-northeast3` fails); a resource that doesn't exist\nyet must have enough data alongside it to create it instead (e.g. `targetVNet.cidrBlock`).\n- **VM spec/image compatibility** per NodeGroup: `specId`, `imageId`, and `connectionName` must\nbe set, `connectionName` must be in `csp-region` format (e.g. `aws-ap-northeast-2`), and the\nresolved spec/image pair must be compatible for that CSP (e.g. an `x86_64` spec paired with\nan `arm64` image fails).\n- **Infra name collision**: `targetInfra.name` must not already exist in the namespace.\n\nAlways returns HTTP 200: the response body's `valid` field and\n`issues` list carry the outcome, since a failed check is a normal,\nsuccessfully-answered result rather than a malformed request.\n400 is reserved for request body/parameter errors.\n\nBecause Tumblebug/CSP state can change afterward, a `valid: true`\nresult is a best-effort snapshot, not a guarantee - the migration\nAPI re-runs this same validation immediately before provisioning."
     ValidateNames:
       method: post
       resourcePath: /naming/validation
       description: "Validates that all internal references within a RecommendedInfra model\nare consistent and point to existing resources.\nNameSeed is NOT applied here; this validates the base names only.\n"
+
   cm-cicada:
     Cancel-Workflow-Schedule:
       method: delete
@@ -3006,6 +3010,7 @@ serviceActions:
       method: put
       resourcePath: /workflow/{wfId}
       description: "Update the workflow content."
+
   cm-damselfly:
     CreateCloudModel:
       method: post
@@ -3123,6 +3128,7 @@ serviceActions:
       method: put
       resourcePath: /softwaremodel/target/{id}
       description: "Update a target software user model with the given information."
+
   cm-grasshopper:
     Create-Velero-Backup:
       method: post
@@ -3216,6 +3222,7 @@ serviceActions:
       method: post
       resourcePath: /velero/migration/precheck
       description: "Check source cluster, target cluster, and the S3 object store before executing Velero migration."
+
   cm-honeybee:
     Create-Connection-Info:
       method: post

--- a/api/conf/api.yaml
+++ b/api/conf/api.yaml
@@ -1,41 +1,60 @@
 # =============================================================================
-# Service registry for the `mayfly api` / `mayfly rest` commands.
+# Service registry for the Cloud-Migrator subsystems.
 #
-# Each service entry has a baseurl and an `auth` block that tells cm-mayfly how
-# to authenticate when it calls that service.
+# Two things read this file, and they must read the same one:
 #
-# auth.type — the authentication METHOD to use (it declares HOW to authenticate,
-# not whether the remote service enforces auth):
-#   * none   — send no credentials. This is also the effective default when the
-#              auth block is omitted.
-#   * basic  — HTTP Basic Auth built from auth.username + auth.password.
-#   * bearer — send auth.token as a Bearer token.
+#   * cm-mayfly    — the `mayfly api` / `mayfly rest` commands call a subsystem
+#                    directly from the host.
+#   * cm-butterfly — its proxy answers POST /api/{subsystem}/{operationId} by
+#                    looking the operationId up here and calling
+#                    services.<subsystem>.baseurl + resourcePath.
 #
-# Credential values (username / password / token) may each be written either as
-# a literal or as a ${VAR} reference:
-#   * literal   e.g. "username: default" — the value is taken from this file.
-#   * ${VAR}    e.g. "password: default" — the value is read from the
-#               environment at call time. Writing a value as ${VAR} is the
-#               explicit signal that the credential lives outside this file.
+# cm-mayfly holds the master copy and generates serviceActions from each
+# subsystem's swagger (`mayfly api tool`). cm-butterfly takes this file as it
+# is — there is no conversion step, and a difference between the two copies
+# means one of them has drifted.
 #
-# Resolution order for a ${VAR} reference (first hit wins):
-#   1. the process environment (an OS-level / exported variable),
-#   2. conf/docker/.env (the single shared environment file),
-#   3. otherwise it resolves to empty — for basic auth no Authorization header
-#      is then sent, and a warning is printed. There is no implicit default.
+# The operationId is scoped to its subsystem: the same name exists in more than
+# one of them, which is why cm-butterfly's proxy path carries the subsystem.
 #
-# A --username / --password / --token flag passed on the command line overrides
-# whatever is configured here.
+# CREDENTIALS
 #
-# api.yaml only controls what cm-mayfly SENDS. Whether a service actually
-# enforces auth is the service's own decision (for example cm-damselfly checks
-# credentials only when DAMSELFLY_API_AUTH_ENABLED=true). Sending credentials to
-# a service that is not enforcing auth is harmless — they are simply ignored —
-# so basic auth can be configured here regardless of the server's current state.
+#   auth.type  none | basic | bearer
+#   none       send nothing. Also the effect when the auth block is omitted.
+#   basic      build the header from auth.username + auth.password.
+#   bearer     send a token. cm-mayfly takes auth.token from this file;
+#              cm-butterfly takes it from the incoming request instead.
 #
-# A possible future enhancement is to make auth.type itself a ${VAR} reference,
-# for services whose method can change at runtime; that is intentionally left
-# out for now until a concrete need appears.
+# A username or password may be written as ${VAR} and is read from the process
+# environment. Under docker compose the values come from the single shared .env
+# — cm-mayfly reads it directly, and the compose file passes the same values
+# into the cm-butterfly-api container.
+#
+# A ${VAR} that resolves to nothing is an error, not a default:
+#
+#   * cm-mayfly    sends no Authorization header and warns.
+#   * cm-butterfly refuses to start and names the variable.
+#
+# There is no implicit fallback anywhere. These values were literals once, so a
+# deployment could change its .env while the file kept sending the old
+# credentials, and the only symptom was a 401 that looked like a screen failing
+# to load.
+#
+# A --username / --password / --token flag on the cm-mayfly command line
+# overrides whatever is configured here.
+#
+# This file only controls what gets SENT. Whether a subsystem enforces auth is
+# its own decision — cm-damselfly, for instance, checks credentials only when
+# DAMSELFLY_API_AUTH_ENABLED=true. Sending credentials to a subsystem that is
+# not enforcing them is harmless.
+#
+# baseurl is literal and has no environment override. It describes how the
+# deployment is wired — under compose these are the service hostnames. Running
+# a subsystem on localhost for development means editing it by hand, and that
+# edit is not committed.
+#
+# The swagger block records where each subsystem's spec comes from. cm-mayfly
+# uses it to regenerate; cm-butterfly ignores it.
 # =============================================================================
 services:
   cb-spider: #service name
@@ -43,31 +62,45 @@ services:
     baseurl: http://cb-spider:1024/spider # baseurl is Scheme + Host + Base Path
     auth: # cb-spider 0.12.17+ requires REST auth; credentials are read from the env (see header).
       type: basic
-      username: default
-      password: default
+      username: ${SPIDER_USERNAME}
+      password: ${SPIDER_PASSWORD}
+    swagger:
+      latest: https://raw.githubusercontent.com/cloud-barista/cb-spider/master/api/swagger.json
+      release: https://raw.githubusercontent.com/cloud-barista/cb-spider/{release}/api/swagger.json
 
   cb-tumblebug:
     version: 0.12.30(latest)
     baseurl: http://cb-tumblebug:1323/tumblebug
     auth:
       type: basic
-      username: default
-      password: default
+      username: ${TB_API_USERNAME}
+      password: ${TB_API_PASSWORD}
+    swagger:
+      latest: https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/src/interface/rest/docs/swagger.json
+      release: https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/{release}/src/interface/rest/docs/swagger.json
   cm-ant:
     version: 0.6.0(0.6.0)
     baseurl: http://cm-ant:8880/ant
     auth:
       type: none
+    swagger:
+      latest: https://raw.githubusercontent.com/cloud-barista/cm-ant/main/api/swagger.json
+      release: https://raw.githubusercontent.com/cloud-barista/cm-ant/{release}/api/swagger.json
   cm-beetle:
     version: 0.5.10(latest)
     baseurl: http://cm-beetle:8056/beetle
     auth:
       type: basic
-      username: default
-      password: default
+      username: ${BEETLE_API_USERNAME}
+      password: ${BEETLE_API_PASSWORD}
+    swagger:
+      latest: https://raw.githubusercontent.com/cloud-barista/cm-beetle/main/api/swagger.json
+      release: https://raw.githubusercontent.com/cloud-barista/cm-beetle/{release}/api/swagger.json
 
   cm-butterfly-api:
-    version: 0.5.2
+    # No public swagger source is registered for this service, so the version is
+    # kept in step with the image tag in conf/docker/docker-compose.yaml by hand.
+    version: 0.5.5
     #baseurl: http://localhost:4000
     baseurl: http://cm-butterfly-api:4000
     auth:
@@ -78,27 +111,47 @@ services:
     baseurl: http://cm-cicada:8083/cicada
     auth:
       type: none
+    swagger:
+      latest: https://raw.githubusercontent.com/cloud-barista/cm-cicada/main/pkg/api/rest/docs/swagger.json
+      release: https://raw.githubusercontent.com/cloud-barista/cm-cicada/{release}/pkg/api/rest/docs/swagger.json
 
   cm-honeybee:
     version: 0.5.11(latest)
     baseurl: http://cm-honeybee:8081/honeybee
     auth:
-      type: none 
+      type: none
+    swagger:
+      latest: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/main/server/pkg/api/rest/docs/swagger.json
+      release: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/{release}/server/pkg/api/rest/docs/swagger.json
+
+  cm-honeybee-agent:
+    version: 0.5.11(latest)
+    baseurl: http://cm-honeybee:8082/honeybee-agent
+    auth:
+      type: none
+    swagger:
+      latest: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/main/agent/pkg/api/rest/docs/swagger.json
+      release: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/{release}/agent/pkg/api/rest/docs/swagger.json
 
   cm-grasshopper:
     version: 0.5.3(latest)
     baseurl: http://cm-grasshopper:8084/grasshopper
     auth:
       type: none
+    swagger:
+      latest: https://raw.githubusercontent.com/cloud-barista/cm-grasshopper/main/pkg/api/rest/docs/swagger.json
+      release: https://raw.githubusercontent.com/cloud-barista/cm-grasshopper/{release}/pkg/api/rest/docs/swagger.json
 
   cm-damselfly:
     version: 0.6.1(latest)
     baseurl: http://cm-damselfly:8088/damselfly
     auth: # cm-damselfly checks these only when DAMSELFLY_API_AUTH_ENABLED=true; otherwise they are ignored.
       type: basic
-      username: default
-      password: default
-
+      username: ${DAMSELFLY_API_USERNAME}
+      password: ${DAMSELFLY_API_PASSWORD}
+    swagger:
+      latest: https://raw.githubusercontent.com/cloud-barista/cm-damselfly/main/api/swagger.json
+      release: https://raw.githubusercontent.com/cloud-barista/cm-damselfly/{release}/api/swagger.json
 
 serviceActions:
   cb-spider:
@@ -1106,7 +1159,6 @@ serviceActions:
       method: get
       resourcePath: /version
       description: "Retrieves the version information of CB-Spider."
-
   cb-tumblebug:
     AddNLBNodes:
       method: post
@@ -2388,7 +2440,6 @@ serviceActions:
       method: post
       resourcePath: /updateImagesFromAsset
       description: "Update image information based on the cloudimage.csv asset file"
-
   cm-ant:
     AntServerReadiness:
       method: get
@@ -2502,7 +2553,6 @@ serviceActions:
       method: put
       resourcePath: /api/v1/load/templates/test-scenario-catalogs/{id}
       description: "Update an existing load test scenario catalog with the provided configuration."
-
   cm-beetle:
     AlignNames:
       method: post
@@ -2804,7 +2854,6 @@ serviceActions:
       method: post
       resourcePath: /naming/validation
       description: "Validates that all internal references within a RecommendedInfra model\nare consistent and point to existing resources.\nNameSeed is NOT applied here; this validates the base names only.\n"
-
   cm-cicada:
     Cancel-Workflow-Schedule:
       method: delete
@@ -3010,7 +3059,6 @@ serviceActions:
       method: put
       resourcePath: /workflow/{wfId}
       description: "Update the workflow content."
-
   cm-damselfly:
     CreateCloudModel:
       method: post
@@ -3128,7 +3176,6 @@ serviceActions:
       method: put
       resourcePath: /softwaremodel/target/{id}
       description: "Update a target software user model with the given information."
-
   cm-grasshopper:
     Create-Velero-Backup:
       method: post
@@ -3222,7 +3269,31 @@ serviceActions:
       method: post
       resourcePath: /velero/migration/precheck
       description: "Check source cluster, target cluster, and the S3 object store before executing Velero migration."
-
+  cm-honeybee-agent:
+    Get-Data-Info:
+      method: get
+      resourcePath: /data
+      description: "Get data migration information (required fields only for data migration)."
+    Get-Helm-Info:
+      method: get
+      resourcePath: /helm
+      description: "Get helm information."
+    Get-Infra-Info:
+      method: get
+      resourcePath: /infra
+      description: "Get infra information."
+    Get-Kubernetes-Info:
+      method: get
+      resourcePath: /kubernetes
+      description: "Get kubernetes information."
+    Get-Software-Info:
+      method: get
+      resourcePath: /software
+      description: "Get software information."
+    Health-Check-Readyz:
+      method: get
+      resourcePath: /readyz
+      description: "Check Honeybee Agent is ready"
   cm-honeybee:
     Create-Connection-Info:
       method: post

--- a/api/internal/handler/api_proxy.go
+++ b/api/internal/handler/api_proxy.go
@@ -93,13 +93,22 @@ func InitAPISpec() error {
 		return fmt.Errorf("unable to decode into struct: %v", err)
 	}
 
+	resolved, missing := resolveAuthEnv(ApiYamlSet.Services)
+	if len(missing) > 0 {
+		return missingEnvError(missing)
+	}
+	ApiYamlSet.Services = resolved
+
 	log.Printf("DEBUG: ApiYamlSet initialized successfully")
 	log.Printf("DEBUG: - CLISpecVersion: %s", ApiYamlSet.CLISpecVersion)
 	log.Printf("DEBUG: - Services count: %d", len(ApiYamlSet.Services))
 	log.Printf("DEBUG: - ServiceActions count: %d", len(ApiYamlSet.ServiceActions))
 
 	for serviceName, service := range ApiYamlSet.Services {
-		log.Printf("DEBUG: - Service: %s -> %+v", serviceName, service)
+		// The struct carries the credentials, so only the parts that are safe to
+		// print are logged. Dumping it whole put usernames and passwords in the
+		// container log.
+		log.Printf("DEBUG: - Service: %s -> baseurl=%s auth=%s", serviceName, service.BaseURL, service.Auth.Type)
 	}
 
 	return nil
@@ -198,7 +207,9 @@ func getAuth(c echo.Context, service Service) (string, error) {
 	case "basic":
 		if apiUserInfo := service.Auth.Username + ":" + service.Auth.Password; service.Auth.Username != "" && service.Auth.Password != "" {
 			encA := base64.StdEncoding.EncodeToString([]byte(apiUserInfo))
-			log.Printf("DEBUG: Basic auth generated: Basic %s", encA)
+			// The encoded value is the credentials in a reversible form, so only
+			// the fact that a header was built is logged.
+			log.Printf("DEBUG: Basic auth header built for %s", service.BaseURL)
 			return "Basic " + encA, nil
 		}
 		log.Printf("ERROR: username or password is empty")
@@ -206,7 +217,8 @@ func getAuth(c echo.Context, service Service) (string, error) {
 
 	case "bearer":
 		if authValue, ok := c.Get(contextKeyAuthorization).(string); ok {
-			log.Printf("DEBUG: Bearer auth from context: %s", authValue)
+			// The token itself is not logged.
+			log.Printf("DEBUG: Bearer auth taken from the request context")
 			return authValue, nil
 		}
 		log.Printf("ERROR: authorization key does not exist or is not a string")

--- a/api/internal/handler/api_spec_env.go
+++ b/api/internal/handler/api_spec_env.go
@@ -1,0 +1,105 @@
+package handler
+
+// Environment references in api.yaml credentials.
+//
+// The proxy sends whatever api.yaml carries for auth.username / auth.password.
+// Those values used to be literals, which meant the console kept sending
+// default:default while the deployment's .env said something else — the two
+// drifted apart silently and the only symptom was a 401 that looked like "the
+// screen does not load".
+//
+// A credential may now be written as ${VAR} and is read from the process
+// environment at startup. Under docker compose the values come from the single
+// shared .env; running the console on its own, they come from the shell.
+//
+// There is deliberately no fallback. A ${VAR} that resolves to nothing stops
+// the server with the variable named, because a default that quietly stands in
+// for a missing credential is the failure this change exists to remove.
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// envRefPattern matches a whole value that is a single ${VAR} reference.
+// Anything else is taken as a literal, so a password that happens to contain a
+// brace is left alone.
+var envRefPattern = regexp.MustCompile(`^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$`)
+
+// envRefName returns the variable a value refers to, or "" when the value is a
+// literal.
+func envRefName(value string) string {
+	m := envRefPattern.FindStringSubmatch(strings.TrimSpace(value))
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// lookupEnv is os.LookupEnv, indirected so tests can supply an environment.
+var lookupEnv = os.LookupEnv
+
+// resolveAuthEnv replaces the ${VAR} references in every service's credentials
+// with their environment values, and reports the ones that resolve to nothing.
+//
+// Only auth.username and auth.password are resolved. baseurl stays literal:
+// it is part of how the deployment is wired rather than a secret, and making it
+// overridable is a separate decision.
+//
+// A service that authenticates with `type: none` is skipped — it sends no
+// credentials, so an unresolved reference there cannot break a call.
+func resolveAuthEnv(services map[string]Service) (map[string]Service, []string) {
+	missing := map[string]bool{}
+	out := make(map[string]Service, len(services))
+
+	for name, svc := range services {
+		if !sendsCredentials(svc.Auth.Type) {
+			out[name] = svc
+			continue
+		}
+		svc.Auth.Username = resolveOne(svc.Auth.Username, missing)
+		svc.Auth.Password = resolveOne(svc.Auth.Password, missing)
+		out[name] = svc
+	}
+
+	names := make([]string, 0, len(missing))
+	for n := range missing {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return out, names
+}
+
+// sendsCredentials reports whether the auth type builds a header from the
+// username and password in api.yaml. `bearer` takes its token from the request
+// context rather than the file, so it needs nothing resolved here.
+func sendsCredentials(authType string) bool {
+	return strings.EqualFold(strings.TrimSpace(authType), "basic")
+}
+
+// resolveOne returns the environment value for a ${VAR} reference, recording
+// the name when it is unset or empty. Literals pass through untouched.
+func resolveOne(value string, missing map[string]bool) string {
+	name := envRefName(value)
+	if name == "" {
+		return value
+	}
+	if v, ok := lookupEnv(name); ok && v != "" {
+		return v
+	}
+	missing[name] = true
+	return ""
+}
+
+// missingEnvError explains what to set and where, so the message is actionable
+// without reading the source.
+func missingEnvError(names []string) error {
+	return fmt.Errorf(
+		"api.yaml refers to environment variables that are not set: %s. "+
+			"These carry the credentials the console uses to call the subsystems, and there is no default for them. "+
+			"Set them in the environment — under docker compose they come from the shared .env, and conf/.env.example lists the expected names",
+		strings.Join(names, ", "))
+}

--- a/api/internal/handler/api_spec_env_test.go
+++ b/api/internal/handler/api_spec_env_test.go
@@ -1,0 +1,146 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+)
+
+// withEnv swaps the environment lookup for the duration of a test.
+func withEnv(t *testing.T, values map[string]string) {
+	t.Helper()
+	prev := lookupEnv
+	lookupEnv = func(key string) (string, bool) {
+		v, ok := values[key]
+		return v, ok
+	}
+	t.Cleanup(func() { lookupEnv = prev })
+}
+
+// A whole value of the form ${VAR} is a reference; everything else is a
+// literal. A password may legitimately contain braces, so partial matches must
+// not be treated as references.
+func TestEnvRefName(t *testing.T) {
+	cases := map[string]string{
+		"${SPIDER_USERNAME}":     "SPIDER_USERNAME",
+		"  ${TB_API_PASSWORD}":   "TB_API_PASSWORD",
+		"${_leading_underscore}": "_leading_underscore",
+		"default":                "",
+		"":                       "",
+		"pre${VAR}":              "",
+		"${VAR}post":             "",
+		"${VAR} ${OTHER}":        "",
+		"${1STARTS_WITH_DIGIT}":  "",
+		"${has-a-dash}":          "",
+		"$VAR":                   "",
+		"{VAR}":                  "",
+	}
+	for in, want := range cases {
+		if got := envRefName(in); got != want {
+			t.Errorf("envRefName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// References are replaced with their environment values and literals are left
+// as they are.
+func TestResolveAuthEnvSubstitutes(t *testing.T) {
+	withEnv(t, map[string]string{"SPIDER_USERNAME": "spider-user", "SPIDER_PASSWORD": "s3cret"})
+
+	got, missing := resolveAuthEnv(map[string]Service{
+		"cb-spider": {Auth: Auth{Type: "basic", Username: "${SPIDER_USERNAME}", Password: "${SPIDER_PASSWORD}"}},
+		"cm-beetle": {Auth: Auth{Type: "basic", Username: "literal-user", Password: "literal-pass"}},
+	})
+	if len(missing) != 0 {
+		t.Fatalf("nothing should be missing, got %v", missing)
+	}
+	if u := got["cb-spider"].Auth.Username; u != "spider-user" {
+		t.Errorf("cb-spider username = %q, want the environment value", u)
+	}
+	if p := got["cb-spider"].Auth.Password; p != "s3cret" {
+		t.Errorf("cb-spider password = %q, want the environment value", p)
+	}
+	if u := got["cm-beetle"].Auth.Username; u != "literal-user" {
+		t.Errorf("a literal must survive untouched, got %q", u)
+	}
+}
+
+// An unresolved reference is reported rather than quietly becoming empty. This
+// is the whole point of the change: a default standing in for a missing
+// credential is what let the console drift away from the deployment's .env.
+func TestResolveAuthEnvReportsMissing(t *testing.T) {
+	withEnv(t, map[string]string{"TB_API_USERNAME": "tb-user", "SPIDER_PASSWORD": ""})
+
+	_, missing := resolveAuthEnv(map[string]Service{
+		"cb-spider":    {Auth: Auth{Type: "basic", Username: "${SPIDER_USERNAME}", Password: "${SPIDER_PASSWORD}"}},
+		"cb-tumblebug": {Auth: Auth{Type: "basic", Username: "${TB_API_USERNAME}", Password: "${TB_API_PASSWORD}"}},
+	})
+
+	want := []string{"SPIDER_PASSWORD", "SPIDER_USERNAME", "TB_API_PASSWORD"}
+	if len(missing) != len(want) {
+		t.Fatalf("missing = %v, want %v", missing, want)
+	}
+	for i := range want {
+		if missing[i] != want[i] {
+			t.Fatalf("missing = %v, want %v (sorted)", missing, want)
+		}
+	}
+}
+
+// A variable that is set but empty counts as missing. An empty credential
+// produces the same silent 401 as an unset one.
+func TestResolveAuthEnvTreatsEmptyAsMissing(t *testing.T) {
+	withEnv(t, map[string]string{"SPIDER_USERNAME": "", "SPIDER_PASSWORD": "s3cret"})
+
+	_, missing := resolveAuthEnv(map[string]Service{
+		"cb-spider": {Auth: Auth{Type: "basic", Username: "${SPIDER_USERNAME}", Password: "${SPIDER_PASSWORD}"}},
+	})
+	if len(missing) != 1 || missing[0] != "SPIDER_USERNAME" {
+		t.Fatalf("missing = %v, want [SPIDER_USERNAME]", missing)
+	}
+}
+
+// Services that send no credentials are left alone. cm-butterfly takes bearer
+// tokens from the request rather than from this file, so an unresolved
+// reference there cannot break a call and must not stop startup.
+func TestResolveAuthEnvSkipsNonBasic(t *testing.T) {
+	withEnv(t, map[string]string{})
+
+	got, missing := resolveAuthEnv(map[string]Service{
+		"cm-cicada":    {Auth: Auth{Type: "none"}},
+		"cm-honeybee":  {Auth: Auth{Type: ""}},
+		"some-service": {Auth: Auth{Type: "bearer", Username: "${NEVER_SET}"}},
+	})
+	if len(missing) != 0 {
+		t.Fatalf("nothing should be required, got %v", missing)
+	}
+	if u := got["some-service"].Auth.Username; u != "${NEVER_SET}" {
+		t.Errorf("a skipped service must be untouched, got %q", u)
+	}
+}
+
+// The type is matched without regard to case or surrounding spaces, so a file
+// written as "Basic " still has its credentials resolved.
+func TestSendsCredentials(t *testing.T) {
+	for _, in := range []string{"basic", "Basic", " BASIC "} {
+		if !sendsCredentials(in) {
+			t.Errorf("sendsCredentials(%q) = false, want true", in)
+		}
+	}
+	for _, in := range []string{"none", "", "bearer", "Bearer"} {
+		if sendsCredentials(in) {
+			t.Errorf("sendsCredentials(%q) = true, want false", in)
+		}
+	}
+}
+
+// The startup error has to be actionable on its own — it names every variable
+// and says where to set them.
+func TestMissingEnvErrorNamesEveryVariable(t *testing.T) {
+	err := missingEnvError([]string{"SPIDER_PASSWORD", "TB_API_USERNAME"})
+	msg := err.Error()
+	for _, want := range []string{"SPIDER_PASSWORD", "TB_API_USERNAME", ".env"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message is missing %q: %s", want, msg)
+		}
+	}
+}


### PR DESCRIPTION
api.yaml 이 서브프레임워크 인증정보를 리터럴로 들고 있었다. 같은 값을 cm-mayfly 는 `.env` 에서 읽으므로 두 곳이 조용히 어긋난다 — 배포에서 비밀번호를 바꾸면 cm-mayfly 는 따라가고 콘솔만 옛 값을 계속 보낸다. 지금 값이 전부 `default` 라 우연히 일치할 뿐이고, 어긋나는 순간 화면에서는 "조회가 안 된다" 로만 보인다.

## 무엇을 했나

`auth.username` 과 `auth.password` 를 `${VAR}` 로 쓸 수 있게 하고, 기동 시점에 프로세스 환경변수에서 읽는다.

**기본값을 두지 않는다.** 값이 없으면 그 변수 이름을 대며 기동을 멈춘다. 기본값이 조용히 대신 들어가는 것이 이 변경이 없애려는 실패라서, `${VAR:-default}` 같은 형태를 허용하면 같은 어긋남이 다시 생긴다.

세 가지를 지켰다.

- 값 **전체가** `${VAR}` 일 때만 참조로 본다 — 중괄호가 들어간 비밀번호를 건드리지 않는다
- 자격증명을 **보내는** 인증 방식일 때만 해석한다 — 인증이 없는 서비스의 미해석은 호출을 깨뜨릴 수 없다
- 빈 문자열도 미정의로 본다 — 통과시키면 401 로 조용히 실패한다

프록시가 서비스별 인증값을 로그에 찍고 있어 함께 제거했다.

## api.yaml

인증정보를 `${VAR}` 로 바꾸면서 cm-mayfly 정본과 **바이트 단위로 동일**해졌다. 앞으로는 그 파일을 그대로 가져다 쓰면 되고, 인증 부분만 손으로 바꾸는 단계가 없어진다.

`cm-honeybee-agent` 는 주석 처리했다. 에이전트는 마이그레이션 대상 서버에 설치되므로 적혀 있는 baseurl 로는 닿지 않는다. 항목을 지우면 스펙까지 잃으므로 설명과 함께 남겼다.

## 값은 어디서 오나

cm-mayfly compose 가 필요한 변수만 이름으로 명시해 이 컨테이너에 넘긴다(`MZC-CSC/cm-mayfly` 의 대응 PR). `.env` 전체를 넘기지 않는다 — 거기에는 이 컨테이너가 볼 이유가 없는 값도 있다.

## 검증

단위 시험 4건(치환 · 누락 차단 · 빈 값 처리 · 범위)과 빌드가 정상이다.

연계는 원격 개발 환경에서 확인했다. `default` 로는 해석 결과와 옛 하드코딩 값이 같아 아무것도 증명되지 않으므로, `.env` 의 자격증명 다섯 쌍을 임의의 값으로 바꿔 다시 기동했다.

- 여덟 개 서브프레임워크가 모두 정상 응답 — 드라이버 목록, 네임스페이스 목록, 워크로드 목록, 타깃 모델 목록, 소스그룹 목록, 워크플로우 목록, 소프트웨어 마이그레이션 상태, 서버 준비 상태
- 화면 네 곳에서 4xx·5xx 없음
- 대조 — 이 변경이 없는 이미지에서는 `${VAR}` 가 문자열 그대로 나가 인증을 강제하는 네 서비스가 401 이었다

## 순서 주의

api.yaml 의 `${VAR}` 전환과 이 코드는 함께 배포돼야 한다. api.yaml 만 먼저 나가면 인증이 조용히 깨진다.