### PR TITLE
docs: bring the guides and the README up to the v0.6.0 lineup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,28 +113,37 @@ Modify the value of services.{subsystem-name}.baseurl. The host currently in use
    
 ```yaml
   cb-spider: #service name
-    version: 0.12.35
+    version: 0.12.42(latest)
     baseurl: http://cb-spider:1024/spider  ## change this end with /spider
     auth:
       type: basic
-      username:
-      password:
+      username: ${SPIDER_USERNAME}
+      password: ${SPIDER_PASSWORD}
 
   cb-tumblebug:
-    version: 0.12.25
+    version: 0.12.30(latest)
     baseurl: http://cb-tumblebug:1323/tumblebug ## change this end with /tumblebug
     auth:
       type: basic
-      username: default
-      password: default
+      username: ${TB_API_USERNAME}
+      password: ${TB_API_PASSWORD}
 
   cm-beetle:
-    version: 0.6.0
+    version: 0.6.0(latest)
     baseurl: http://cm-beetle:8056/beetle  ## change this end with /beetle
     auth:
+      type: basic
+      username: ${BEETLE_API_USERNAME}
+      password: ${BEETLE_API_PASSWORD}
 
   # others ...
 ```
+
+A username or password written as `${VAR}` is read from the process environment when the server starts.
+Under docker compose the values come from the single shared `.env`, which cm-mayfly passes into this container.
+**There is no fallback**: a variable that resolves to nothing stops the server and names it, rather than quietly sending something else.
+
+`version` records the tag the operations were generated from, and it is kept in step with the image tag the lineup runs.
  
 
 ### 6. Self auth settings (Optional)
@@ -210,3 +219,7 @@ If you run it through docker compose, you can see the login page by accessing `h
 | [Bulk Import of Source Connections](docs/guide/source-connection-bulk-import.md) | Register many source connections at once from a CSV or Excel file |
 | [Running Workflow Tasks in Parallel](docs/guide/workflow-parallel-steps.md) | Place workflow tasks side by side so they run at the same time |
 | [Reading the Run Status Screen](docs/guide/workflow-run-status.md) | What the run view shows at each moment — progress, waiting, failures, and running part of it again |
+| [Editing a Model as JSON](docs/guide/json-editor.md) | The table and tree views, searching, and reshaping an array with sort and transform |
+| [Checking That Source Servers Can Be Reached](docs/guide/source-connection-status.md) | What each connection message means, and what to check when a server does not answer |
+| [Finding Your Way with the Migration Guide](docs/guide/migration-guide.md) | Where to start, what comes next, and how the console works that out |
+| [Checking That the Linked Services Are Answering](docs/guide/service-status.md) | The Service Status screen, and the alert that reaches you wherever you are |

--- a/docs/guide/migration-guide.md
+++ b/docs/guide/migration-guide.md
@@ -1,0 +1,78 @@
+# Finding your way with the Migration Guide
+
+A migration in this console is five steps across four screens, and the screens do not say which one comes first. Someone opening it for the first time can see every menu and still not know where to start.
+
+The **Migration Guide** answers that. It shows the five steps, marks the ones already done, and points at the one to do next.
+
+---
+
+## 1. The five steps
+
+| # | Step | Where it happens |
+|---|---|---|
+| 1 | **Register Source Service** | Source Services |
+| 2 | **Collect** | Source Services |
+| 3 | **Create Source Model** | Source Services |
+| 4 | **Create Target Model** | Source Models |
+| 5 | **Create and Run Workflow** | Target Models |
+
+Two things about this list are worth saying out loud, because they are the parts people get wrong.
+
+- **Collecting is its own step.** It is not part of making a source model. A source model is built *from* what was collected, so a model made before collecting is a model of nothing.
+- **Creating a workflow and running it are one step.** They happen on the same screen and finishing one without the other leaves nothing to show for it.
+
+Each step names **what is left of it**, not the whole of it. A step that is half done and named by the whole leaves you looking for work that is already finished.
+
+## 2. Where it opens
+
+The guide opens on **the step that matches the screen you are looking at**, rather than always at the top. Coming to it from Source Models opens step 4.
+
+You can walk the whole list from there — a completed step still shows what it produced, which is the fastest way to check whether something was actually made.
+
+## 3. Your position is worked out, not remembered
+
+The console does not keep a checklist. It reads the data and works out where you are.
+
+Register a source service, and step 1 is finished the moment that data exists. Nothing has to be marked. Sign out, sign back in on another machine, and the answer is the same, because it was never stored anywhere to go stale.
+
+The reading is refreshed when the step moves, so a step completed on the screen you are on is reflected without a reload.
+
+> This is also why a step can go *back*. Delete the only source service and step 1 is unfinished again — which is correct, and is what you would want to be told.
+
+## 4. Next-action banners
+
+The guide screen is not the only place this shows up. **Source Services**, **Source Models**, **Target Models** and **Workflows** each carry a banner naming what to do next on that screen.
+
+The banner appears only on the step you are actually on. On a screen whose step is finished there is nothing to say, so nothing is said.
+
+An empty screen carries the same hint rather than being blank — an empty list because nothing has been made yet reads very differently from an empty list because something failed.
+
+## 5. First entry, and turning it off
+
+On first entry the console **opens on the guide** with a short welcome dialog.
+
+- Both buttons on the welcome dismiss it **for good**. It is shown once, not once per session.
+- Guidance can be **turned off** in the settings, and **reopened** from there later.
+- Turning it off hides the welcome and the banners. The guide screen itself stays reachable from the menu.
+
+The welcome is deliberately once-only: something that reappears every time you sign in stops being read after the second time.
+
+## 6. Two constraints worth reading before you start
+
+Both cost a failed attempt if they are skipped, so they are marked in the help panel where they apply rather than left in prose.
+
+- **Which collection to run depends on what you are migrating.** Collecting the wrong thing produces a source model that cannot become the target you want. The help on the Source Services screen goes through each one.
+- **A server that cannot be reached cannot be collected from.** Check the connection status first — see [Checking that source servers can be reached](source-connection-status.md).
+
+## 7. Going deeper
+
+Some steps have a written guide behind them, reachable from the step itself.
+
+| Step | Guide |
+|---|---|
+| Register Source Service | [Bulk Import of Source Connections](source-connection-bulk-import.md) |
+| Create and Run Workflow | [Reading the Run Status Screen](workflow-run-status.md) |
+
+The guides ship with the source, so they move with the version they describe and cannot drift into a stale copy hosted somewhere else.
+
+For the whole path end to end, see [Quick Start: Running a Migration](quick-start-migration.md).

--- a/docs/guide/service-status.md
+++ b/docs/guide/service-status.md
@@ -1,0 +1,72 @@
+# Checking that the linked services are answering
+
+cm-butterfly does not do the migration itself. It asks the linked services — cb-tumblebug, cb-spider, cm-beetle, cm-honeybee, cm-grasshopper, cm-cicada, cm-damselfly, cm-ant — and shows what they answer.
+
+So when one of them stops answering, the console has nothing to show. Until this screen existed, that looked exactly like having nothing to show: an empty list either way, with no way to tell which it was without asking someone.
+
+---
+
+## 1. The screen
+
+**System > Service Status**, at the bottom of the left menu.
+
+Each service takes two rows. The first carries the name, the state and the version; the second carries the address of the specification those operations came from. They are split because putting the address on the same row pushed the state across the screen and wrapped the name.
+
+| Column | What it says |
+|---|---|
+| Service | The name the console calls it by, which is the name used in the operation path |
+| Status | **Healthy**, **Not answering**, or **Unknown** |
+| Version | The tag the operations were generated from, as recorded in `api.yaml` |
+| Specification | Where that specification was read from |
+
+**Recheck** asks again immediately, rather than waiting for the next round.
+
+## 2. Why the version is on this screen
+
+An empty screen has two causes that look the same, and the version separates them.
+
+- **The service is not answering.** Status says so.
+- **The service answers, but the console is asking for something it no longer has.** Status is Healthy and the version is behind the running image.
+
+The second is the one that used to cost an afternoon. A screen would come up blank, the service was plainly running, and nothing on screen connected the two. The version and the specification address are here so both are visible next to the status rather than found by reading configuration files.
+
+> The version is what `api.yaml` records, not what the container reports. `0.6.0(latest)` means the operations were generated from the `v0.6.0` tag and the specification called itself `latest`.
+
+## 3. You are told wherever you are
+
+The check runs in the console's layout, not on this screen, so it keeps running whichever screen you are on.
+
+- A failure raises a **dialog**. It does not close by itself — a failure that happened while nobody was looking is still there when they come back.
+- Acknowledging it leaves **one line at the top**, which goes by itself once everything answers again.
+- The line comes back if a service fails again.
+
+This matters because the screens where a failure actually hurts are the ones where you are doing the migration, not this one.
+
+## 4. When something is not answering
+
+The state is what the service reported, so start from what the row says.
+
+| What you see | What to do |
+|---|---|
+| One service Not answering | That container is down or still starting. Bring it up and press Recheck |
+| Several at once | Usually the host or the network rather than the services. Check the stack is up |
+| Healthy but a screen is still empty | Compare the version with the image the lineup runs. If they disagree, the specification is behind |
+| Unknown | The check has not completed a round yet. Press Recheck |
+
+Running the whole stack with cm-mayfly:
+
+```bash
+./mayfly infra info      # what is running, and its state
+./mayfly infra run -d    # bring up what is not
+```
+
+## 5. Changing how often it checks
+
+Both settings come from the environment, so they can be changed without a new image.
+
+| Variable | What it sets |
+|---|---|
+| `HEALTH_CHECK_INTERVAL_SEC` | Seconds between rounds |
+| `HEALTH_CHECK_FAILURE_THRESHOLD` | How many failures in a row before a service is called Not answering |
+
+The threshold exists so a single slow reply does not raise a dialog. Lower it to be told sooner; raise it if a service on a busy host reports failures it recovers from on its own.


### PR DESCRIPTION
v0.6.0 프리릴리스 태그에 담길 문서를 현행화한다.

## README

api.yaml 예시가 cb-spider `0.12.35` · cb-tumblebug `0.12.25` 를 보여 주고 있었고, 자격증명은 빈 값과 `default:default` 로 적혀 있었다. 확정 라인업은 `0.12.42` · `0.12.30` 이고 자격증명은 `${VAR}` 로 환경에서 읽는다.

그 예시를 그대로 베끼면 기동이 막히거나, 나머지 라인업과 다른 값으로 인증하게 된다. 파일이 실제로 담고 있는 형태로 고치고 **폴백이 없다는 것**을 함께 적었다.

User Guides 표에 **2건이 빠져 있었다** — `json-editor.md`, `source-connection-status.md`. 파일은 있는데 표에 없어 디렉토리를 뒤져야만 찾을 수 있었다.

## 새로 쓴 가이드 2건

가장 최근에 들어온 사용자 기능 둘이 가이드 없이 나가 있었다.

- **`docs/guide/migration-guide.md`** — *어디서 시작하나* 에 답한다. 다섯 단계, 그 위치를 저장된 체크리스트가 아니라 데이터에서 계산한다는 것(그래서 로그아웃해도 같고, 뒤로 갈 수도 있다), 다음 할 일 배너, 처음 한 번만 뜨는 환영 창.
- **`docs/guide/service-status.md`** — *지금 무엇이 응답하고 있나* 에 답한다. 이 화면이 존재하는 이유가 **서비스가 죽어서 빈 화면과, 아직 아무것도 안 만들어서 빈 화면이 구분되지 않던 것**이라 그 대비를 중심에 뒀다. 버전 열이 왜 여기 있는지(스펙이 뒤처져도 Healthy 로 보인다), `HEALTH_CHECK_INTERVAL_SEC`·`HEALTH_CHECK_FAILURE_THRESHOLD` 도 함께.

두 문서의 서술은 `steps.ts`·`guidedSetupPreferences.ts`·`ServiceStatusPage.vue`·`health.go` 를 읽고 맞춘 것이다.

---

- [BAR-1215](https://mzdevs.atlassian.net/browse/BAR-1215) README·API 문서 v0.6.0 정리 및 구동 방법 정비
- [BAR-1213](https://mzdevs.atlassian.net/browse/BAR-1213) cm-butterfly v0.6.0 릴리스 범위 확정 및 프리릴리스