### PR TITLE
improve(front): name the toggles that open a nested field

### DIFF
--- a/front/src/features/sequential/designer/editor/ui/RecursiveFormField.vue
+++ b/front/src/features/sequential/designer/editor/ui/RecursiveFormField.vue
@@ -2,8 +2,8 @@
   <div class="form-field" :class="`depth-${depth}`">
     <!-- String, Number, Boolean - Simple Input -->
     <div v-if="isSimpleType" class="simple-field">
-      <label 
-        class="field-label" 
+      <label
+        class="field-label"
         :class="{ 'has-tooltip': fieldSchema.description }"
         :title="fieldSchema.description || ''"
       >
@@ -28,7 +28,9 @@
         :placeholder="`Enter ${fieldName}`"
       />
       <input
-        v-else-if="fieldSchema.type === 'number' || fieldSchema.type === 'integer'"
+        v-else-if="
+          fieldSchema.type === 'number' || fieldSchema.type === 'integer'
+        "
         :data-testid="fieldTestId"
         type="number"
         :value="fieldValue || 0"
@@ -50,15 +52,20 @@
     <div v-else-if="fieldSchema.type === 'array'" class="array-field">
       <div class="array-header">
         <div class="header-left">
-          <button @click="toggleArrayCollapse" class="btn-collapse">
+          <button
+            :data-testid="arrayToggleTestId"
+            @click="toggleArrayCollapse"
+            class="btn-collapse"
+          >
             {{ isArrayCollapsed ? '▶' : '▼' }}
           </button>
-          <label 
-            class="field-label" 
+          <label
+            class="field-label"
             :class="{ 'has-tooltip': fieldSchema.description }"
             :title="fieldSchema.description || ''"
           >
-            {{ fieldName }}<span v-if="isRequired" class="required-mark">*</span>
+            {{ fieldName
+            }}<span v-if="isRequired" class="required-mark">*</span>
             <span class="field-type">({{ arrayValue.length }} items)</span>
           </label>
         </div>
@@ -67,14 +74,20 @@
             :data-testid="arrayAddTestId"
             @click="addArrayItem"
             class="btn-add-item"
-          >+ Add entity</button>
+          >
+            + Add entity
+          </button>
         </div>
       </div>
-      
+
       <div v-if="!isArrayCollapsed" class="array-items">
         <!-- String Array -->
         <div v-if="isStringArray" class="string-array">
-          <div v-for="(item, index) in arrayValue" :key="index" class="array-item">
+          <div
+            v-for="(item, index) in arrayValue"
+            :key="index"
+            class="array-item"
+          >
             <input
               :data-testid="arrayItemTestId(index)"
               type="text"
@@ -87,28 +100,50 @@
               :data-testid="arrayRemoveTestId(index)"
               @click="removeArrayItem(index)"
               class="btn-remove-item"
-            >×</button>
+            >
+              ×
+            </button>
           </div>
         </div>
-        
+
         <!-- Object Array -->
-        <div v-else-if="fieldSchema.items && fieldSchema.items.type === 'object'" class="object-array">
-          <div v-for="(item, index) in arrayValue" :key="index" class="array-item-object">
-            <div class="item-header" @click="toggleItemCollapse(index)" style="cursor: pointer;">
+        <div
+          v-else-if="fieldSchema.items && fieldSchema.items.type === 'object'"
+          class="object-array"
+        >
+          <div
+            v-for="(item, index) in arrayValue"
+            :key="index"
+            class="array-item-object"
+          >
+            <div
+              class="item-header"
+              @click="toggleItemCollapse(index)"
+              style="cursor: pointer"
+            >
               <div class="item-header-left">
-                <button @click.stop="toggleItemCollapse(index)" class="btn-item-collapse">
+                <button
+                  :data-testid="arrayItemToggleTestId(index)"
+                  @click.stop="toggleItemCollapse(index)"
+                  class="btn-item-collapse"
+                >
                   {{ isItemCollapsed(index) ? '▶' : '▼' }}
                 </button>
                 <span class="item-title">Item {{ index + 1 }}</span>
                 <span v-if="isItemCollapsed(index)" class="item-prop-count">
-                  ({{ Object.keys(fieldSchema.items.properties || {}).length }} properties)
+                  ({{
+                    Object.keys(fieldSchema.items.properties || {}).length
+                  }}
+                  properties)
                 </span>
               </div>
               <button
                 :data-testid="arrayRemoveTestId(index)"
                 @click.stop="removeArrayItem(index)"
                 class="btn-remove-item"
-              >× Remove</button>
+              >
+                × Remove
+              </button>
             </div>
             <div v-if="!isItemCollapsed(index)" class="item-properties">
               <recursive-form-field
@@ -123,25 +158,32 @@
                 :task-name="taskName"
                 :current-path="`${currentPath}[]`"
                 :index-path="childIndexPath(String(propName), index)"
-                @update="updateObjectArrayItemProperty(index, String(propName), $event)"
+                @update="
+                  updateObjectArrayItemProperty(index, String(propName), $event)
+                "
                 :depth="depth + 1"
               />
             </div>
             <div v-else class="item-collapsed-indicator">
               <span class="item-collapsed-text">
-                {{ Object.keys(fieldSchema.items.properties || {}).length }} properties (collapsed)
+                {{
+                  Object.keys(fieldSchema.items.properties || {}).length
+                }}
+                properties (collapsed)
               </span>
             </div>
           </div>
         </div>
-        
+
         <div v-if="!arrayValue || arrayValue.length === 0" class="empty-array">
           No items. Click "Add Item" to add.
         </div>
       </div>
-      
+
       <div v-else class="collapsed-indicator">
-        <span class="collapsed-text">{{ arrayValue.length }} items (collapsed)</span>
+        <span class="collapsed-text"
+          >{{ arrayValue.length }} items (collapsed)</span
+        >
       </div>
     </div>
 
@@ -149,20 +191,34 @@
     <div v-else-if="fieldSchema.type === 'object'" class="object-field">
       <div class="object-header">
         <div class="header-left">
-          <button @click="toggleObjectCollapse" class="btn-collapse">
+          <button
+            :data-testid="objectToggleTestId"
+            @click="toggleObjectCollapse"
+            class="btn-collapse"
+          >
             {{ isObjectCollapsed ? '▶' : '▼' }}
           </button>
-          <label 
-            class="field-label" 
+          <label
+            class="field-label"
             :class="{ 'has-tooltip': fieldSchema.description }"
             :title="fieldSchema.description || ''"
           >
-            {{ fieldName }}<span v-if="isRequired" class="required-mark">*</span>
-            <span class="field-type">({{ Object.keys(fieldSchema.properties || {}).length }} properties)</span>
+            {{ fieldName
+            }}<span v-if="isRequired" class="required-mark">*</span>
+            <span class="field-type"
+              >({{
+                Object.keys(fieldSchema.properties || {}).length
+              }}
+              properties)</span
+            >
           </label>
         </div>
       </div>
-      <div v-if="!isObjectCollapsed" class="object-properties" :class="{ 'depth-0-object': depth === 0 }">
+      <div
+        v-if="!isObjectCollapsed"
+        class="object-properties"
+        :class="{ 'depth-0-object': depth === 0 }"
+      >
         <recursive-form-field
           v-for="propName in sortedPropertyNames"
           :key="propName"
@@ -180,7 +236,10 @@
         />
       </div>
       <div v-else class="collapsed-indicator">
-        <span class="collapsed-text">{{ Object.keys(fieldSchema.properties || {}).length }} properties (collapsed)</span>
+        <span class="collapsed-text"
+          >{{ Object.keys(fieldSchema.properties || {}).length }} properties
+          (collapsed)</span
+        >
       </div>
     </div>
   </div>
@@ -188,53 +247,56 @@
 
 <script lang="ts">
 import { defineComponent, computed, ref } from 'vue';
-import { getPropertyOrder, sortPropertiesByOrder } from '../config/taskPropertyOrderConfig';
+import {
+  getPropertyOrder,
+  sortPropertiesByOrder,
+} from '../config/taskPropertyOrderConfig';
 
 export default defineComponent({
   name: 'RecursiveFormField',
   props: {
     fieldName: {
       type: String,
-      required: true
+      required: true,
     },
     fieldSchema: {
       type: Object,
-      required: true
+      required: true,
     },
     fieldValue: {
       type: [String, Number, Boolean, Object, Array],
-      default: null
+      default: null,
     },
     stepProperties: {
       type: Object,
-      default: () => ({})
+      default: () => ({}),
     },
     depth: {
       type: Number,
-      default: 0
+      default: 0,
     },
     maxAutoExpandDepth: {
       type: Number,
-      default: 2  // default: auto-expand only up to depth 2
+      default: 2, // default: auto-expand only up to depth 2
     },
     parentRequired: {
       type: Array,
-      default: () => []
+      default: () => [],
     },
     taskName: {
       type: String,
-      default: ''
+      default: '',
     },
     currentPath: {
       type: String,
-      default: ''
+      default: '',
     },
     // Path used only to build test ids. It mirrors currentPath but keeps array indices, so every leaf
     // gets a unique id. currentPath itself must stay index-free — the schema lookup keys off `foo[]`.
     indexPath: {
       type: String,
-      default: ''
-    }
+      default: '',
+    },
   },
   emits: ['update'],
   setup(props, { emit }) {
@@ -242,8 +304,9 @@ export default defineComponent({
     // `wf-field-body_params.targetInfra.name`. The label text is the only other thing that identifies
     // a field here, and label text changes; the path does not. Tests need to point at one specific
     // field (the target infrastructure name, say) without guessing at wording or DOM position.
-    const fieldTestId = computed(() =>
-      `wf-field-${props.indexPath || props.currentPath || props.fieldName}`,
+    const fieldTestId = computed(
+      () =>
+        `wf-field-${props.indexPath || props.currentPath || props.fieldName}`,
     );
 
     /** Child path for the test id, keeping the array index so siblings do not collide. */
@@ -258,8 +321,29 @@ export default defineComponent({
 
     /** The button that adds an entry to this array, named after the array it acts on. */
     const arrayAddTestId = computed(
-      () => `wf-array-add-${props.indexPath || props.currentPath || props.fieldName}`,
+      () =>
+        `wf-array-add-${props.indexPath || props.currentPath || props.fieldName}`,
     );
+
+    /*
+      The toggles that open a field, named by the path they open.
+
+      Without these a walkthrough has to open every collapsed row in turn to reach one field -
+      two hundred clicks, and on a recording that is all the viewer sees. Named, it opens the
+      handful of ancestors on the way to what it came for.
+    */
+    const arrayToggleTestId = computed(
+      () =>
+        `wf-toggle-${props.indexPath || props.currentPath || props.fieldName}`,
+    );
+
+    const objectToggleTestId = computed(
+      () =>
+        `wf-toggle-${props.indexPath || props.currentPath || props.fieldName}`,
+    );
+
+    const arrayItemToggleTestId = (arrayIndex: number) =>
+      `wf-toggle-${props.indexPath || props.currentPath || props.fieldName}[${arrayIndex}]`;
 
     /** The button that removes one entry, which needs the entry's position as well. */
     const arrayRemoveTestId = (arrayIndex: number) =>
@@ -278,8 +362,9 @@ export default defineComponent({
     const shouldUseTextarea = computed(() => {
       const taskComponent = props.stepProperties?.originalData?.task_component;
       // Support both cicada_task_script and cicada_task_run_script
-      const isCicadaScriptTask = taskComponent === 'cicada_task_script' ||
-                                 taskComponent === 'cicada_task_run_script';
+      const isCicadaScriptTask =
+        taskComponent === 'cicada_task_script' ||
+        taskComponent === 'cicada_task_run_script';
       const result = isCicadaScriptTask && props.fieldName === 'content';
 
       // Debug logging
@@ -291,17 +376,19 @@ export default defineComponent({
         console.log('   result:', result);
         console.log('   stepProperties:', props.stepProperties);
       }
-      
+
       return result;
     });
-    
+
     // Collapse states
     const isArrayCollapsed = ref(shouldAutoCollapse.value);
     const isObjectCollapsed = ref(shouldAutoCollapse.value);
     const itemCollapsedStates = ref<Record<number, boolean>>({}); // Per-array-item collapse/expand state
-    
+
     const isSimpleType = computed(() => {
-      return ['string', 'number', 'integer', 'boolean'].includes(props.fieldSchema.type);
+      return ['string', 'number', 'integer', 'boolean'].includes(
+        props.fieldSchema.type,
+      );
     });
 
     const isStringArray = computed(() => {
@@ -316,7 +403,10 @@ export default defineComponent({
 
     const objectValue = computed(() => {
       if (!props.fieldValue) return {};
-      if (typeof props.fieldValue === 'object' && !Array.isArray(props.fieldValue)) {
+      if (
+        typeof props.fieldValue === 'object' &&
+        !Array.isArray(props.fieldValue)
+      ) {
         return props.fieldValue;
       }
       return {};
@@ -326,9 +416,9 @@ export default defineComponent({
     const sortedPropertyNames = computed(() => {
       if (!props.fieldSchema.properties) return [];
       const keys = Object.keys(props.fieldSchema.properties);
-      
+
       if (!props.taskName || !props.currentPath) return keys;
-      
+
       const order = getPropertyOrder(props.taskName, props.currentPath);
       return order ? sortPropertiesByOrder(keys, order) : keys;
     });
@@ -337,9 +427,9 @@ export default defineComponent({
     const sortedArrayItemPropertyNames = computed(() => {
       if (!props.fieldSchema.items?.properties) return [];
       const keys = Object.keys(props.fieldSchema.items.properties);
-      
+
       if (!props.taskName || !props.currentPath) return keys;
-      
+
       const arrayItemPath = `${props.currentPath}[]`;
       const order = getPropertyOrder(props.taskName, arrayItemPath);
       return order ? sortPropertiesByOrder(keys, order) : keys;
@@ -354,15 +444,18 @@ export default defineComponent({
     const handleInput = (event: Event) => {
       const target = event.target as HTMLInputElement;
       let value: any;
-      
+
       if (props.fieldSchema.type === 'boolean') {
         value = target.checked;
-      } else if (props.fieldSchema.type === 'number' || props.fieldSchema.type === 'integer') {
+      } else if (
+        props.fieldSchema.type === 'number' ||
+        props.fieldSchema.type === 'integer'
+      ) {
         value = parseFloat(target.value) || 0;
       } else {
         value = target.value;
       }
-      
+
       emit('update', value);
     };
 
@@ -373,38 +466,43 @@ export default defineComponent({
     const findDataInStepProperties = (fieldPath: string): any => {
       console.log('🔍 Finding data in stepProperties for path:', fieldPath);
       console.log('   stepProperties:', props.stepProperties);
-      
+
       if (!props.stepProperties) return null;
-      
+
       // Search in step.properties.model or step.properties.originalData.request_body
       const searchPaths = [
         props.stepProperties,
         (props.stepProperties as any)?.model,
         (props.stepProperties as any)?.originalData?.request_body,
-        (props.stepProperties as any)?.targetSoftwareModel
+        (props.stepProperties as any)?.targetSoftwareModel,
       ];
-      
+
       for (const searchRoot of searchPaths) {
         if (!searchRoot) continue;
-        
+
         // Look up directly by the current fieldName
         if (searchRoot[props.fieldName] !== undefined) {
-          console.log('✅ Found data in stepProperties:', props.fieldName, '=', searchRoot[props.fieldName]);
+          console.log(
+            '✅ Found data in stepProperties:',
+            props.fieldName,
+            '=',
+            searchRoot[props.fieldName],
+          );
           return searchRoot[props.fieldName];
         }
       }
-      
+
       console.log('⚠️ No data found in stepProperties for:', props.fieldName);
       return null;
     };
 
     const addArrayItem = () => {
       const newArray = [...arrayValue.value];
-      
+
       console.log('=== Add Array Item ===');
       console.log('Field name:', props.fieldName);
       console.log('Current array length:', newArray.length);
-      
+
       if (isStringArray.value) {
         // String array - default value from schema or empty string
         const defaultValue = props.fieldSchema.items?.default || '';
@@ -412,55 +510,85 @@ export default defineComponent({
       } else if (props.fieldSchema.items?.type === 'object') {
         // Object array - create object from schema with default values
         const newItem: any = {};
-        
+
         // 1. Find the actual data in stepProperties
         const actualDataArray = findDataInStepProperties(props.fieldName);
         console.log('📊 Actual data from stepProperties:', actualDataArray);
-        
+
         if (props.fieldSchema.items.properties) {
           Object.keys(props.fieldSchema.items.properties).forEach(key => {
             const propSchema = props.fieldSchema.items.properties[key];
-            
+
             // Priority 1: use the first item's value from the actual stepProperties data
-            if (Array.isArray(actualDataArray) && actualDataArray.length > 0 && 
-                actualDataArray[0][key] !== undefined) {
+            if (
+              Array.isArray(actualDataArray) &&
+              actualDataArray.length > 0 &&
+              actualDataArray[0][key] !== undefined
+            ) {
               if (propSchema.type === 'array') {
-                newItem[key] = Array.isArray(actualDataArray[0][key]) ? 
-                  JSON.parse(JSON.stringify(actualDataArray[0][key])) : [];
-                console.log(`   📋 Property "${key}" from stepProperties (array):`, newItem[key]);
+                newItem[key] = Array.isArray(actualDataArray[0][key])
+                  ? JSON.parse(JSON.stringify(actualDataArray[0][key]))
+                  : [];
+                console.log(
+                  `   📋 Property "${key}" from stepProperties (array):`,
+                  newItem[key],
+                );
               } else if (propSchema.type === 'object') {
-                newItem[key] = typeof actualDataArray[0][key] === 'object' ? 
-                  JSON.parse(JSON.stringify(actualDataArray[0][key])) : {};
-                console.log(`   📋 Property "${key}" from stepProperties (object):`, newItem[key]);
+                newItem[key] =
+                  typeof actualDataArray[0][key] === 'object'
+                    ? JSON.parse(JSON.stringify(actualDataArray[0][key]))
+                    : {};
+                console.log(
+                  `   📋 Property "${key}" from stepProperties (object):`,
+                  newItem[key],
+                );
               } else {
                 newItem[key] = actualDataArray[0][key];
-                console.log(`   📋 Property "${key}" from stepProperties (value):`, newItem[key]);
+                console.log(
+                  `   📋 Property "${key}" from stepProperties (value):`,
+                  newItem[key],
+                );
               }
             }
             // Priority 2: Schema default value
             else if (propSchema.default !== undefined) {
               newItem[key] = propSchema.default;
-              console.log(`   🔧 Property "${key}" from schema default:`, newItem[key]);
+              console.log(
+                `   🔧 Property "${key}" from schema default:`,
+                newItem[key],
+              );
             }
             // Priority 3: copy from the first item of the current array
-            else if (arrayValue.value.length > 0 && arrayValue.value[0][key] !== undefined) {
+            else if (
+              arrayValue.value.length > 0 &&
+              arrayValue.value[0][key] !== undefined
+            ) {
               if (propSchema.type === 'array') {
-                newItem[key] = Array.isArray(arrayValue.value[0][key]) ? 
-                  JSON.parse(JSON.stringify(arrayValue.value[0][key])) : [];
+                newItem[key] = Array.isArray(arrayValue.value[0][key])
+                  ? JSON.parse(JSON.stringify(arrayValue.value[0][key]))
+                  : [];
               } else if (propSchema.type === 'object') {
-                newItem[key] = typeof arrayValue.value[0][key] === 'object' ? 
-                  JSON.parse(JSON.stringify(arrayValue.value[0][key])) : {};
+                newItem[key] =
+                  typeof arrayValue.value[0][key] === 'object'
+                    ? JSON.parse(JSON.stringify(arrayValue.value[0][key]))
+                    : {};
               } else {
                 newItem[key] = arrayValue.value[0][key];
               }
-              console.log(`   📝 Property "${key}" from current array[0]:`, newItem[key]);
+              console.log(
+                `   📝 Property "${key}" from current array[0]:`,
+                newItem[key],
+              );
             }
             // Priority 4: Type-based default
             else if (propSchema.type === 'array') {
               newItem[key] = [];
             } else if (propSchema.type === 'object') {
               newItem[key] = {};
-            } else if (propSchema.type === 'number' || propSchema.type === 'integer') {
+            } else if (
+              propSchema.type === 'number' ||
+              propSchema.type === 'integer'
+            ) {
               newItem[key] = 0;
             } else if (propSchema.type === 'boolean') {
               newItem[key] = false;
@@ -470,20 +598,23 @@ export default defineComponent({
           });
         }
         newArray.push(newItem);
-        
+
         console.log('✅ Added new array item:', newItem);
-        console.log('   Based on schema properties:', Object.keys(props.fieldSchema.items.properties || {}));
+        console.log(
+          '   Based on schema properties:',
+          Object.keys(props.fieldSchema.items.properties || {}),
+        );
       }
-      
+
       emit('update', newArray);
     };
 
     const duplicateLastArrayItem = () => {
       const newArray = [...arrayValue.value];
-      
+
       if (newArray.length > 0) {
         const lastItem = newArray[newArray.length - 1];
-        
+
         // Deep clone the last item
         let duplicatedItem;
         if (typeof lastItem === 'object') {
@@ -491,14 +622,14 @@ export default defineComponent({
         } else {
           duplicatedItem = lastItem;
         }
-        
+
         newArray.push(duplicatedItem);
-        
+
         console.log('✅ Duplicated last array item');
         console.log('   Original item:', lastItem);
         console.log('   Duplicated item:', duplicatedItem);
       }
-      
+
       emit('update', newArray);
     };
 
@@ -515,43 +646,54 @@ export default defineComponent({
       emit('update', newArray);
     };
 
-    const updateObjectArrayItemProperty = (index: number, propName: string, value: any) => {
+    const updateObjectArrayItemProperty = (
+      index: number,
+      propName: string,
+      value: any,
+    ) => {
       const newArray = [...arrayValue.value];
       if (!newArray[index]) {
         newArray[index] = {};
       }
       newArray[index] = {
         ...newArray[index],
-        [propName]: value
+        [propName]: value,
       };
       emit('update', newArray);
     };
 
     const updateObjectProperty = (propName: string, value: any) => {
       let baseObject = objectValue.value;
-      
+
       // 🔍 CRITICAL FIX: Check if baseObject is a schema (not actual data)
-      if (baseObject && 
-          baseObject.type === 'object' && 
-          baseObject.properties && 
-          typeof baseObject.properties === 'object') {
+      if (
+        baseObject &&
+        baseObject.type === 'object' &&
+        baseObject.properties &&
+        typeof baseObject.properties === 'object'
+      ) {
         // This is a JSON schema, not actual data!
         // Start with empty object to avoid including schema properties in the result
-        console.warn(`⚠️ updateObjectProperty: objectValue is schema for field "${props.fieldName}", starting with empty object`);
-        console.warn('   Schema properties:', Object.keys(baseObject.properties));
+        console.warn(
+          `⚠️ updateObjectProperty: objectValue is schema for field "${props.fieldName}", starting with empty object`,
+        );
+        console.warn(
+          '   Schema properties:',
+          Object.keys(baseObject.properties),
+        );
         baseObject = {};
       }
-      
+
       const newObject = {
         ...baseObject,
-        [propName]: value
+        [propName]: value,
       };
-      
+
       console.log(`🔄 updateObjectProperty: ${props.fieldName}.${propName}`);
       console.log('   Base object keys:', Object.keys(baseObject));
       console.log('   New value type:', typeof value);
       console.log('   Result object keys:', Object.keys(newObject));
-      
+
       emit('update', newObject);
     };
 
@@ -566,14 +708,16 @@ export default defineComponent({
 
     const toggleItemCollapse = (index: number) => {
       const currentState = isItemCollapsed(index);
-      console.log(`🔄 Toggle Item ${index}: ${currentState} → ${!currentState}`);
-      
+      console.log(
+        `🔄 Toggle Item ${index}: ${currentState} → ${!currentState}`,
+      );
+
       // Create a new object for Vue 3 reactivity
       itemCollapsedStates.value = {
         ...itemCollapsedStates.value,
-        [index]: !currentState
+        [index]: !currentState,
       };
-      
+
       console.log(`   Updated state:`, itemCollapsedStates.value[index]);
     };
 
@@ -584,7 +728,7 @@ export default defineComponent({
         const initialState = props.depth >= props.maxAutoExpandDepth - 1;
         itemCollapsedStates.value = {
           ...itemCollapsedStates.value,
-          [index]: initialState
+          [index]: initialState,
         };
       }
       return itemCollapsedStates.value[index];
@@ -596,6 +740,9 @@ export default defineComponent({
       arrayItemTestId,
       arrayAddTestId,
       arrayRemoveTestId,
+      arrayToggleTestId,
+      objectToggleTestId,
+      arrayItemToggleTestId,
       isSimpleType,
       isStringArray,
       arrayValue,
@@ -619,9 +766,9 @@ export default defineComponent({
       toggleArrayCollapse,
       toggleObjectCollapse,
       toggleItemCollapse,
-      isItemCollapsed
+      isItemCollapsed,
     };
-  }
+  },
 });
 </script>
 
@@ -1047,4 +1194,3 @@ export default defineComponent({
   padding: 0.375rem 0.5rem;
 }
 </style>
-


### PR DESCRIPTION
워크플로우 편집기에서 중첩 필드를 펼치는 토글에 그 필드의 경로를 이름으로 붙인다.

이름이 없으면 특정 칸에 닿기 위해 화면 전체를 펼치는 수밖에 없다. 시연 영상에서 그것이 항목을 하나씩 눌러 나가는 모습으로 드러났다.

배열·객체·배열 항목의 접기/펼치기 버튼이 각각 자기 경로를 갖는다.

```
wf-toggle-body_params.targetInfra.label
wf-toggle-body_params.targetSpecList[0]
```

## 동작은 바뀌지 않았다

이미 시험이 끝난 화면이라 식별자 외에 한 줄도 바뀌면 안 된다. 식별자와 주석을 걷어낸 뒤 같은 규칙으로 포맷해 낱말 흐름으로 대조했고, 줄바꿈 외에 차이가 없다. `+263/-117` 로 크지만 대부분 속성이 붙어 prettier 가 줄을 다시 접은 것이다.

원격 개발 환경의 브랜치 검증용 프런트에 올려 화면에서 확인했다 — 파라미터 화면에 79개, 경로까지 정확하다. 그 이미지로 통합 시나리오 14구간을 완주했다.

검증 스크립트 변경은 이 PR에 넣지 않았다. 업스트림에 올리지 않는 자산이라 섞으면 식별자까지 함께 묶여 올라가지 못한다.

- [BAR-1827](https://mzdevs.atlassian.net/browse/BAR-1827) [cm-butterfly] 워크플로우 편집기 토글 식별자 develop 반영과 업스트림 기여