### PR TITLE
improve(front): move and resize a detached help panel, and name screen elements

### DIFF
--- a/front/src/features/sequential/designer/editor/ui/RecursiveFormField.vue
+++ b/front/src/features/sequential/designer/editor/ui/RecursiveFormField.vue
@@ -63,7 +63,11 @@
           </label>
         </div>
         <div class="header-actions">
-          <button @click="addArrayItem" class="btn-add-item">+ Add entity</button>
+          <button
+            :data-testid="arrayAddTestId"
+            @click="addArrayItem"
+            class="btn-add-item"
+          >+ Add entity</button>
         </div>
       </div>
       
@@ -79,7 +83,11 @@
               class="field-input"
               :placeholder="`Item ${index + 1}`"
             />
-            <button @click="removeArrayItem(index)" class="btn-remove-item">×</button>
+            <button
+              :data-testid="arrayRemoveTestId(index)"
+              @click="removeArrayItem(index)"
+              class="btn-remove-item"
+            >×</button>
           </div>
         </div>
         
@@ -96,7 +104,11 @@
                   ({{ Object.keys(fieldSchema.items.properties || {}).length }} properties)
                 </span>
               </div>
-              <button @click.stop="removeArrayItem(index)" class="btn-remove-item">× Remove</button>
+              <button
+                :data-testid="arrayRemoveTestId(index)"
+                @click.stop="removeArrayItem(index)"
+                class="btn-remove-item"
+              >× Remove</button>
             </div>
             <div v-if="!isItemCollapsed(index)" class="item-properties">
               <recursive-form-field
@@ -243,6 +255,15 @@ export default defineComponent({
     };
     const arrayItemTestId = (arrayIndex: number) =>
       `wf-field-${props.indexPath || props.currentPath || props.fieldName}[${arrayIndex}]`;
+
+    /** The button that adds an entry to this array, named after the array it acts on. */
+    const arrayAddTestId = computed(
+      () => `wf-array-add-${props.indexPath || props.currentPath || props.fieldName}`,
+    );
+
+    /** The button that removes one entry, which needs the entry's position as well. */
+    const arrayRemoveTestId = (arrayIndex: number) =>
+      `wf-array-remove-${props.indexPath || props.currentPath || props.fieldName}[${arrayIndex}]`;
 
     // Check whether required
     const isRequired = computed(() => {
@@ -573,6 +594,8 @@ export default defineComponent({
       fieldTestId,
       childIndexPath,
       arrayItemTestId,
+      arrayAddTestId,
+      arrayRemoveTestId,
       isSimpleType,
       isStringArray,
       arrayValue,

--- a/front/src/shared/ui/EnhancedJsonEditor/JsonPropertyGrid.vue
+++ b/front/src/shared/ui/EnhancedJsonEditor/JsonPropertyGrid.vue
@@ -473,7 +473,51 @@ function duplicateRow(row: FlatRow) {
 
   const index = Number(row.keys[row.keys.length - 1]);
   container.splice(index + 1, 0, copyOf(container[index]));
+  carryExpansionThroughInsert(row, index);
   commit(data);
+}
+
+/*
+  The copy opens the way its original was, and everything below keeps the state it had.
+
+  Paths carry the index, so inserting at 6 makes what was `…firewallTable.7` into `.8` - and the
+  set of opened paths, which is keyed by path, would otherwise be pointing at the wrong entries.
+  Every path at or after the insert is shifted up one, then the copy is given whatever the original
+  had.
+
+  Not "always open the copy": duplicating a folded entry and having it spring open lengthens the
+  list and pushes the next entry out of reach. What was folded stays folded.
+*/
+function carryExpansionThroughInsert(row: FlatRow, index: number) {
+  const arrayPath = row.path.replace(/\.[^.]+$/, '');
+  const prefix = `${arrayPath}.`;
+  const next = new Set<string>();
+
+  for (const path of expandedPaths.value) {
+    if (!path.startsWith(prefix)) {
+      next.add(path);
+      continue;
+    }
+    const rest = path.slice(prefix.length);
+    const [head, ...tail] = rest.split('.');
+    const at = Number(head);
+    if (Number.isNaN(at) || at <= index) {
+      next.add(path);
+      continue;
+    }
+    next.add([prefix + String(at + 1), ...tail].join('.'));
+  }
+
+  // The copy inherits the original's state, itself and everything under it.
+  const originalPrefix = `${prefix}${index}`;
+  const copyPrefix = `${prefix}${index + 1}`;
+  for (const path of expandedPaths.value) {
+    if (path === originalPrefix || path.startsWith(`${originalPrefix}.`)) {
+      next.add(copyPrefix + path.slice(originalPrefix.length));
+    }
+  }
+
+  expandedPaths.value = next;
 }
 
 function removeRow(row: FlatRow) {
@@ -663,9 +707,20 @@ function cancelEdit() {
           </tr>
         </thead>
         <tbody>
+          <!--
+            The row carries where it came from.
+
+            Without it a row is only a key and a value, and telling one `dstPorts` from another
+            means counting rows or reading the neighbours - both of which move when the document
+            changes. `firewallTable[7].dstPorts` says which rule it belongs to, and a caller that
+            wants the address of that same rule asks for `firewallTable[7].dstCIDR` rather than
+            guessing where the rule begins and ends.
+          -->
           <tr
             v-for="row in filteredRows"
             :key="row.path"
+            :data-path="row.path"
+            :data-testid="`json-grid-row-${row.path}`"
             :class="[
               'pg-row',
               `depth-${Math.min(row.depth, 8)}`,

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -221,12 +221,14 @@ const HELP: Array<{ path: string; help: Help }> = [
         {
           item: 'Save',
           kind: 'btn2',
-          meaning: 'Bottom right of the source connection form. Stays off until the required fields, marked in red, are filled in.',
+          meaning:
+            'Bottom right of the source connection form. Stays off until the required fields, marked in red, are filled in.',
         },
         {
           item: 'Name',
           kind: 'column',
-          meaning: 'The name you gave the source service. Selecting it opens its source connections below.',
+          meaning:
+            'The name you gave the source service. Selecting it opens its source connections below.',
         },
         {
           item: 'Connection #',
@@ -243,7 +245,8 @@ const HELP: Array<{ path: string; help: Help }> = [
         {
           item: 'Description',
           kind: 'column',
-          meaning: 'Whatever you wrote when creating it, as a note to yourself. Nothing depends on it.',
+          meaning:
+            'Whatever you wrote when creating it, as a note to yourself. Nothing depends on it.',
         },
       ],
       groups: [
@@ -278,7 +281,8 @@ const HELP: Array<{ path: string; help: Help }> = [
                   ],
                 },
                 {
-                  heading: 'Bring source connections in from an Excel or CSV file',
+                  heading:
+                    'Bring source connections in from an Excel or CSV file',
                   guide: {
                     label: 'Preparing the connection file',
                     url: DOC_LINKS.sourceConnectionBulkImport,
@@ -294,7 +298,8 @@ const HELP: Array<{ path: string; help: Help }> = [
               ],
             },
             {
-              heading: 'Add source connections to a source service that already exists',
+              heading:
+                'Add source connections to a source service that already exists',
               // Registered a service and stopped there: this is the one thing left.
               openWhen: f => f.sourceServices > 0 && f.connections === 0,
               steps: [
@@ -820,6 +825,8 @@ const HEIGHT_KEY = 'cm.helpPanel.height';
 const MIN_HEIGHT = 220;
 /** The header the panel has to stay clear of, so its own icon stays reachable. */
 const HEADER_HEIGHT = 40;
+/** The gap a detached panel keeps from the window edge and from the header. */
+const FLOAT_MARGIN = 12;
 
 const route = useRoute();
 const { $refs } = getCurrentInstance()!.proxy as unknown as {
@@ -856,7 +863,21 @@ function applyDock() {
 
 function setDocked(next: boolean) {
   docked.value = next;
-  if (next) offset.value = null;
+  /*
+    Undocking settles the panel where it stands, rather than leaving it "as opened".
+
+    While the offset is null the floating panel keeps no height of its own and fills the screen the
+    way the docked one does. Dragging it then cannot move it downwards at all: the move clamps
+    against the height it has at that moment, and a panel as tall as the window has nowhere to go.
+    The window slid sideways while the pointer went down and across, which read as the pointer
+    having let go of the title bar.
+  */
+  offset.value = next
+    ? null
+    : {
+        x: Math.max(0, window.innerWidth - width.value - FLOAT_MARGIN),
+        y: HEADER_HEIGHT + FLOAT_MARGIN,
+      };
   localStorage.setItem(MODE_KEY, next ? 'dock' : 'float');
   applyDock();
 }
@@ -873,7 +894,9 @@ function maxHeight(): number {
 
 function readHeight(): number {
   const saved = Number(localStorage.getItem(HEIGHT_KEY));
-  return saved >= MIN_HEIGHT ? Math.min(saved, maxHeight()) : Math.round(window.innerHeight * 0.7);
+  return saved >= MIN_HEIGHT
+    ? Math.min(saved, maxHeight())
+    : Math.round(window.innerHeight * 0.7);
 }
 
 const height = ref(readHeight());
@@ -1079,7 +1102,7 @@ watch(helpPanelOpenRequests, () => {
   answer either way, and the reader has just asked for an explanation, so a moment's work
   is what they came for.
 */
-watch(open, async (isOpen) => {
+watch(open, async isOpen => {
   // Read again every time, not only the first. Opening the help is the moment the
   // reader most needs the answer to match what is on the screen behind it, and by
   // then they may have registered, collected or saved something.
@@ -1087,7 +1110,8 @@ watch(open, async (isOpen) => {
 });
 
 const guidedLine = computed(() => {
-  if (guidanceOff.value || !progressKnown.value || isFinished.value) return null;
+  if (guidanceOff.value || !progressKnown.value || isFinished.value)
+    return null;
   const step = currentGuidedStep.value;
   if (!step) return null;
   return {
@@ -1140,7 +1164,10 @@ function openReferenced(target: string | undefined): void {
   const [groupId, rawIndex] = target.split('#');
   const index = Number(rawIndex);
   if (!groupId || !Number.isFinite(index)) return;
-  openSections.value = { ...openSections.value, [sectionKey(groupId, index)]: true };
+  openSections.value = {
+    ...openSections.value,
+    [sectionKey(groupId, index)]: true,
+  };
   requestAnimationFrame(() => {
     document
       .querySelector(`[data-testid="help-section-toggle-${groupId}-${index}"]`)
@@ -1240,9 +1267,24 @@ function startResize(event: MouseEvent) {
   const startX = event.clientX;
   const startWidth = width.value;
 
+  /*
+    A docked panel is held against the right of the window, so widening it takes the left edge
+    outwards on its own and the edge stays under the pointer. A detached one is held by its left,
+    so the same widening pushes the *right* edge out instead and the edge being dragged does not
+    move at all. Keeping the right edge where it was puts the left edge back under the pointer.
+  */
+  const fixedRight =
+    !docked.value && offset.value ? offset.value.x + startWidth : null;
+
   const onMove = (e: MouseEvent) => {
     const next = startWidth + (startX - e.clientX);
     width.value = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, next));
+    if (fixedRight !== null && offset.value) {
+      offset.value = {
+        x: Math.max(0, fixedRight - width.value),
+        y: offset.value.y,
+      };
+    }
     applyDock();
   };
   const onUp = () => {
@@ -1267,15 +1309,21 @@ function startMove(event: MouseEvent) {
   const grabX = event.clientX - box.left;
   const grabY = event.clientY - box.top;
 
+  /*
+    Measured on every move, not once at the start. The panel takes its floating size as it is being
+    let go of, and a limit worked out from the size it had a moment earlier pins it in place.
+  */
   const onMove = (e: MouseEvent) => {
+    const w = panel.offsetWidth;
+    const h = panel.offsetHeight;
     offset.value = {
-      x: Math.max(
-        0,
-        Math.min(window.innerWidth - box.width, e.clientX - grabX),
-      ),
+      x: Math.max(0, Math.min(window.innerWidth - w, e.clientX - grabX)),
       y: Math.max(
         HEADER_HEIGHT,
-        Math.min(window.innerHeight - box.height, e.clientY - grabY),
+        Math.min(
+          Math.max(HEADER_HEIGHT, window.innerHeight - h),
+          e.clientY - grabY,
+        ),
       ),
     };
   };
@@ -1305,7 +1353,10 @@ onBeforeUnmount(() => {
       one appearing at once and the other after a second's wait read as two different
       kinds of control.
     -->
-    <p-tooltip :contents="`Help for this screen (${help.title})`" position="absolute">
+    <p-tooltip
+      :contents="`Help for this screen (${help.title})`"
+      position="absolute"
+    >
       <button
         class="help-button"
         data-testid="help-toggle"
@@ -1412,9 +1463,11 @@ onBeforeUnmount(() => {
             >Step {{ guidedLine.no }} of {{ guidedLine.total }}</span
           >
           <span class="help-guided-text">{{ guidedLine.title }}</span>
-          <span class="help-guided-standing" data-testid="help-guided-standing">{{
-            guidedLine.standing
-          }}</span>
+          <span
+            class="help-guided-standing"
+            data-testid="help-guided-standing"
+            >{{ guidedLine.standing }}</span
+          >
           <!--
             What finishes this step, and how far it is met. Without it a step that stays
             put after you have registered something reads as broken rather than as work
@@ -1482,7 +1535,9 @@ onBeforeUnmount(() => {
             >
               <li v-for="(step, t) in sec.steps" :key="t">
                 <template v-for="(tok, k) in tokensOf(step)">
-                  <span v-if="tok.t === 'text'" :key="`t${k}`">{{ tok.v }}</span>
+                  <span v-if="tok.t === 'text'" :key="`t${k}`">{{
+                    tok.v
+                  }}</span>
                   <button
                     v-else-if="tok.t === 'see'"
                     :key="`s${k}`"
@@ -1493,12 +1548,18 @@ onBeforeUnmount(() => {
                   >
                     {{ tok.v }}
                   </button>
-                  <strong v-else-if="tok.t === 'b'" :key="`b${k}`" class="help-strong">{{
-                    tok.v
-                  }}</strong>
-                  <span v-else :key="`c${k}`" :class="`help-chip help-chip-${tok.t}`">{{
-                    tok.v
-                  }}</span>
+                  <strong
+                    v-else-if="tok.t === 'b'"
+                    :key="`b${k}`"
+                    class="help-strong"
+                    >{{ tok.v }}</strong
+                  >
+                  <span
+                    v-else
+                    :key="`c${k}`"
+                    :class="`help-chip help-chip-${tok.t}`"
+                    >{{ tok.v }}</span
+                  >
                 </template>
               </li>
             </ol>
@@ -1508,12 +1569,18 @@ onBeforeUnmount(() => {
               v-if="sec.sub && isSectionOpen(group.id, x)"
               class="help-subsections"
             >
-              <div v-for="(sub, y) in sec.sub" :key="`sub${y}`" class="help-subsection">
+              <div
+                v-for="(sub, y) in sec.sub"
+                :key="`sub${y}`"
+                class="help-subsection"
+              >
                 <button
                   type="button"
                   class="help-subheading"
                   :data-testid="`help-subsection-toggle-${group.id}-${x}-${y}`"
-                  :aria-expanded="isSectionOpen(`${group.id}#${x}`, y) ? 'true' : 'false'"
+                  :aria-expanded="
+                    isSectionOpen(`${group.id}#${x}`, y) ? 'true' : 'false'
+                  "
                   @click="toggleSection(`${group.id}#${x}`, y)"
                 >
                   <span class="help-heading-mark" aria-hidden="true">{{
@@ -1528,7 +1595,9 @@ onBeforeUnmount(() => {
                 >
                   <li v-for="(step, t) in sub.steps" :key="t">
                     <template v-for="(tok, k) in tokensOf(step)">
-                      <span v-if="tok.t === 'text'" :key="`t${k}`">{{ tok.v }}</span>
+                      <span v-if="tok.t === 'text'" :key="`t${k}`">{{
+                        tok.v
+                      }}</span>
                       <button
                         v-else-if="tok.t === 'see'"
                         :key="`s${k}`"
@@ -1559,12 +1628,18 @@ onBeforeUnmount(() => {
                   :data-testid="`help-subsection-guide-${group.id}-${x}-${y}`"
                   @click="openDocLink(sub.guide.url)"
                 >
-                  <svg class="help-doc-icon" viewBox="0 0 16 16" aria-hidden="true">
+                  <svg
+                    class="help-doc-icon"
+                    viewBox="0 0 16 16"
+                    aria-hidden="true"
+                  >
                     <path
                       d="M4 1.5h5.2L13 5.3V14a.5.5 0 0 1-.5.5h-8A.5.5 0 0 1 4 14V1.5Zm1 1V13.5h7V6H8.7V2.5H5Zm4.7.7V5H12L9.7 3.2ZM6 7.5h5v1H6v-1Zm0 2.5h5v1H6v-1Z"
                     />
                   </svg>
-                  <span class="help-guide-text">Guide: {{ sub.guide.label }}</span>
+                  <span class="help-guide-text"
+                    >Guide: {{ sub.guide.label }}</span
+                  >
                   <span class="help-guide-out">&#8599;</span>
                 </button>
               </div>
@@ -1653,7 +1728,9 @@ onBeforeUnmount(() => {
             <span class="help-heading-mark" aria-hidden="true">{{
               isSectionOpen('__reference', 0) ? '\u25be' : '\u25b8'
             }}</span>
-            <span class="help-heading-text">Buttons and columns on this screen</span>
+            <span class="help-heading-text"
+              >Buttons and columns on this screen</span
+            >
           </button>
           <dl
             v-if="isSectionOpen('__reference', 0)"
@@ -1662,9 +1739,10 @@ onBeforeUnmount(() => {
           >
             <template v-for="(r, k) in help.reference">
               <dt :key="`rt${k}`">
-                <span :class="`help-chip help-chip-${r.kind === 'column' ? 'menu' : r.kind}`">{{
-                  r.item
-                }}</span>
+                <span
+                  :class="`help-chip help-chip-${r.kind === 'column' ? 'menu' : r.kind}`"
+                  >{{ r.item }}</span
+                >
               </dt>
               <dd :key="`rd${k}`">{{ r.meaning }}</dd>
             </template>
@@ -1689,7 +1767,11 @@ onBeforeUnmount(() => {
             }}</span>
             <span class="help-heading-text">Key terms</span>
           </button>
-          <dl v-if="isSectionOpen('__terms', 0)" class="help-terms" data-testid="help-terms-list">
+          <dl
+            v-if="isSectionOpen('__terms', 0)"
+            class="help-terms"
+            data-testid="help-terms-list"
+          >
             <template v-for="(t, k) in help.terms">
               <dt :key="`t${k}`">{{ t.term }}</dt>
               <dd :key="`d${k}`">{{ t.meaning }}</dd>
@@ -2156,7 +2238,6 @@ onBeforeUnmount(() => {
 .help-subheading-text {
   flex: 1;
 }
-
 
 .help-chip {
   display: inline-block;


### PR DESCRIPTION
도움말 창을 원하는 자리에 두고 그 자리에서 크기를 바꿀 수 있게 한다. 함께 화면 요소에 식별자를 부여한다.

## 무엇이 문제였나

도킹을 해제한 도움말 창이 **가로로만 움직였다.** 제목 줄을 잡고 아래로 끌어도 창은 옆으로만 미끄러져, 커서가 창을 놓친 것처럼 보인다. 도킹 해제 후 창이 자기 크기를 갖지 않아 화면 높이만큼 커지고(화면 1000px에 창 960px), 이동이 그 높이로 세로 한계를 계산해 세로 좌표가 고정되기 때문이다.

크기 조절에도 같은 종류의 어긋남이 있었다. 도킹된 창은 오른쪽에 붙어 있어 왼쪽 모서리를 왼쪽으로 끌면 왼쪽 변이 따라 나오지만, **떠 있는 창은 왼쪽이 고정**돼 있어 같은 조작에 오른쪽 변이 늘어난다. 잡고 있는 변은 제자리고 반대편이 자라니 창이 손에서 달아나는 것처럼 보인다.

표 모드에서 행을 복제하면 사본이 늘 접힌 채로 나타났다. 펼쳐진 행을 경로 문자열 집합으로 들고 있는데 배열 경로에 순번이 들어 있어, 사본을 끼워 넣는 순간 그 아래 항목들의 열쇠가 한 칸씩 어긋난다.

셋 다 화면을 열어야만 드러난다 — 빌드·타입 검사·린트를 모두 통과한다.

## 무엇을 바꿨나

| 대상 | 내용 |
|---|---|
| `HelpPanel.vue` | 도킹 해제 순간 창의 자리·크기를 확정. 이동 한계를 그때그때의 실제 크기로 계산. 떠 있는 창은 오른쪽 변을 고정해 왼쪽 변이 포인터를 따라오게 함 |
| `JsonPropertyGrid.vue` | 행에 문서 내 경로(`data-path`) 부여. 복제 시 사본이 원본의 펼침 상태를 물려받음 — 접힌 것은 접힌 채로 |
| `RecursiveFormField.vue` | 배열 추가·삭제 버튼에 그 배열의 경로를 담은 식별자 부여 |

`HelpPanel.vue`는 원래 프로젝트 prettier 설정에 맞지 않던 파일이라 커밋 게이트가 전체 포맷을 요구한다. 118줄 중 동작 변경은 30줄 남짓이다.

## 검증

눈으로 보는 확인이 이 결함을 못 잡았으므로, **끄는 도중에 포인터와 손잡이의 좌표를 재는** 방식으로 판정했다. 원격 dev에 배포해 확인했다.

```
해제 후: x=1308 y=52  height=700     (전에는 960 — 화면 높이에 닿아 있었다)
옮긴 뒤: x=988  y=232                 가로·세로 모두 이동
폭:      x=808  width=560             오른쪽 변 1368 고정
높이:    height=500                   윗변 232 고정
```

세 손잡이 모두 끄는 15구간 내내 포인터가 손잡이 안에 머물렀다. 행 복제는 펼친 것·접힌 것 양쪽으로 확인했다.

통합 시나리오 15구간 전부 통과했고, seg1을 다시 찍어 영상에서도 창이 커서를 따라가는 것을 확인했다.

---

- [BAR-1804](https://mzdevs.atlassian.net/browse/BAR-1804) 도움말 창 이동·크기 조절 개선
- [BAR-1805](https://mzdevs.atlassian.net/browse/BAR-1805) 화면 조작·검증용 식별자 부여
- [BAR-1806](https://mzdevs.atlassian.net/browse/BAR-1806) JSON 표 행 복제 시 펼침 상태 계승

테스트 결과서: `notion/cm-bf-ep-전환워크플로우웹플래닝고도화/022_도움말창이동과화면식별자/ST3_단위테스트/TR-BAR-1804-도움말창이동과식별자.md`