### PR TITLE
chore(api): take the v0.6.0 api.yaml from cm-mayfly

### DIFF
--- a/api/conf/api.yaml
+++ b/api/conf/api.yaml
@@ -87,7 +87,7 @@ services:
       latest: https://raw.githubusercontent.com/cloud-barista/cm-ant/main/api/swagger.json
       release: https://raw.githubusercontent.com/cloud-barista/cm-ant/{release}/api/swagger.json
   cm-beetle:
-    version: 0.5.11(latest)
+    version: 0.6.0(latest)
     baseurl: http://cm-beetle:8056/beetle
     auth:
       type: basic
@@ -100,14 +100,14 @@ services:
   cm-butterfly-api:
     # No public swagger source is registered for this service, so the version is
     # kept in step with the image tag in conf/docker/docker-compose.yaml by hand.
-    version: 0.5.5
+    version: 0.6.0
     #baseurl: http://localhost:4000
     baseurl: http://cm-butterfly-api:4000
     auth:
       type: none
       
   cm-cicada:
-    version: 0.5.3(latest)
+    version: 0.6.0(latest)
     baseurl: http://cm-cicada:8083/cicada
     auth:
       type: none
@@ -116,7 +116,7 @@ services:
       release: https://raw.githubusercontent.com/cloud-barista/cm-cicada/{release}/pkg/api/rest/docs/swagger.json
 
   cm-honeybee:
-    version: 0.5.12(latest)
+    version: 0.6.0(latest)
     baseurl: http://cm-honeybee:8081/honeybee
     auth:
       type: none
@@ -149,7 +149,7 @@ services:
   #    release: https://raw.githubusercontent.com/cloud-barista/cm-honeybee/{release}/agent/pkg/api/rest/docs/swagger.json
 
   cm-grasshopper:
-    version: 0.5.3(latest)
+    version: 0.6.0(latest)
     baseurl: http://cm-grasshopper:8084/grasshopper
     auth:
       type: none
@@ -2769,10 +2769,10 @@ serviceActions:
       method: post
       resourcePath: /migration/ns/{nsId}/infraWithDefaults
       description: "Migrate an infrastructure to the multi-cloud infrastructure (Infra) with defaults.\n\nBy default this API runs synchronously. Send header `Prefer: respond-async` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized."
-    MigrateK8sCluster:
+    MigrateK8sInfra:
       method: post
       resourcePath: /migration/ns/{nsId}/k8sCluster
-      description: "Migrate an on-premise Kubernetes cluster to a managed K8s service (e.g., AWS EKS).\n\n**Workflow**:\n1. Call POST /recommendation/k8sCluster to get a RecommendedK8sInfra.\n2. Pass the recommendation result as-is to this endpoint.\n\n**Internal steps**: VNet → SSH Key → Security Group → K8s Cluster → Node Groups\n\nBy default this API runs synchronously (EKS takes ~10-20 min). Send header\n`Prefer: respond-async` to run it asynchronously: receive 202 Accepted with a\nreqId, then poll GET /request/{reqId} to check status."
+      description: "Migrate an on-premise Kubernetes cluster to a managed K8s service (e.g., AWS EKS).\n\n**Workflow**:\n1. Call POST /recommendation/k8sCluster to get a RecommendK8sInfraResponse.\n2. Pass the recommendation result as-is to this endpoint.\n\n**Internal steps**: VNet → SSH Key → Security Group → K8s Cluster → Node Groups\n\n**Long-running** — This API waits for the cluster to become Active, up to **40 min**\n(typically **~10-20 min** on EKS), then adds the node groups, so it can take longer still.\n\nBy default it runs synchronously, so configure your own HTTP client to wait that long —\nmost client defaults cut the connection first. Send header `Prefer: respond-async` to run it\nasynchronously instead: receive 202 Accepted with a reqId, then poll GET /request/{reqId}\n(status flow: Handling → Success / Error). Only the \"respond-async\" token is recognized.\n\nIf a synchronous connection drops the migration keeps running on the server; poll\nGET /migration/ns/{nsId}/k8sCluster/{k8sClusterId} with the cluster name you supplied."
     MigrateNlbs:
       method: post
       resourcePath: /migration/middleware/ns/{nsId}/infra/{infraId}/nlb
@@ -2789,10 +2789,10 @@ serviceActions:
       method: post
       resourcePath: /recommendation/infraWithNlb
       description: "Perform NLB-aware infrastructure recommendation and return multiple Pareto-optimal candidates.\n\nThe recommendation engine:\n1. Correlates NLB backend server IPs with source Node IPs\n2. Normalizes backend ports via majority vote when ports differ\n3. Assigns NLB-related nodes to shared NodeGroups (N:1), unrelated nodes to individual NodeGroups (1:1)\n4. Finds ranked compatible spec-image pairs per NodeGroup (representative node for NLB groups)\n5. Generates up to `limit` candidates — candidate i uses the i-th ranked pair per NodeGroup\n6. Maps source NLB configuration to target cloud NLB model (same for all candidates)\n\n[Note] `sourceInfra.nlbs` must be populated (HAProxy frontend-backend pairs from cm-honeybee).\n\n[Note] The returned `targetInfra.nodeGroups[].name` values are referenced by `targetNlbList[].targetGroup.nodeGroupId`.\nUse the same NodeGroup IDs when calling POST /migration/infra so that the NLB migration can reference them immediately.\n\n---\n## CSP-Specific NLB Notes\n\nAWS:\n- Port translation supported (e.g., listener 9999 → backend 8086).\n- DNS endpoint; allow ~5 min for propagation after creation.\n- [Auto] SG rule for backend port opened from 0.0.0.0/0.\n\nAzure:\n- Port translation supported. DNS + static IP endpoint.\n- [Auto] Health check timeout omitted (not supported by Azure).\n\nGCP:\n- Port translation NOT supported; traffic arrives at backend VMs on the listener port.\n- [Auto] Listener port is forced equal to the backend port — clients must connect on the application port (e.g., 8086, not 9999).\n- IP-only endpoint (no DNS name).\n\nIBM:\n- Port translation supported.\n- Listener address is assigned asynchronously; re-query if the address is empty after migration.\n- [Auto] Health check timeout forced strictly less than the interval.\n---"
-    RecommendK8sCluster:
+    RecommendK8sInfra:
       method: post
       resourcePath: /recommendation/k8sCluster
-      description: "Recommend a complete K8s cluster configuration based on on-premise infra data from cm-honeybee.\nReturns a RecommendedK8sInfra that can be passed directly to the K8s migration API.\n\n**Required Parameters**: `desiredProvider`, `desiredRegion`\n**Input**: On-premise infra model (from honeybee /infra/refined) with K8s cluster info and node roles"
+      description: "Recommend a complete K8s infra configuration based on on-premise infra data from cm-honeybee.\nReturns a RecommendK8sInfraResponse that can be passed directly to the K8s migration API.\n\n**Required Parameters**: `desiredProvider`, `desiredRegion`\n**Input**: On-premise infra model (from honeybee /infra/refined) with K8s cluster info and node roles"
     RecommendK8sNodeGroupImages:
       method: post
       resourcePath: /recommendation/resources/k8sNodeGroupImages
@@ -3284,33 +3284,6 @@ serviceActions:
       method: post
       resourcePath: /velero/migration/precheck
       description: "Check source cluster, target cluster, and the S3 object store before executing Velero migration."
-  # cm-honeybee-agent — commented out with the service entry above.
-  #
-  #cm-honeybee-agent:
-  #  Get-Data-Info:
-  #    method: get
-  #    resourcePath: /data
-  #    description: "Get data migration information (required fields only for data migration)."
-  #  Get-Helm-Info:
-  #    method: get
-  #    resourcePath: /helm
-  #    description: "Get helm information."
-  #  Get-Infra-Info:
-  #    method: get
-  #    resourcePath: /infra
-  #    description: "Get infra information."
-  #  Get-Kubernetes-Info:
-  #    method: get
-  #    resourcePath: /kubernetes
-  #    description: "Get kubernetes information."
-  #  Get-Software-Info:
-  #    method: get
-  #    resourcePath: /software
-  #    description: "Get software information."
-  #  Health-Check-Readyz:
-  #    method: get
-  #    resourcePath: /readyz
-  #    description: "Check Honeybee Agent is ready"
   cm-honeybee:
     Create-Connection-Info:
       method: post


### PR DESCRIPTION
0.6.0 공식 릴리스를 위해 모든 서브 프레임워크를 0.6.0 으로 최종 확인하는 작업의 cm-butterfly 몫이다.

cm-mayfly 가 정본을 들고 있고, 각 서브시스템 swagger 를 v0.6.0 라인업 태그 기준으로 **전체 덤프**해 다시 만들었다. 이 PR 은 그 파일을 **변환 없이 그대로** 가져온다. 두 파일이 달라지면 둘 중 하나가 어긋난 것이므로 중간 가공을 두지 않는다.

## 담고 있는 API 변경

| 사라짐 | 추가 |
|---|---|
| `MigrateK8sCluster` | `MigrateK8sInfra` |
| `RecommendK8sCluster` | `RecommendK8sInfra` |

Cluster→Infra 용어 통일의 연장이다. **사라진 두 이름을 `front/src`·`api` 어디서도 참조하지 않아**(전수 확인) 함께 고칠 화면이 없다. K8s 마이그레이션은 아직 화면에 붙어 있지 않다.

낡아 있던 `version` 표기도 함께 맞춘다 — cm-honeybee 0.5.12 · cm-grasshopper 0.5.3 · cm-butterfly-api 0.5.5 가 각자의 compose 태그 뒤에 멈춰 있었다.

## 검증

원격 stage 에서 파일 대조가 아니라 **프록시로 직접 호출해** 세 부류를 함께 봤다.

- 추가된 것 — 라우팅되어 cm-beetle 이 응답
- 사라진 것 — 존재하지 않는 이름과 똑같은 `404 …-getApiSpec not found`
- 기존 것 — 8개 서브시스템 전부 정상, 회귀 없음
- Service Status 집계 8/8 healthy, 버전 문자열이 새 값을 반영

사라진 것이 없는 이름과 같은 404 를 주는 것이 스펙이 실제로 교체됐다는 증거다. 기존 것만 확인하면 옛 파일이 그대로여도 통과한다.

`api` 빌드·`go vet`·`internal/handler` 테스트 모두 통과.

## 이 PR 이 0.6.0 의 전제다

cm-butterfly 0.6.0 이미지는 이 api.yaml 이 들어가야 성립하므로, 위 검증은 공식 최신 0.5.8 이미지에 새 api.yaml 을 마운트해 수행했다. 0.6.0 이미지가 발행되면 마운트 없이 다시 확인한다.

---

- [BAR-1213](https://mzdevs.atlassian.net/browse/BAR-1213) cm-butterfly v0.6.0 릴리스 범위 확정 및 프리릴리스
- [BAR-1216](https://mzdevs.atlassian.net/browse/BAR-1216) v0.6.0 릴리스
- 테스트 결과서 — cmig-workflow `notion/cm-mf-ep-연계시스템버전현행화/004_v0.6.0_프리릴리스/ST3_단위테스트/TR-v0.6.0-라인업-및-api현행화.md`